### PR TITLE
DBZ-4458: Add shard attribute to VitessPartition

### DIFF
--- a/src/test/java/io/debezium/connector/vitess/VitessPartitionTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessPartitionTest.java
@@ -5,6 +5,10 @@
  */
 package io.debezium.connector.vitess;
 
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+
 import io.debezium.connector.common.AbstractPartitionTest;
 
 public class VitessPartitionTest extends AbstractPartitionTest<VitessPartition> {
@@ -17,5 +21,29 @@ public class VitessPartitionTest extends AbstractPartitionTest<VitessPartition> 
     @Override
     protected VitessPartition createPartition2() {
         return new VitessPartition("server2");
+    }
+
+    @Test
+    public void sameShardsShouldBeEqual() {
+        VitessPartition partition1 = new VitessPartition("server1", "shard1");
+        VitessPartition partition2 = new VitessPartition("server1", "shard1");
+        assertThat(partition1).isEqualTo(partition2);
+        assertThat(partition1.hashCode()).isEqualTo(partition2.hashCode());
+    }
+
+    @Test
+    public void differentShardsShouldNotBeEqual() {
+        VitessPartition partition1 = new VitessPartition("server1", "shard1");
+        VitessPartition partition2 = new VitessPartition("server1", "shard2");
+        assertThat(partition1).isNotEqualTo(partition2);
+        assertThat(partition1.hashCode()).isNotEqualTo(partition2.hashCode());
+    }
+
+    @Test
+    public void nullShardShouldNotBeEqualToShard() {
+        VitessPartition partition1 = new VitessPartition("server1");
+        VitessPartition partition2 = new VitessPartition("server1", "shard1");
+        assertThat(partition1).isNotEqualTo(partition2);
+        assertThat(partition1.hashCode()).isNotEqualTo(partition2.hashCode());
     }
 }


### PR DESCRIPTION
Add shard to VitessPartition besides server so the offset commits will be partitioned by (server, shard) when `vitess.shard` is provided in the config.

This fixes https://issues.redhat.com/browse/DBZ-4458

cc @jeffchao @sonne5 