### PR TITLE
DBZ-2578 Add support for using Vitess primary key as Kafka message key.

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/ColumnMetaData.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ColumnMetaData.java
@@ -17,13 +17,13 @@ import io.debezium.relational.Table;
 public class ColumnMetaData {
     private final String columnName;
     private final VitessType vitessType;
-    private final boolean key;
     private final boolean optional;
+    private final KeyMetaData keyMetaData;
 
-    public ColumnMetaData(String columnName, VitessType vitessType, boolean key, boolean optional) {
+    public ColumnMetaData(String columnName, VitessType vitessType, boolean optional, KeyMetaData keyMetaData) {
         this.columnName = columnName;
         this.vitessType = vitessType;
-        this.key = key;
+        this.keyMetaData = keyMetaData;
         this.optional = optional;
     }
 
@@ -35,11 +35,11 @@ public class ColumnMetaData {
         return vitessType;
     }
 
-    public boolean isKey() {
-        return key;
-    }
-
     public boolean isOptional() {
         return optional;
+    }
+
+    public KeyMetaData getKeyMetaData() {
+        return keyMetaData;
     }
 }

--- a/src/main/java/io/debezium/connector/vitess/connection/KeyMetaData.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/KeyMetaData.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess.connection;
+
+/**
+ * If a column is part of the primary key (including multi-column primary key),
+ * or a column is a single-column unique key
+ */
+public enum KeyMetaData {
+    /**
+     * The column is part of the primary key (including multi-column primary key)
+     */
+    IS_KEY,
+    /**
+     * The column is single-column unique key
+     */
+    IS_UNIQUE_KEY,
+    /**
+     * The column is not part of any key, or the column is part of multi-column unique key
+     */
+    NONE
+}

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -49,7 +49,12 @@ public class TestHelper {
         return defaultConfig(false);
     }
 
-    public static Configuration.Builder defaultConfig(boolean isMultiShards) {
+    /**
+     * Get the default configuration of the connector
+     * @param hasMultipleShards whether the keyspace has multiple shards
+     * @return Configuration builder
+     */
+    public static Configuration.Builder defaultConfig(boolean hasMultipleShards) {
         Configuration.Builder builder = Configuration.create();
         builder = builder
                 .with(RelationalDatabaseConnectorConfig.SERVER_NAME, TEST_SERVER)
@@ -58,7 +63,7 @@ public class TestHelper {
                 .with(VitessConnectorConfig.VTCTLD_HOST, VTCTLD_HOST)
                 .with(VitessConnectorConfig.VTCTLD_PORT, VTCTLD_PORT)
                 .with(VitessConnectorConfig.POLL_INTERVAL_MS, 100);
-        if (isMultiShards) {
+        if (hasMultipleShards) {
             return builder.with(VitessConnectorConfig.KEYSPACE, TEST_SHARDED_KEYSPACE);
         }
         else {

--- a/src/test/java/io/debezium/connector/vitess/VitessVerifyRecord.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessVerifyRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.data.VerifyRecord;
+
+/**
+ * An extension of {@link VerifyRecord} that verifies Vitess generated record
+ */
+public class VitessVerifyRecord extends VerifyRecord {
+
+    /**
+     * Verify that the given {@link SourceRecord} is an INSERT record, and that the key exists.
+     *
+     * @param record the source record; may not be null
+     * @param pkField the single field defining the primary key of the struct; may not be null
+     */
+    public static void isValidInsert(SourceRecord record, String pkField) {
+        hasValidKey(record, pkField);
+        isValidInsert(record, true);
+    }
+
+    /**
+     * Verify that the given {@link SourceRecord} has a valid non-null integer key.
+     *
+     * @param record the source record; may not be null
+     * @param pkField the single field defining the primary key of the struct; may not be null
+     */
+    public static void hasValidKey(SourceRecord record, String pkField) {
+        Struct key = (Struct) record.key();
+        assertThat(key.get(pkField)).isNotNull();
+    }
+}

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -56,3 +56,52 @@ CREATE TABLE time_table
     year_col      YEAR      NOT NULL DEFAULT '2020',
     PRIMARY KEY (id)
 );
+
+DROP TABLE IF EXISTS no_pk_table;
+CREATE TABLE no_pk_table
+(
+    id             BIGINT NOT NULL,
+    int_col        INT NOT NULL
+);
+
+DROP TABLE IF EXISTS pk_single_unique_key_table;
+CREATE TABLE pk_single_unique_key_table
+(
+    id             BIGINT NOT NULL,
+    int_col        INT,
+    PRIMARY KEY (id),
+    UNIQUE KEY unique_col (int_col)
+);
+
+DROP TABLE IF EXISTS no_pk_multi_unique_keys_table;
+CREATE TABLE no_pk_multi_unique_keys_table
+(
+    id             BIGINT NOT NULL,
+    int_col        INT,
+    int_col2       INT,
+    UNIQUE KEY unique_col (int_col),
+    UNIQUE KEY unique_col2 (int_col2)
+);
+
+DROP TABLE IF EXISTS no_pk_multi_comp_unique_keys_table;
+CREATE TABLE no_pk_multi_comp_unique_keys_table
+(
+    id             BIGINT NOT NULL,
+    int_col        INT,
+    int_col2       INT,
+    int_col3       INT,
+    int_col4       INT,
+    int_col5       INT,
+    UNIQUE KEY unique_col_1_2 (int_col, int_col2),
+    UNIQUE KEY unique_col_3 (int_col3),
+    UNIQUE KEY unique_col_4_5 (int_col4, int_col5)
+);
+
+DROP TABLE IF EXISTS comp_pk_table;
+CREATE TABLE comp_pk_table
+(
+    id             BIGINT NOT NULL,
+    int_col        INT,
+    int_col2        INT,
+    PRIMARY KEY (id, int_col)
+);

--- a/src/test/resources/vitess_vschema.json
+++ b/src/test/resources/vitess_vschema.json
@@ -6,18 +6,6 @@
     }
   },
   "tables": {
-    "t1": {
-      "columnVindexes": [
-        {
-          "column": "id",
-          "name": "hash"
-        }
-      ],
-      "autoIncrement": {
-        "column": "id",
-        "sequence": "my_seq"
-      }
-    },
     "numeric_table": {
       "columnVindexes": [
         {
@@ -67,6 +55,66 @@
       }
     },
     "time_table": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ],
+      "autoIncrement": {
+        "column": "id",
+        "sequence": "my_seq"
+      }
+    },
+    "no_pk_table": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ],
+      "autoIncrement": {
+        "column": "id",
+        "sequence": "my_seq"
+      }
+    },
+    "pk_single_unique_key_table": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ],
+      "autoIncrement": {
+        "column": "id",
+        "sequence": "my_seq"
+      }
+    },
+    "no_pk_multi_unique_keys_table": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ],
+      "autoIncrement": {
+        "column": "id",
+        "sequence": "my_seq"
+      }
+    },
+    "no_pk_multi_comp_unique_keys_table": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ],
+      "autoIncrement": {
+        "column": "id",
+        "sequence": "my_seq"
+      }
+    },
+    "comp_pk_table": {
       "columnVindexes": [
         {
           "column": "id",


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2578

A Vitess table's primary key will be used as the Kafka message key, or the unique key if the table does not have a primary key.

We will not support multi-column keys because the `flags` provided by VStream doesn't have sufficient information for multi-column keys.