### PR TITLE
DBZ-4667 Fix BEGIN/COMMIT handling when no VGTID was received

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -93,10 +93,10 @@ public class VitessReplicationConnection implements ReplicationConnection {
             @Override
             public void onNext(Vtgate.VStreamResponse response) {
 
-                LOGGER.debug("Received {} vEvents in the VStreamResponse:",
+                LOGGER.debug("Received {} VEvents in the VStreamResponse:",
                         response.getEventsCount());
                 for (VEvent vEvent : response.getEventsList()) {
-                    LOGGER.debug("vEvent: {}", vEvent);
+                    LOGGER.debug("VEvent: {}", vEvent);
                 }
 
                 Vgtid newVgtid = getVgtid(response);

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -21,7 +21,7 @@ public class VgtidTest {
     private static final String TEST_GTID = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000a:1-1513";
     private static final String TEST_SHARD2 = "80-";
     private static final String TEST_GTID2 = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000b:1-1513";
-    private static final String VGTID_JSON = String.format(
+    public static final String VGTID_JSON = String.format(
             "[" +
                     "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}," +
                     "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}" +


### PR DESCRIPTION
Transaction ID in TransactionalMessage cannot be null. Therefore, when the decoder is handling BEGIN and COMMIT events and there is no VGTID event received (this can happen in VStream where the VStream Response consists of only BEGIN and COMMIT events), we do not process it.

This change has been tested in our corporate environment.

This fixes https://issues.redhat.com/browse/DBZ-4667

cc @y5w @keweishang @gunnarmorling 