### PR TITLE
DBZ-4428 Override db and remove schema in Vitess source

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessSourceInfoStructMaker.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessSourceInfoStructMaker.java
@@ -14,16 +14,13 @@ import io.debezium.connector.AbstractSourceInfoStructMaker;
 public class VitessSourceInfoStructMaker extends AbstractSourceInfoStructMaker<SourceInfo> {
 
     private final Schema schema;
-    private final String keyspace;
 
     public VitessSourceInfoStructMaker(
                                        String connector, String version, VitessConnectorConfig connectorConfig) {
         super(connector, version, connectorConfig);
-        this.keyspace = connectorConfig.getKeyspace();
         this.schema = commonSchemaBuilder()
                 .name("io.debezium.connector.vitess.Source")
                 .field(SourceInfo.KEYSPACE_NAME_KEY, Schema.STRING_SCHEMA)
-                .field(SourceInfo.SCHEMA_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.TABLE_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.VGTID_KEY, Schema.STRING_SCHEMA)
                 .build();
@@ -37,11 +34,11 @@ public class VitessSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
     @Override
     public Struct struct(SourceInfo sourceInfo) {
         final Struct res = super.commonStruct(sourceInfo)
-                .put(SourceInfo.KEYSPACE_NAME_KEY, this.keyspace)
-                .put(SourceInfo.SCHEMA_NAME_KEY, sourceInfo.getTableId().schema())
+                .put(SourceInfo.KEYSPACE_NAME_KEY, sourceInfo.database())
+                // Override DATABASE_NAME_KEY to empty string and in favor of KEYSPACE_NAME_KEY
+                .put(SourceInfo.DATABASE_NAME_KEY, "")
                 .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table())
                 .put(SourceInfo.VGTID_KEY, sourceInfo.getCurrentVgtid().toString());
-
         return res;
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -369,13 +369,12 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
         }
     }
 
-    protected void assertSourceInfo(SourceRecord record, String name, String keyspace, String schema, String table) {
+    protected void assertSourceInfo(SourceRecord record, String name, String keyspace, String table) {
         assertTrue(record.value() instanceof Struct);
         Struct source = ((Struct) record.value()).getStruct("source");
         Assert.assertEquals(name, source.getString(SourceInfo.SERVER_NAME_KEY));
-        Assert.assertEquals(keyspace, source.getString(SourceInfo.DATABASE_NAME_KEY));
+        Assert.assertEquals("", source.getString(SourceInfo.DATABASE_NAME_KEY));
         Assert.assertEquals(keyspace, source.getString(SourceInfo.KEYSPACE_NAME_KEY));
-        Assert.assertEquals(schema, source.getString(SourceInfo.SCHEMA_NAME_KEY));
         Assert.assertEquals(table, source.getString(SourceInfo.TABLE_NAME_KEY));
         assertNotNull(source.getString(SourceInfo.VGTID_KEY));
     }

--- a/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
@@ -96,14 +96,17 @@ public class SourceInfoTest {
     }
 
     @Test
-    public void tableIdIsPresent() {
-        assertThat(source.struct().getString(SourceInfo.DATABASE_NAME_KEY)).isEqualTo(TEST_KEYSPACE);
-        assertThat(source.struct().getString(SourceInfo.SCHEMA_NAME_KEY)).isEqualTo("s");
+    public void databaseIsEmpty() {
+        assertThat(source.struct().getString(SourceInfo.DATABASE_NAME_KEY)).isEmpty();
+    }
+
+    @Test
+    public void tableIsPresent() {
         assertThat(source.struct().getString(SourceInfo.TABLE_NAME_KEY)).isEqualTo("t");
     }
 
     @Test
-    public void keyspaceIsPresent() {
+    public void keyspaceAndTableArePresent() {
         assertThat(source.struct().getString(SourceInfo.KEYSPACE_NAME_KEY)).isEqualTo(TEST_KEYSPACE);
     }
 
@@ -119,7 +122,6 @@ public class SourceInfoTest {
                 .field("db", Schema.STRING_SCHEMA)
                 .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("keyspace", Schema.STRING_SCHEMA)
-                .field("schema", Schema.STRING_SCHEMA)
                 .field("table", Schema.STRING_SCHEMA)
                 .field("vgtid", Schema.STRING_SCHEMA)
                 .build();

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -229,7 +229,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
                 // last row event has the new vgtid
                 assertRecordOffset(record, RecordOffset.fromSourceInfo(record));
             }
-            assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_UNSHARDED_KEYSPACE, table.schema(), table.table());
+            assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_UNSHARDED_KEYSPACE, table.table());
             assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
         }
     }
@@ -275,7 +275,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
                 // last row event has the new vgtid
                 assertRecordOffset(record, RecordOffset.fromSourceInfo(record));
             }
-            assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_UNSHARDED_KEYSPACE, table.schema(), table.table());
+            assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_UNSHARDED_KEYSPACE, table.table());
             assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
         }
     }
@@ -373,7 +373,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         assertRecordInserted(record, expectedTopicName, TestHelper.PK_FIELD);
         assertRecordInserted(record, expectedTopicName, "int_col");
         assertRecordOffset(record, hasMultipleShards);
-        assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_SHARDED_KEYSPACE, table.schema(), table.table());
+        assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_SHARDED_KEYSPACE, table.table());
     }
 
     @Test
@@ -606,7 +606,6 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
      *
      * @param statement The insert sql statement
      * @param expectedSchemaAndValuesByColumn The expected column type and value
-     * @param database The database (a.k.a keyspace or schema) name
      * @param pkField The primary key column's name
      * @param hasMultipleShards whether the keyspace has multiple shards
      * @return The {@link SourceRecord} generated from the insert event
@@ -623,7 +622,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
             executeAndWait(statement, keyspace);
             SourceRecord record = assertRecordInserted(topicNameFromInsertStmt(statement, keyspace), pkField);
             assertRecordOffset(record, hasMultipleShards);
-            assertSourceInfo(record, TestHelper.TEST_SERVER, keyspace, table.schema(), table.table());
+            assertSourceInfo(record, TestHelper.TEST_SERVER, keyspace, table.table());
             if (expectedSchemaAndValuesByColumn != null && !expectedSchemaAndValuesByColumn.isEmpty()) {
                 assertRecordSchemaAndValues(
                         expectedSchemaAndValuesByColumn, record, Envelope.FieldName.AFTER);

--- a/src/test/java/io/debezium/connector/vitess/VitessSourceInfoStructMakerTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessSourceInfoStructMakerTest.java
@@ -41,8 +41,6 @@ public class VitessSourceInfoStructMakerTest {
 
         assertThat(structMaker.schema().field(SourceInfo.KEYSPACE_NAME_KEY).schema())
                 .isEqualTo(Schema.STRING_SCHEMA);
-        assertThat(structMaker.schema().field(SourceInfo.SCHEMA_NAME_KEY).schema())
-                .isEqualTo(Schema.STRING_SCHEMA);
         assertThat(structMaker.schema().field(SourceInfo.TABLE_NAME_KEY).schema())
                 .isEqualTo(Schema.STRING_SCHEMA);
         assertThat(structMaker.schema().field(SourceInfo.VGTID_KEY).schema())
@@ -74,7 +72,6 @@ public class VitessSourceInfoStructMakerTest {
 
         // verify outcome
         assertThat(struct.getString(SourceInfo.KEYSPACE_NAME_KEY)).isEqualTo(TestHelper.TEST_UNSHARDED_KEYSPACE);
-        assertThat(struct.getString(SourceInfo.SCHEMA_NAME_KEY)).isEqualTo(schemaName);
         assertThat(struct.getString(SourceInfo.TABLE_NAME_KEY)).isEqualTo(tableName);
         assertThat(struct.getString(SourceInfo.VGTID_KEY)).isEqualTo(VGTID_JSON);
     }


### PR DESCRIPTION
Address https://issues.redhat.com/browse/DBZ-4428

## Problem
Follow up on https://github.com/debezium/debezium-connector-vitess/pull/58, we have keyspace information in 3 places in Vitess source: db, keyspace and schema. We should clean it up.

## Solution
This PR remove the `schema` from the Vitess source and override `db` to empty string since in Vitess keyspace is essentially a logical database.

PR to update doc: https://github.com/debezium/debezium/pull/3026