### PR TITLE
DBZ-4412: Fix source fields and add keyspace field

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/vitess/SourceInfo.java
@@ -8,7 +8,6 @@ package io.debezium.connector.vitess;
 import java.time.Instant;
 
 import io.debezium.annotation.NotThreadSafe;
-import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.common.BaseSourceInfo;
 import io.debezium.relational.TableId;
 
@@ -18,9 +17,10 @@ import io.debezium.relational.TableId;
  */
 @NotThreadSafe
 public class SourceInfo extends BaseSourceInfo {
-    public static final String VGTID = "vgtid";
+    public static final String VGTID_KEY = "vgtid";
+    public static final String KEYSPACE_NAME_KEY = "keyspace";
 
-    private final String dbServerName;
+    private final String keyspace;
 
     private Vgtid currentVgtid;
 
@@ -29,9 +29,9 @@ public class SourceInfo extends BaseSourceInfo {
     // kafka offset topic stores restartVgtid, it is the previous commited transaction vgtid
     private Vgtid restartVgtid;
 
-    public SourceInfo(CommonConnectorConfig config) {
+    public SourceInfo(VitessConnectorConfig config) {
         super(config);
-        this.dbServerName = config.getLogicalName();
+        this.keyspace = config.getKeyspace();
     }
 
     @Override
@@ -41,7 +41,7 @@ public class SourceInfo extends BaseSourceInfo {
 
     @Override
     protected String database() {
-        return dbServerName;
+        return keyspace;
     }
 
     public TableId getTableId() {

--- a/src/main/java/io/debezium/connector/vitess/VitessEventMetadataProvider.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessEventMetadataProvider.java
@@ -44,8 +44,8 @@ public class VitessEventMetadataProvider implements EventMetadataProvider {
         }
 
         return Collect.hashMapOf(
-                SourceInfo.VGTID,
-                sourceInfo.getString(SourceInfo.VGTID));
+                SourceInfo.VGTID_KEY,
+                sourceInfo.getString(SourceInfo.VGTID_KEY));
     }
 
     @Override
@@ -58,7 +58,7 @@ public class VitessEventMetadataProvider implements EventMetadataProvider {
 
         final Struct sourceInfo = value.getStruct(Envelope.FieldName.SOURCE);
         // Use the entire VGTID as transaction id
-        return sourceInfo.getString(SourceInfo.VGTID);
+        return sourceInfo.getString(SourceInfo.VGTID_KEY);
     }
 
 }

--- a/src/main/java/io/debezium/connector/vitess/VitessOffsetContext.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessOffsetContext.java
@@ -78,7 +78,7 @@ public class VitessOffsetContext implements OffsetContext {
     public Map<String, ?> getOffset() {
         Map<String, Object> result = new HashMap<>();
         if (sourceInfo.getRestartVgtid() != null) {
-            result.put(SourceInfo.VGTID, sourceInfo.getRestartVgtid().toString());
+            result.put(SourceInfo.VGTID_KEY, sourceInfo.getRestartVgtid().toString());
         }
         // put OFFSET_TRANSACTION_ID
         return transactionContext.store(result);
@@ -144,7 +144,7 @@ public class VitessOffsetContext implements OffsetContext {
 
         @Override
         public VitessOffsetContext load(Map<String, ?> offset) {
-            final String vgtid = (String) offset.get(SourceInfo.VGTID);
+            final String vgtid = (String) offset.get(SourceInfo.VGTID_KEY);
             return new VitessOffsetContext(
                     connectorConfig,
                     Vgtid.of(vgtid),

--- a/src/main/java/io/debezium/connector/vitess/VitessSourceInfoStructMaker.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessSourceInfoStructMaker.java
@@ -8,22 +8,24 @@ package io.debezium.connector.vitess;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
-import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
 
 /** Create the source struct in the SourceRecord */
 public class VitessSourceInfoStructMaker extends AbstractSourceInfoStructMaker<SourceInfo> {
 
     private final Schema schema;
+    private final String keyspace;
 
     public VitessSourceInfoStructMaker(
-                                       String connector, String version, CommonConnectorConfig connectorConfig) {
+                                       String connector, String version, VitessConnectorConfig connectorConfig) {
         super(connector, version, connectorConfig);
+        this.keyspace = connectorConfig.getKeyspace();
         this.schema = commonSchemaBuilder()
                 .name("io.debezium.connector.vitess.Source")
+                .field(SourceInfo.KEYSPACE_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.SCHEMA_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.TABLE_NAME_KEY, Schema.STRING_SCHEMA)
-                .field(SourceInfo.VGTID, Schema.STRING_SCHEMA)
+                .field(SourceInfo.VGTID_KEY, Schema.STRING_SCHEMA)
                 .build();
     }
 
@@ -35,9 +37,10 @@ public class VitessSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
     @Override
     public Struct struct(SourceInfo sourceInfo) {
         final Struct res = super.commonStruct(sourceInfo)
+                .put(SourceInfo.KEYSPACE_NAME_KEY, this.keyspace)
                 .put(SourceInfo.SCHEMA_NAME_KEY, sourceInfo.getTableId().schema())
                 .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table())
-                .put(SourceInfo.VGTID, sourceInfo.getCurrentVgtid().toString());
+                .put(SourceInfo.VGTID_KEY, sourceInfo.getCurrentVgtid().toString());
 
         return res;
     }

--- a/src/main/java/io/debezium/connector/vitess/converters/VitessCloudEventsMaker.java
+++ b/src/main/java/io/debezium/connector/vitess/converters/VitessCloudEventsMaker.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.vitess.converters;
 
 import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.vitess.SourceInfo;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.converters.spi.SerializerType;
@@ -24,6 +25,6 @@ public class VitessCloudEventsMaker extends CloudEventsMaker {
     @Override
     public String ceId() {
         return "name:" + recordParser.getMetadata(AbstractSourceInfo.SERVER_NAME_KEY)
-                + ";vgtid:" + recordParser.getMetadata(VitessRecordParser.VGTID_KEY);
+                + ";vgtid:" + recordParser.getMetadata(SourceInfo.VGTID_KEY);
     }
 }

--- a/src/main/java/io/debezium/connector/vitess/converters/VitessRecordParser.java
+++ b/src/main/java/io/debezium/connector/vitess/converters/VitessRecordParser.java
@@ -11,6 +11,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
+import io.debezium.connector.vitess.SourceInfo;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.data.Envelope;
 import io.debezium.util.Collect;
@@ -22,11 +23,9 @@ import io.debezium.util.Collect;
  */
 public class VitessRecordParser extends RecordParser {
 
-    static final String VGTID_KEY = "vgtid";
+    private static final Set<String> VITESS_SOURCE_FIELD = Collect.unmodifiableSet(SourceInfo.VGTID_KEY, SourceInfo.KEYSPACE_NAME_KEY);
 
-    static final Set<String> VITESS_SOURCE_FIELD = Collect.unmodifiableSet(VGTID_KEY);
-
-    VitessRecordParser(Schema schema, Struct record) {
+    public VitessRecordParser(Schema schema, Struct record) {
         super(schema, record, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
     }
 

--- a/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
@@ -46,7 +46,7 @@ public class SourceInfoTest {
         final VitessConnectorConfig connectorConfig = new VitessConnectorConfig(
                 Configuration.create()
                         .with(RelationalDatabaseConnectorConfig.SERVER_NAME, "server_foo")
-                        .with(VitessConnectorConfig.KEYSPACE, AnonymousValue.getString())
+                        .with(VitessConnectorConfig.KEYSPACE, TEST_KEYSPACE)
                         .with(VitessConnectorConfig.SHARD, AnonymousValue.getString())
                         .with(VitessConnectorConfig.VTGATE_HOST, AnonymousValue.getString())
                         .with(VitessConnectorConfig.VTGATE_PORT, AnonymousValue.getInt())
@@ -81,7 +81,7 @@ public class SourceInfoTest {
 
     @Test
     public void vgtidKeyspaceIsPresent() {
-        assertThat(source.struct().getString(SourceInfo.VGTID)).isEqualTo(VGTID_JSON);
+        assertThat(source.struct().getString(SourceInfo.VGTID_KEY)).isEqualTo(VGTID_JSON);
     }
 
     @Test
@@ -97,9 +97,14 @@ public class SourceInfoTest {
 
     @Test
     public void tableIdIsPresent() {
-        assertThat(source.struct().getString(SourceInfo.DATABASE_NAME_KEY)).isEqualTo("server_foo");
+        assertThat(source.struct().getString(SourceInfo.DATABASE_NAME_KEY)).isEqualTo(TEST_KEYSPACE);
         assertThat(source.struct().getString(SourceInfo.SCHEMA_NAME_KEY)).isEqualTo("s");
         assertThat(source.struct().getString(SourceInfo.TABLE_NAME_KEY)).isEqualTo("t");
+    }
+
+    @Test
+    public void keyspaceIsPresent() {
+        assertThat(source.struct().getString(SourceInfo.KEYSPACE_NAME_KEY)).isEqualTo(TEST_KEYSPACE);
     }
 
     @Test
@@ -113,6 +118,7 @@ public class SourceInfoTest {
                 .field("snapshot", AbstractSourceInfoStructMaker.SNAPSHOT_RECORD_SCHEMA)
                 .field("db", Schema.STRING_SCHEMA)
                 .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("keyspace", Schema.STRING_SCHEMA)
                 .field("schema", Schema.STRING_SCHEMA)
                 .field("table", Schema.STRING_SCHEMA)
                 .field("vgtid", Schema.STRING_SCHEMA)

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -155,7 +155,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         String expectedOffset = RecordOffset
                 .fromSourceInfo(sourceRecord)
                 .incrementOffset(numOfGtidsFromDdl + 1).getVgtid();
-        String actualOffset = (String) sourceRecord2.sourceOffset().get(SourceInfo.VGTID);
+        String actualOffset = (String) sourceRecord2.sourceOffset().get(SourceInfo.VGTID_KEY);
         Assert.assertEquals(expectedOffset, actualOffset);
     }
 
@@ -229,7 +229,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
                 // last row event has the new vgtid
                 assertRecordOffset(record, RecordOffset.fromSourceInfo(record));
             }
-            assertSourceInfo(record, TestHelper.TEST_SERVER, table.schema(), table.table());
+            assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_UNSHARDED_KEYSPACE, table.schema(), table.table());
             assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
         }
     }
@@ -275,7 +275,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
                 // last row event has the new vgtid
                 assertRecordOffset(record, RecordOffset.fromSourceInfo(record));
             }
-            assertSourceInfo(record, TestHelper.TEST_SERVER, table.schema(), table.table());
+            assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_UNSHARDED_KEYSPACE, table.schema(), table.table());
             assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
         }
     }
@@ -373,7 +373,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         assertRecordInserted(record, expectedTopicName, TestHelper.PK_FIELD);
         assertRecordInserted(record, expectedTopicName, "int_col");
         assertRecordOffset(record, hasMultipleShards);
-        assertSourceInfo(record, TestHelper.TEST_SERVER, table.schema(), table.table());
+        assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_SHARDED_KEYSPACE, table.schema(), table.table());
     }
 
     @Test
@@ -614,16 +614,16 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     private SourceRecord assertInsert(
                                       String statement,
                                       List<SchemaAndValueField> expectedSchemaAndValuesByColumn,
-                                      String database,
+                                      String keyspace,
                                       String pkField,
                                       boolean hasMultipleShards) {
-        TableId table = tableIdFromInsertStmt(statement, database);
+        TableId table = tableIdFromInsertStmt(statement, keyspace);
 
         try {
-            executeAndWait(statement, database);
-            SourceRecord record = assertRecordInserted(topicNameFromInsertStmt(statement, database), pkField);
+            executeAndWait(statement, keyspace);
+            SourceRecord record = assertRecordInserted(topicNameFromInsertStmt(statement, keyspace), pkField);
             assertRecordOffset(record, hasMultipleShards);
-            assertSourceInfo(record, TestHelper.TEST_SERVER, table.schema(), table.table());
+            assertSourceInfo(record, TestHelper.TEST_SERVER, keyspace, table.schema(), table.table());
             if (expectedSchemaAndValuesByColumn != null && !expectedSchemaAndValuesByColumn.isEmpty()) {
                 assertRecordSchemaAndValues(
                         expectedSchemaAndValuesByColumn, record, Envelope.FieldName.AFTER);

--- a/src/test/java/io/debezium/connector/vitess/VitessOffsetContextTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessOffsetContextTest.java
@@ -42,7 +42,7 @@ public class VitessOffsetContextTest {
         loader = new VitessOffsetContext.Loader(
                 new VitessConnectorConfig(TestHelper.defaultConfig().build()));
 
-        offsetContext = (VitessOffsetContext) loader.load(Collect.hashMapOf(SourceInfo.VGTID, VGTID_JSON));
+        offsetContext = (VitessOffsetContext) loader.load(Collect.hashMapOf(SourceInfo.VGTID_KEY, VGTID_JSON));
     }
 
     @Test
@@ -78,7 +78,7 @@ public class VitessOffsetContextTest {
     public void shouldBeAbleToConvertToOffset() {
         Map<String, ?> offset = offsetContext.getOffset();
         assertThat(offset).isNotNull();
-        assertThat(offset.get(SourceInfo.VGTID)).isEqualTo(VGTID_JSON);
+        assertThat(offset.get(SourceInfo.VGTID_KEY)).isEqualTo(VGTID_JSON);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessSourceInfoStructMakerTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessSourceInfoStructMakerTest.java
@@ -39,11 +39,13 @@ public class VitessSourceInfoStructMakerTest {
                 "test_version",
                 new VitessConnectorConfig(TestHelper.defaultConfig().build()));
 
+        assertThat(structMaker.schema().field(SourceInfo.KEYSPACE_NAME_KEY).schema())
+                .isEqualTo(Schema.STRING_SCHEMA);
         assertThat(structMaker.schema().field(SourceInfo.SCHEMA_NAME_KEY).schema())
                 .isEqualTo(Schema.STRING_SCHEMA);
         assertThat(structMaker.schema().field(SourceInfo.TABLE_NAME_KEY).schema())
                 .isEqualTo(Schema.STRING_SCHEMA);
-        assertThat(structMaker.schema().field(SourceInfo.VGTID).schema())
+        assertThat(structMaker.schema().field(SourceInfo.VGTID_KEY).schema())
                 .isEqualTo(Schema.STRING_SCHEMA);
         assertThat(structMaker.schema()).isNotNull();
     }
@@ -71,8 +73,9 @@ public class VitessSourceInfoStructMakerTest {
                         .struct(sourceInfo);
 
         // verify outcome
+        assertThat(struct.getString(SourceInfo.KEYSPACE_NAME_KEY)).isEqualTo(TestHelper.TEST_UNSHARDED_KEYSPACE);
         assertThat(struct.getString(SourceInfo.SCHEMA_NAME_KEY)).isEqualTo(schemaName);
         assertThat(struct.getString(SourceInfo.TABLE_NAME_KEY)).isEqualTo(tableName);
-        assertThat(struct.getString(SourceInfo.VGTID)).isEqualTo(VGTID_JSON);
+        assertThat(struct.getString(SourceInfo.VGTID_KEY)).isEqualTo(VGTID_JSON);
     }
 }


### PR DESCRIPTION
Changes in source fields
- "db" value is changed from logical name to keyspace
- "keyspace" field is added

Other changes:
- Make VitessRecordParser constructor public so we can use it directly
- Rename variable VGTID to VGTID_KEY and declare it only once in SourceInfo and reference from all places.

This fixes https://issues.redhat.com/browse/DBZ-4412