### PR TITLE
DBZ-4403: Support blob types and fix uint64 overflows

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -94,13 +94,14 @@ public class VitessType {
                 return new VitessType(type, Types.BIGINT, resolveEnumAndSetValues(field.getColumnType()));
             case "UINT32":
             case "INT64":
-            case "UINT64":
                 return new VitessType(type, Types.BIGINT);
+            case "UINT64":
             case "VARBINARY":
             case "BINARY":
             case "VARCHAR":
             case "CHAR":
             case "TEXT":
+            case "BLOB":
             case "JSON":
             case "DECIMAL":
             case "TIME":

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
@@ -8,7 +8,6 @@ package io.debezium.connector.vitess.connection;
 import java.sql.Types;
 
 import io.debezium.connector.vitess.VitessType;
-import io.vitess.proto.Query;
 
 /** Resolve raw column value to Java value */
 public class ReplicationMessageColumnValueResolver {
@@ -25,12 +24,7 @@ public class ReplicationMessageColumnValueResolver {
             case Types.INTEGER:
                 return value.asInteger();
             case Types.BIGINT:
-                if (vitessType.getName().equals(Query.Type.UINT64.name())) {
-                    return Long.parseUnsignedLong(value.asString());
-                }
-                else {
-                    return value.asLong();
-                }
+                return value.asLong();
             case Types.VARCHAR:
                 return value.asString();
             case Types.FLOAT:

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -78,8 +78,10 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
             + "text_col,"
             + "mediumtext_col,"
             + "longtext_col,"
+            + "blob_col,"
+            + "mediumblob_col,"
             + "json_col)"
-            + " VALUES ('a', 'bc', '상품 명1', 'リンゴ', 'd', 'ef', 'gh', 'ij', 'kl','mn', '{\"key1\": \"value1\", \"key2\": {\"key21\": \"value21\", \"key22\": \"value22\"}}');";
+            + " VALUES ('a', 'bc', '상품 명1', 'リンゴ', 'd', 'ef', 'gh', 'ij', 'kl','mn', 'op', 'qs', '{\"key1\": \"value1\", \"key2\": {\"key21\": \"value21\", \"key22\": \"value22\"}}');";
     protected static final String INSERT_ENUM_TYPE_STMT = "INSERT INTO enum_table (enum_col)" + " VALUES ('large');";
     protected static final String INSERT_SET_TYPE_STMT = "INSERT INTO set_table (set_col)" + " VALUES ('a,c');";
     protected static final String INSERT_TIME_TYPES_STMT = "INSERT INTO time_table ("
@@ -107,8 +109,8 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
                         new SchemaAndValueField("int_col", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 1234),
                         new SchemaAndValueField("int_unsigned_col", SchemaBuilder.OPTIONAL_INT64_SCHEMA, 1234L),
                         new SchemaAndValueField("bigint_col", SchemaBuilder.OPTIONAL_INT64_SCHEMA, 12345L),
-                        new SchemaAndValueField("bigint_unsigned_col", SchemaBuilder.OPTIONAL_INT64_SCHEMA, 12345L),
-                        new SchemaAndValueField("bigint_unsigned_overflow_col", SchemaBuilder.OPTIONAL_INT64_SCHEMA, -1L),
+                        new SchemaAndValueField("bigint_unsigned_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "12345"),
+                        new SchemaAndValueField("bigint_unsigned_overflow_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "18446744073709551615"),
                         new SchemaAndValueField("float_col", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA, 1.5),
                         new SchemaAndValueField("double_col", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA, 2.5),
                         new SchemaAndValueField("decimal_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "12.3400"),
@@ -131,6 +133,8 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
                         new SchemaAndValueField("text_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "ij"),
                         new SchemaAndValueField("mediumtext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "kl"),
                         new SchemaAndValueField("longtext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "mn"),
+                        new SchemaAndValueField("blob_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "op"),
+                        new SchemaAndValueField("mediumblob_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "qs"),
                         new SchemaAndValueField("json_col", Json.builder().optional().build(),
                                 "{\"key1\":\"value1\",\"key2\":{\"key21\":\"value21\",\"key22\":\"value22\"}}")));
         return fields;

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -34,6 +34,8 @@ CREATE TABLE string_table
     text_col            TEXT,
     mediumtext_col      MEDIUMTEXT,
     longtext_col        LONGTEXT,
+    blob_col            BLOB,
+    mediumblob_col      MEDIUMBLOB,
     json_col            JSON,
     PRIMARY KEY (id)
 );


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DBZ-4403
* Support blob types
* Use string schema (VARCHAR in JDBC) for UINT64 to avoid overflow