### PR TITLE
DBZ-4409: Enforce consistent JSON serialization of vgtid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,10 +173,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
         <!-- Building -->
         <dependency>
             <groupId>io.debezium</groupId>

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -68,9 +68,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
     @Override
     public void startStreaming(
                                Vgtid vgtid, ReplicationMessageProcessor processor, AtomicReference<Throwable> error) {
-        if (vgtid == null) {
-            Objects.requireNonNull(vgtid);
-        }
+        Objects.requireNonNull(vgtid);
 
         ManagedChannel channel = newChannel(config.getVtgateHost(), config.getVtgatePort());
         managedChannel.compareAndSet(null, channel);
@@ -97,7 +95,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
                         if (vEvent.getType() == Binlogdata.VEventType.ROW) {
                             rowEventSeen++;
                         }
-                        boolean isLastRowEventOfTransaction = newVgtid != null && numOfRowEvents != 0 && rowEventSeen == numOfRowEvents ? true : false;
+                        boolean isLastRowEventOfTransaction = newVgtid != null && numOfRowEvents != 0 && rowEventSeen == numOfRowEvents;
                         messageDecoder.processMessage(response.getEvents(i), processor, newVgtid, isLastRowEventOfTransaction);
                     }
                 }

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -54,9 +54,9 @@ public class VgtidTest {
 
         // verify outcome
         assertThat(vgtid.getRawVgtid()).isEqualTo(rawVgtid);
-        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
+        assertThat(vgtid.getShardGtids()).containsExactly(
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID),
-                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2)));
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2));
         assertThat(vgtid.toString()).isEqualTo(VGTID_JSON);
     }
 

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -54,7 +54,7 @@ public class VgtidTest {
 
         // verify outcome
         assertThat(vgtid.getRawVgtid()).isEqualTo(rawVgtid);
-        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.unmodifiableSet(
+        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID),
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2)));
         assertThat(vgtid.toString()).isEqualTo(VGTID_JSON);
@@ -85,7 +85,7 @@ public class VgtidTest {
                                 .build())
                         .build());
 
-        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.unmodifiableSet(
+        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID),
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2)));
 
@@ -94,11 +94,6 @@ public class VgtidTest {
 
     @Test
     public void shouldCreateFromShardGtidsInJson() {
-        // setup fixture
-        List<Vgtid.ShardGtid> shardGtids = Collect.arrayListOf(
-                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID),
-                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2));
-
         // exercise SUT
         Vgtid vgtid = Vgtid.of(VGTID_JSON);
 
@@ -117,10 +112,40 @@ public class VgtidTest {
                                 .build())
                         .build());
 
-        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.unmodifiableSet(
+        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID),
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2)));
 
         assertThat(vgtid.toString()).isEqualTo(VGTID_JSON);
+    }
+
+    @Test
+    public void shouldEqualsIfEqualityHolds() {
+        // setup fixture
+        Vgtid vgtid1 = Vgtid.of(VGTID_JSON);
+        Vgtid vgtid2 = Vgtid.of(VGTID_JSON);
+        Binlogdata.VGtid rawVgtid = Binlogdata.VGtid.newBuilder()
+                .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                        .setKeyspace(TEST_KEYSPACE)
+                        .setShard(TEST_SHARD)
+                        .setGtid(TEST_GTID)
+                        .build())
+                .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                        .setKeyspace(TEST_KEYSPACE)
+                        .setShard(TEST_SHARD2)
+                        .setGtid(TEST_GTID2)
+                        .build())
+                .build();
+        Vgtid vgtid3 = Vgtid.of(rawVgtid);
+        List<Vgtid.ShardGtid> shardGtids = Collect.arrayListOf(
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID),
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2));
+        Vgtid vgtid4 = Vgtid.of(shardGtids);
+        List<Vgtid> vgtids = Collect.arrayListOf(vgtid1, vgtid2, vgtid3, vgtid4);
+
+        // exercise SU
+        for (Vgtid vgtid : vgtids) {
+            assertThat(vgtids.stream().allMatch(vgtid::equals)).isTrue();
+        }
     }
 }


### PR DESCRIPTION
Ensure `Vgtid.toString` method always produces consistent JSON string of the vgtid by making ShardGtids a list (respecting the list order from raw vgtid) and ensure key sequence in each JSON object representing a ShardGtid.

This fixes https://issues.redhat.com/browse/DBZ-4409
