### PR TITLE
DBZ-2579 Add support for Vitess nullable columns

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -34,6 +34,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
     private static final Logger LOGGER = LoggerFactory.getLogger(VStreamOutputMessageDecoder.class);
 
     // See all flags: https://dev.mysql.com/doc/dev/mysql-server/8.0.12/group__group__cs__column__definition__flags.html
+    private static final int NOT_NULL_FLAG = 1;
     private static final int PRI_KEY_FLAG = 1 << 1;
     private static final int UNIQUE_KEY_FLAG = 1 << 2;
 
@@ -335,7 +336,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                     else if ((field.getFlags() & UNIQUE_KEY_FLAG) != 0) {
                         keyMetaData = KeyMetaData.IS_UNIQUE_KEY;
                     }
-                    boolean optional = true;
+                    boolean optional = (field.getFlags() & NOT_NULL_FLAG) == 0;
 
                     columns.add(new ColumnMetaData(columnName, vitessType, optional, keyMetaData));
                 }
@@ -354,7 +355,8 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
             ColumnEditor editor = io.debezium.relational.Column.editor()
                     .name(columnMetaData.getColumnName())
                     .type(columnMetaData.getVitessType().getName())
-                    .jdbcType(columnMetaData.getVitessType().getJdbcId());
+                    .jdbcType(columnMetaData.getVitessType().getJdbcId())
+                    .optional(columnMetaData.isOptional());
             cols.add(editor.create());
 
             switch (columnMetaData.getKeyMetaData()) {

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -116,7 +116,7 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
         final List<SchemaAndValueField> fields = new ArrayList<>();
         fields.addAll(
                 Arrays.asList(
-                        new SchemaAndValueField("enum_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "3")));
+                        new SchemaAndValueField("enum_col", SchemaBuilder.STRING_SCHEMA, "3")));
         return fields;
     }
 
@@ -125,7 +125,7 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
         fields.addAll(
                 Arrays.asList(
                         // value is 5 because a = 0001 (1), c = 0100 (4), so a,c = 5
-                        new SchemaAndValueField("set_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "5")));
+                        new SchemaAndValueField("set_col", SchemaBuilder.STRING_SCHEMA, "5")));
         return fields;
     }
 
@@ -133,13 +133,13 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
         final List<SchemaAndValueField> fields = new ArrayList<>();
         fields.addAll(
                 Arrays.asList(
-                        new SchemaAndValueField("time_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "01:02:03"),
-                        new SchemaAndValueField("date_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "2020-02-11"),
+                        new SchemaAndValueField("time_col", SchemaBuilder.STRING_SCHEMA, "01:02:03"),
+                        new SchemaAndValueField("date_col", SchemaBuilder.STRING_SCHEMA, "2020-02-11"),
                         new SchemaAndValueField(
-                                "datetime_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "2020-02-12 01:02:03"),
+                                "datetime_col", SchemaBuilder.STRING_SCHEMA, "2020-02-12 01:02:03"),
                         new SchemaAndValueField(
-                                "timestamp_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "2020-02-13 01:02:03"),
-                        new SchemaAndValueField("year_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "2020")));
+                                "timestamp_col", SchemaBuilder.STRING_SCHEMA, "2020-02-13 01:02:03"),
+                        new SchemaAndValueField("year_col", SchemaBuilder.STRING_SCHEMA, "2020")));
         return fields;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2579

Vitess 8 added Nullable information in the `FIELD` event [flags](https://dev.mysql.com/doc/dev/mysql-server/8.0.12/group__group__cs__column__definition__flags.html#ga0b89f761611b41b80de1f7d50f9b6020). We can make a field in the SourceRecord optional accordingly.

Instead of adding additional integration tests, existing integration tests already cover this case.