### PR TITLE
DBZ-2908 Remove DECIMAL string sanitisation for Vitess 9 GA

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
@@ -6,15 +6,12 @@
 package io.debezium.connector.vitess.connection;
 
 import java.sql.Types;
-import java.util.regex.Pattern;
 
 import io.debezium.connector.vitess.VitessType;
 import io.vitess.proto.Query;
 
 /** Resolve raw column value to Java value */
 public class ReplicationMessageColumnValueResolver {
-
-    private static Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
 
     public static Object resolveValue(
                                       VitessType vitessType, ReplicationMessage.ColumnValue value, boolean includeUnknownDatatypes) {
@@ -35,9 +32,6 @@ public class ReplicationMessageColumnValueResolver {
                     return value.asLong();
                 }
             case Types.VARCHAR:
-                if (Query.Type.DECIMAL.name().equals(vitessType.getName())) {
-                    return WHITESPACE_PATTERN.matcher(value.asString()).replaceAll("");
-                }
                 return value.asString();
             case Types.FLOAT:
                 return value.asFloat();

--- a/src/test/docker/Dockerfile
+++ b/src/test/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Use a temporary layer for the build stage.
-FROM vitess/base:v8.0.0 AS base
+FROM vitess/base:v9.0.0 AS base
 
-FROM vitess/lite:v8.0.0
+FROM vitess/lite:v9.0.0
 
 USER root
 

--- a/src/test/docker/local/create_tables_sharded.sql
+++ b/src/test/docker/local/create_tables_sharded.sql
@@ -1,1 +1,1 @@
-create table t1 (id bigint not null, varchar_col varchar(16), primary key (`id`));
+create table t1 (id bigint not null, varchar_col varchar(16), decimal_col decimal(12,4), decimal_col2 decimal(13,4), primary key (`id`));

--- a/src/test/docker/local/create_tables_unsharded.sql
+++ b/src/test/docker/local/create_tables_unsharded.sql
@@ -1,3 +1,3 @@
 create table my_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into my_seq(id, next_id, cache) values(0, 1000, 100);
-create table t1 (id bigint not null, varchar_col varchar(16), primary key (`id`));
+create table t1 (id bigint not null, varchar_col varchar(16), decimal_col decimal(12,4), decimal_col2 decimal(13,4), primary key (`id`));

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -116,7 +116,7 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
                 Arrays.asList(
                         new SchemaAndValueField("char_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "a"),
                         new SchemaAndValueField("varchar_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "bc"),
-                        new SchemaAndValueField("binary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "d\u0000"),
+                        new SchemaAndValueField("binary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "d"),
                         new SchemaAndValueField("varbinary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "ef"),
                         new SchemaAndValueField("tinytext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "gh"),
                         new SchemaAndValueField("text_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "ij"),

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -491,6 +491,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     public void shouldSanitizeDecimalValue() throws Exception {
         TestHelper.executeDDL("vitess_create_tables.ddl");
         TestHelper.execute("ALTER TABLE numeric_table ADD decimal_col2 DECIMAL(14, 4) DEFAULT 12.3400;");
+        TestHelper.execute("ALTER TABLE numeric_table ADD decimal_col3 DECIMAL(14, 4) DEFAULT -12.3400;");
 
         startConnector();
         assertConnectorIsRunning();
@@ -500,6 +501,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         final List<SchemaAndValueField> fields = schemasAndValuesForNumericTypes();
         fields.add(new SchemaAndValueField("decimal_col2", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "12.3400"));
+        fields.add(new SchemaAndValueField("decimal_col3", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "-12.3400"));
         assertInsert(INSERT_NUMERIC_TYPES_STMT, fields, TestHelper.PK_FIELD);
 
         stopConnector();


### PR DESCRIPTION
- https://issues.redhat.com/browse/DBZ-3100
- https://issues.redhat.com/browse/DBZ-2908

Vitess 9.0.0 GA has fixed the bug on the server-side. Also, the Vitess Connector starts to support Vitess 9.0.0 GA from now on.