### PR TITLE
DBZ-4428 Use keyspace in source info

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/vitess/SourceInfo.java
@@ -41,6 +41,11 @@ public class SourceInfo extends BaseSourceInfo {
 
     @Override
     protected String database() {
+        // Override DATABASE_NAME_KEY to empty string and in favor of KEYSPACE_NAME_KEY
+        return "";
+    }
+
+    protected String keyspace() {
         return keyspace;
     }
 

--- a/src/main/java/io/debezium/connector/vitess/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/vitess/SourceInfo.java
@@ -42,7 +42,7 @@ public class SourceInfo extends BaseSourceInfo {
     @Override
     protected String database() {
         // Override DATABASE_NAME_KEY to empty string and in favor of KEYSPACE_NAME_KEY
-        return "";
+        return null;
     }
 
     protected String keyspace() {

--- a/src/main/java/io/debezium/connector/vitess/VitessSourceInfoStructMaker.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessSourceInfoStructMaker.java
@@ -34,9 +34,7 @@ public class VitessSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
     @Override
     public Struct struct(SourceInfo sourceInfo) {
         final Struct res = super.commonStruct(sourceInfo)
-                .put(SourceInfo.KEYSPACE_NAME_KEY, sourceInfo.database())
-                // Override DATABASE_NAME_KEY to empty string and in favor of KEYSPACE_NAME_KEY
-                .put(SourceInfo.DATABASE_NAME_KEY, "")
+                .put(SourceInfo.KEYSPACE_NAME_KEY, sourceInfo.keyspace())
                 .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table())
                 .put(SourceInfo.VGTID_KEY, sourceInfo.getCurrentVgtid().toString());
         return res;

--- a/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
@@ -106,7 +106,7 @@ public class SourceInfoTest {
     }
 
     @Test
-    public void keyspaceAndTableArePresent() {
+    public void keyspaceIsPresent() {
         assertThat(source.struct().getString(SourceInfo.KEYSPACE_NAME_KEY)).isEqualTo(TEST_KEYSPACE);
     }
 


### PR DESCRIPTION
Address comments in https://github.com/debezium/debezium-connector-vitess/pull/59

- Fix typo in test 
- Add `keyspace()` in SourceInfo and use that directly instead of `database()`