### PR TITLE
DBZ-4355: Do not exclude provide.transaction.metadata from config

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -131,7 +131,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     TABLET_TYPE,
                     STOP_ON_RESHARD_FLAG)
             .events(INCLUDE_UNKNOWN_DATATYPES)
-            .excluding(SCHEMA_EXCLUDE_LIST, SCHEMA_INCLUDE_LIST, PROVIDE_TRANSACTION_METADATA)
+            .excluding(SCHEMA_EXCLUDE_LIST, SCHEMA_INCLUDE_LIST)
             .create();
 
     /**


### PR DESCRIPTION
Currently provide.transaction.metadata config won't take effect because it is excluded from the config definition.

https://github.com/debezium/debezium-connector-vitess/blob/main/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java#L134

We need to not exclude it in order to use this this feature.
This fixes https://issues.redhat.com/browse/DBZ-4355