### PR TITLE
DBZ-2911 Add sequence field to Vitess SourceInfo test

### DIFF
--- a/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
@@ -114,6 +114,7 @@ public class SourceInfoTest {
                 .field("ts_ms", Schema.INT64_SCHEMA)
                 .field("snapshot", AbstractSourceInfoStructMaker.SNAPSHOT_RECORD_SCHEMA)
                 .field("db", Schema.STRING_SCHEMA)
+                .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("schema", Schema.STRING_SCHEMA)
                 .field("table", Schema.STRING_SCHEMA)
                 .field("vgtid", Schema.STRING_SCHEMA)


### PR DESCRIPTION
Issue [#2172 in the main Debezium repository](https://github.com/debezium/debezium/pull/2172#issuecomment-799195784) adds a new sequence field
to all `SourceInfo` objects via `AbstractSourceInfo`. This change updates
Vitess' `SourceInfo` schema test to account for this additional field.