### PR TITLE
DBZ-4493: Add keyspace and shard properties in task context

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessTaskContext.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessTaskContext.java
@@ -5,12 +5,28 @@
  */
 package io.debezium.connector.vitess;
 
+import java.util.Map;
+
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.util.Collect;
 
 /** A state (context) associated with a Vitess task. Used mostly by metrics collection. */
 public class VitessTaskContext extends CdcSourceTaskContext {
 
+    private final VitessConnectorConfig config;
+
     public VitessTaskContext(VitessConnectorConfig config, VitessDatabaseSchema schema) {
         super(config.getContextName(), config.getLogicalName(), schema::tableIds);
+        this.config = config;
+    }
+
+    @Override
+    public Map<String, String> getConnectorProperties() {
+        Map<String, String> props = Collect.hashMapOf("keyspace", config.getKeyspace());
+        String shard = config.getShard();
+        if (shard != null && !shard.isEmpty()) {
+            props.put("shard", shard);
+        }
+        return props;
     }
 }


### PR DESCRIPTION
This enables keyspace and shard to be included in the JMX metric name
This PR depends on https://github.com/debezium/debezium/pull/3070 to be merged first
This fixes https://issues.redhat.com/browse/DBZ-4493