### PR TITLE
DBZ-4705 Add bytes support for blob and binary types

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -158,7 +158,8 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     TABLET_TYPE,
                     STOP_ON_RESHARD_FLAG,
                     KEEPALIVE_INTERVAL_MS,
-                    GRPC_HEADERS)
+                    GRPC_HEADERS,
+                    BINARY_HANDLING_MODE)
             .events(INCLUDE_UNKNOWN_DATATYPES)
             .excluding(SCHEMA_EXCLUDE_LIST, SCHEMA_INCLUDE_LIST)
             .create();

--- a/src/main/java/io/debezium/connector/vitess/VitessDatabaseSchema.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessDatabaseSchema.java
@@ -39,6 +39,7 @@ public class VitessDatabaseSchema extends RelationalDatabaseSchema {
                                 config.getDecimalMode(),
                                 config.getTemporalPrecisionMode(),
                                 ZoneOffset.UTC,
+                                config.binaryHandlingMode(),
                                 config.includeUnknownDatatypes()),
                         schemaNameAdjuster,
                         config.customConverterRegistry(),

--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -95,13 +95,15 @@ public class VitessType {
             case "UINT32":
             case "INT64":
                 return new VitessType(type, Types.BIGINT);
-            case "UINT64":
+            case "BLOB":
+                return new VitessType(type, Types.BLOB);
             case "VARBINARY":
             case "BINARY":
+                return new VitessType(type, Types.BINARY);
+            case "UINT64":
             case "VARCHAR":
             case "CHAR":
             case "TEXT":
-            case "BLOB":
             case "JSON":
             case "DECIMAL":
             case "TIME":

--- a/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
+import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
 import io.debezium.data.Json;
 import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
@@ -27,12 +28,13 @@ public class VitessValueConverter extends JdbcValueConverters {
                                 DecimalMode decimalMode,
                                 TemporalPrecisionMode temporalPrecisionMode,
                                 ZoneOffset defaultOffset,
+                                BinaryHandlingMode binaryMode,
                                 boolean includeUnknownDatatypes) {
-        super(decimalMode, temporalPrecisionMode, defaultOffset, null, null, null);
+        super(decimalMode, temporalPrecisionMode, defaultOffset, null, null, binaryMode);
         this.includeUnknownDatatypes = includeUnknownDatatypes;
     }
 
-    // Get Kafka connect schema from Debebzium column.
+    // Get Kafka connect schema from Debezium column.
     @Override
     public SchemaBuilder schemaBuilder(Column column) {
         String typeName = column.typeName().toUpperCase();
@@ -55,7 +57,7 @@ public class VitessValueConverter extends JdbcValueConverters {
         }
     }
 
-    // Convert Java value to Kafka connect value.
+    // Convert Java value to Kafka Connect value.
     @Override
     public ValueConverter converter(Column column, Field fieldDefn) {
         String typeName = column.typeName().toUpperCase();

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
@@ -48,6 +48,8 @@ public interface ReplicationMessage {
 
         boolean isNull();
 
+        byte[] asBytes();
+
         String asString();
 
         Integer asInteger();

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumn.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumn.java
@@ -7,6 +7,8 @@ package io.debezium.connector.vitess.connection;
 
 import static io.debezium.connector.vitess.connection.ReplicationMessage.Column;
 
+import java.nio.charset.StandardCharsets;
+
 import io.debezium.connector.vitess.VitessType;
 
 /** Logical represenation of both column type and value. */
@@ -15,10 +17,10 @@ public class ReplicationMessageColumn implements Column {
     private final String columnName;
     private final VitessType type;
     private final boolean optional;
-    private final String rawValue;
+    private final byte[] rawValue;
 
     public ReplicationMessageColumn(
-                                    String columnName, VitessType type, boolean optional, String rawValue) {
+                                    String columnName, VitessType type, boolean optional, byte[] rawValue) {
         this.columnName = columnName;
         this.type = type;
         this.optional = optional;
@@ -48,12 +50,12 @@ public class ReplicationMessageColumn implements Column {
                 type, columnValue, includeUnknownDatatypes);
     }
 
-    public String getRawValue() {
+    public byte[] getRawValue() {
         return rawValue;
     }
 
     @Override
     public String toString() {
-        return columnName + "=" + rawValue;
+        return columnName + "=" + new String(rawValue, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
@@ -13,7 +13,7 @@ import io.debezium.connector.vitess.VitessType;
 public class ReplicationMessageColumnValueResolver {
 
     public static Object resolveValue(
-                                      VitessType vitessType, ReplicationMessage.ColumnValue value, boolean includeUnknownDatatypes) {
+                                      VitessType vitessType, ReplicationMessage.ColumnValue<byte[]> value, boolean includeUnknownDatatypes) {
         if (value.isNull()) {
             return null;
         }
@@ -25,6 +25,9 @@ public class ReplicationMessageColumnValueResolver {
                 return value.asInteger();
             case Types.BIGINT:
                 return value.asLong();
+            case Types.BLOB:
+            case Types.BINARY:
+                return value.asBytes();
             case Types.VARCHAR:
                 return value.asString();
             case Types.FLOAT:

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -307,9 +307,9 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
             final boolean optional = column.isOptional();
 
             final int rawValueLength = (int) row.getLengths(i);
-            final String rawValue = rawValueLength == -1
+            final byte[] rawValue = rawValueLength == -1
                     ? null
-                    : rawValues.substring(rawValueIndex, rawValueIndex + rawValueLength).toStringUtf8();
+                    : rawValues.substring(rawValueIndex, rawValueIndex + rawValueLength).toByteArray();
             if (rawValueLength != -1) {
                 // no update to rawValueIndex when no value in the rawValue
                 rawValueIndex += rawValueLength;

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessColumnValue.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessColumnValue.java
@@ -5,23 +5,25 @@
  */
 package io.debezium.connector.vitess.connection;
 
+import java.nio.charset.StandardCharsets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.vitess.VitessType;
 
-/** A convenient wrapper that wraps the raw string value and converts it to Java value. */
-public class VitessColumnValue implements ReplicationMessage.ColumnValue<String> {
+/** A convenient wrapper that wraps the raw bytes value and converts it to Java value. */
+public class VitessColumnValue implements ReplicationMessage.ColumnValue<byte[]> {
     private static final Logger LOGGER = LoggerFactory.getLogger(VitessColumnValue.class);
 
-    private final String value;
+    private final byte[] value;
 
-    public VitessColumnValue(String value) {
+    public VitessColumnValue(byte[] value) {
         this.value = value;
     }
 
     @Override
-    public String getRawValue() {
+    public byte[] getRawValue() {
         return value;
     }
 
@@ -31,33 +33,38 @@ public class VitessColumnValue implements ReplicationMessage.ColumnValue<String>
     }
 
     @Override
-    public String asString() {
+    public byte[] asBytes() {
         return value;
     }
 
     @Override
+    public String asString() {
+        return new String(value, StandardCharsets.UTF_8);
+    }
+
+    @Override
     public Integer asInteger() {
-        return Integer.valueOf(value);
+        return Integer.valueOf(asString());
     }
 
     @Override
     public Short asShort() {
-        return Short.valueOf(value);
+        return Short.valueOf(asString());
     }
 
     @Override
     public Long asLong() {
-        return Long.valueOf(value);
+        return Long.valueOf(asString());
     }
 
     @Override
     public Float asFloat() {
-        return Float.valueOf(value);
+        return Float.valueOf(asString());
     }
 
     @Override
     public Double asDouble() {
-        return Double.valueOf(value);
+        return Double.valueOf(asString());
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessColumnValue.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessColumnValue.java
@@ -37,6 +37,14 @@ public class VitessColumnValue implements ReplicationMessage.ColumnValue<byte[]>
         return value;
     }
 
+    /**
+     * Convert raw bytes value to string using UTF-8 encoding.
+     *
+     * This is *enforced* for VARCHAR and CHAR types, and is *required* for other non-bytes types (numeric,
+     * timestamp, etc.). For bytes (BLOB, BINARY, etc.) types, the asBytes() should be used.
+     *
+     * @return the UTF-8 string
+     */
     @Override
     public String asString() {
         return new String(value, StandardCharsets.UTF_8);

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -13,8 +13,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -37,6 +39,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.BaseEncoding;
 
 import io.debezium.data.Json;
 import io.debezium.data.SchemaUtil;
@@ -73,16 +76,18 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
             + "varchar_col,"
             + "varchar_ko_col,"
             + "varchar_ja_col,"
-            + "binary_col,"
-            + "varbinary_col,"
             + "tinytext_col,"
             + "text_col,"
             + "mediumtext_col,"
             + "longtext_col,"
-            + "blob_col,"
-            + "mediumblob_col,"
             + "json_col)"
-            + " VALUES ('a', 'bc', '상품 명1', 'リンゴ', 'd', 'ef', 'gh', 'ij', 'kl','mn', 'op', 'qs', '{\"key1\": \"value1\", \"key2\": {\"key21\": \"value21\", \"key22\": \"value22\"}}');";
+            + " VALUES ('a', 'bc', '상품 명1', 'リンゴ', 'gh', 'ij', 'kl', 'mn', '{\"key1\": \"value1\", \"key2\": {\"key21\": \"value21\", \"key22\": \"value22\"}}');";
+    protected static final String INSERT_BYTES_TYPES_STMT = "INSERT INTO string_table ("
+            + "binary_col,"
+            + "varbinary_col,"
+            + "blob_col,"
+            + "mediumblob_col)"
+            + " VALUES ('d', 'ef', 'op', 'qs');";
     protected static final String INSERT_ENUM_TYPE_STMT = "INSERT INTO enum_table (enum_col)" + " VALUES ('large');";
     protected static final String INSERT_SET_TYPE_STMT = "INSERT INTO set_table (set_col)" + " VALUES ('a,c');";
     protected static final String INSERT_TIME_TYPES_STMT = "INSERT INTO time_table ("
@@ -128,16 +133,45 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
                         new SchemaAndValueField("varchar_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "bc"),
                         new SchemaAndValueField("varchar_ko_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "상품 명1"),
                         new SchemaAndValueField("varchar_ja_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "リンゴ"),
-                        new SchemaAndValueField("binary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "d\0"),
-                        new SchemaAndValueField("varbinary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "ef"),
                         new SchemaAndValueField("tinytext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "gh"),
                         new SchemaAndValueField("text_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "ij"),
                         new SchemaAndValueField("mediumtext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "kl"),
                         new SchemaAndValueField("longtext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "mn"),
-                        new SchemaAndValueField("blob_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "op"),
-                        new SchemaAndValueField("mediumblob_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "qs"),
                         new SchemaAndValueField("json_col", Json.builder().optional().build(),
                                 "{\"key1\":\"value1\",\"key2\":{\"key21\":\"value21\",\"key22\":\"value22\"}}")));
+        return fields;
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForBytesTypesAsBytes() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField("binary_col", SchemaBuilder.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("d\0".getBytes())),
+                        new SchemaAndValueField("varbinary_col", SchemaBuilder.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("ef".getBytes())),
+                        new SchemaAndValueField("blob_col", SchemaBuilder.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("op".getBytes())),
+                        new SchemaAndValueField("mediumblob_col", SchemaBuilder.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("qs".getBytes()))));
+        return fields;
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForBytesTypesAsBase64String() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField("binary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, Base64.getEncoder().encodeToString("d\0".getBytes())),
+                        new SchemaAndValueField("varbinary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, Base64.getEncoder().encodeToString("ef".getBytes())),
+                        new SchemaAndValueField("blob_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, Base64.getEncoder().encodeToString("op".getBytes())),
+                        new SchemaAndValueField("mediumblob_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, Base64.getEncoder().encodeToString("qs".getBytes()))));
+        return fields;
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForBytesTypesAsHexString() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField("binary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, BaseEncoding.base16().lowerCase().encode("d\0".getBytes())),
+                        new SchemaAndValueField("varbinary_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, BaseEncoding.base16().lowerCase().encode("ef".getBytes())),
+                        new SchemaAndValueField("blob_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, BaseEncoding.base16().lowerCase().encode("op".getBytes())),
+                        new SchemaAndValueField("mediumblob_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, BaseEncoding.base16().lowerCase().encode("qs".getBytes()))));
         return fields;
     }
 

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -10,7 +10,6 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
@@ -21,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.google.common.primitives.Bytes;
 import com.google.protobuf.ByteString;
 
 import io.debezium.config.Configuration;
@@ -197,7 +197,7 @@ public class TestHelper {
     }
 
     public static Binlogdata.VEvent newInsertEvent(List<ColumnValue> columnValues) {
-        List<String> rawValues = newRawValues(columnValues);
+        List<byte[]> rawValues = newRawValues(columnValues);
         Query.Row row = newRow(rawValues);
 
         return Binlogdata.VEvent.newBuilder()
@@ -216,7 +216,7 @@ public class TestHelper {
     }
 
     public static Binlogdata.VEvent newDeleteEvent(List<ColumnValue> columnValues) {
-        List<String> rawValues = newRawValues(columnValues);
+        List<byte[]> rawValues = newRawValues(columnValues);
         Query.Row row = newRow(rawValues);
 
         return Binlogdata.VEvent.newBuilder()
@@ -236,9 +236,9 @@ public class TestHelper {
 
     public static Binlogdata.VEvent newUpdateEvent(
                                                    List<ColumnValue> beforeColumnValues, List<ColumnValue> afterColumnValues) {
-        List<String> beforeRawValues = newRawValues(beforeColumnValues);
+        List<byte[]> beforeRawValues = newRawValues(beforeColumnValues);
         Query.Row beforeRow = newRow(beforeRawValues);
-        List<String> afterRawValues = newRawValues(afterColumnValues);
+        List<byte[]> afterRawValues = newRawValues(afterColumnValues);
         Query.Row afterRow = newRow(afterRawValues);
 
         return Binlogdata.VEvent.newBuilder()
@@ -254,17 +254,17 @@ public class TestHelper {
 
     public static List<ColumnValue> defaultColumnValues() {
         return Arrays.asList(
-                new ColumnValue("bool_col", Query.Type.INT8, Types.SMALLINT, "1", (short) 1),
+                new ColumnValue("bool_col", Query.Type.INT8, Types.SMALLINT, "1".getBytes(), (short) 1),
                 new ColumnValue("int_col", Query.Type.INT32, Types.INTEGER, null, null),
-                new ColumnValue("long_col", Query.Type.INT32, Types.BIGINT, "23", 23L),
-                new ColumnValue("string_col", Query.Type.VARBINARY, Types.VARCHAR, "test", "test"));
+                new ColumnValue("long_col", Query.Type.INT32, Types.BIGINT, "23".getBytes(), 23L),
+                new ColumnValue("string_col", Query.Type.VARBINARY, Types.VARCHAR, "test".getBytes(), "test"));
     }
 
-    public static List<String> defaultRawValues() {
+    public static List<byte[]> defaultRawValues() {
         return newRawValues(defaultColumnValues());
     }
 
-    public static List<String> newRawValues(List<ColumnValue> columnValues) {
+    public static List<byte[]> newRawValues(List<ColumnValue> columnValues) {
         return columnValues.stream().map(x -> x.getRawValue()).collect(Collectors.toList());
     }
 
@@ -276,15 +276,13 @@ public class TestHelper {
         return newRow(defaultRawValues());
     }
 
-    public static Query.Row newRow(List<String> rawValues) {
+    public static Query.Row newRow(List<byte[]> rawValues) {
         return Query.Row.newBuilder()
                 .setValues(
-                        ByteString.copyFrom(
-                                rawValues.stream().filter(Objects::nonNull).collect(Collectors.joining()),
-                                StandardCharsets.UTF_8))
+                        ByteString.copyFrom(Bytes.concat(rawValues.stream().filter(Objects::nonNull).toArray(byte[][]::new))))
                 .addAllLengths(
-                        defaultRawValues().stream()
-                                .map(x -> x != null ? (long) x.length() : -1L)
+                        rawValues.stream()
+                                .map(x -> x != null ? (long) x.length : -1L)
                                 .collect(Collectors.toList()))
                 .build();
     }
@@ -313,7 +311,7 @@ public class TestHelper {
         private final Object javaValue;
 
         public ColumnValue(
-                           String columnName, Query.Type queryType, int jdbcId, String rawValue, Object javaValue) {
+                           String columnName, Query.Type queryType, int jdbcId, byte[] rawValue, Object javaValue) {
             this.field = Field.newBuilder().setName(columnName).setType(queryType).build();
             this.replicationMessageColumn = new ReplicationMessageColumn(
                     columnName, new VitessType(queryType.name(), jdbcId), true, rawValue);
@@ -328,7 +326,7 @@ public class TestHelper {
             return replicationMessageColumn;
         }
 
-        public String getRawValue() {
+        public byte[] getRawValue() {
             return replicationMessageColumn.getRawValue();
         }
 

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -120,6 +120,9 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         assertInsert(INSERT_STRING_TYPES_STMT, schemasAndValuesForStringTypes(), TestHelper.PK_FIELD);
 
         consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_BYTES_TYPES_STMT, schemasAndValuesForBytesTypesAsBytes(), TestHelper.PK_FIELD);
+
+        consumer.expects(expectedRecordsCount);
         assertInsert(INSERT_ENUM_TYPE_STMT, schemasAndValuesForEnumType(), TestHelper.PK_FIELD);
 
         consumer.expects(expectedRecordsCount);
@@ -127,6 +130,45 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         consumer.expects(expectedRecordsCount);
         assertInsert(INSERT_TIME_TYPES_STMT, schemasAndValuesForTimeType(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveBytesAsBytes() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(CommonConnectorConfig.BINARY_HANDLING_MODE, CommonConnectorConfig.BinaryHandlingMode.BYTES), false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_BYTES_TYPES_STMT, schemasAndValuesForBytesTypesAsBytes(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveBytesAsBase64String() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(VitessConnectorConfig.BINARY_HANDLING_MODE, VitessConnectorConfig.BinaryHandlingMode.BASE64), false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_BYTES_TYPES_STMT, schemasAndValuesForBytesTypesAsBase64String(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveBytesAsHexString() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(VitessConnectorConfig.BINARY_HANDLING_MODE, VitessConnectorConfig.BinaryHandlingMode.HEX), false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_BYTES_TYPES_STMT, schemasAndValuesForBytesTypesAsHexString(), TestHelper.PK_FIELD);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
@@ -23,11 +23,13 @@ public class VitessTypeTest {
         assertThat(VitessType.resolve(asField(Query.Type.INT24)).getJdbcId()).isEqualTo(Types.INTEGER);
         assertThat(VitessType.resolve(asField(Query.Type.INT32)).getJdbcId()).isEqualTo(Types.INTEGER);
         assertThat(VitessType.resolve(asField(Query.Type.INT64)).getJdbcId()).isEqualTo(Types.BIGINT);
+        assertThat(VitessType.resolve(asField(Query.Type.UINT64)).getJdbcId()).isEqualTo(Types.VARCHAR);
         assertThat(VitessType.resolve(asField(Query.Type.FLOAT32)).getJdbcId()).isEqualTo(Types.FLOAT);
         assertThat(VitessType.resolve(asField(Query.Type.FLOAT64)).getJdbcId()).isEqualTo(Types.DOUBLE);
         assertThat(VitessType.resolve(asField(Query.Type.VARBINARY)).getJdbcId())
-                .isEqualTo(Types.VARCHAR);
-        assertThat(VitessType.resolve(asField(Query.Type.BINARY)).getJdbcId()).isEqualTo(Types.VARCHAR);
+                .isEqualTo(Types.BINARY);
+        assertThat(VitessType.resolve(asField(Query.Type.BINARY)).getJdbcId()).isEqualTo(Types.BINARY);
+        assertThat(VitessType.resolve(asField(Query.Type.BLOB)).getJdbcId()).isEqualTo(Types.BLOB);
         assertThat(VitessType.resolve(asField(Query.Type.VARCHAR)).getJdbcId()).isEqualTo(Types.VARCHAR);
         assertThat(VitessType.resolve(asField(Query.Type.CHAR)).getJdbcId()).isEqualTo(Types.VARCHAR);
         assertThat(VitessType.resolve(asField(Query.Type.TEXT)).getJdbcId()).isEqualTo(Types.VARCHAR);

--- a/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnTest.java
@@ -22,7 +22,7 @@ public class ReplicationMessageColumnTest {
                 AnonymousValue.getString(),
                 new VitessType(AnonymousValue.getString(), Types.INTEGER),
                 true,
-                "10");
+                "10".getBytes());
         Object columnValue = column.getValue(false);
         assertThat(columnValue).isEqualTo(10);
     }
@@ -33,7 +33,7 @@ public class ReplicationMessageColumnTest {
                 AnonymousValue.getString(),
                 new VitessType(AnonymousValue.getString(), Types.INTEGER),
                 true,
-                "10.1");
+                "10.1".getBytes());
         column.getValue(false);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolverTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolverTest.java
@@ -20,7 +20,7 @@ public class ReplicationMessageColumnValueResolverTest {
     public void shouldResolveIntToInt() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.INTEGER),
-                new VitessColumnValue("10"),
+                new VitessColumnValue("10".getBytes()),
                 false);
         assertThat(resolvedJavaValue).isEqualTo(10);
     }
@@ -29,7 +29,7 @@ public class ReplicationMessageColumnValueResolverTest {
     public void shouldResolveSmallIntToShort() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.SMALLINT),
-                new VitessColumnValue("10"),
+                new VitessColumnValue("10".getBytes()),
                 false);
         assertThat(resolvedJavaValue).isEqualTo((short) 10);
     }
@@ -38,7 +38,7 @@ public class ReplicationMessageColumnValueResolverTest {
     public void shouldResolveBigIntToLong() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.BIGINT),
-                new VitessColumnValue("10"),
+                new VitessColumnValue("10".getBytes()),
                 false);
         assertThat(resolvedJavaValue).isEqualTo(10L);
     }
@@ -47,16 +47,34 @@ public class ReplicationMessageColumnValueResolverTest {
     public void shouldResolveVarcharToString() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.VARCHAR),
-                new VitessColumnValue("foo"),
+                new VitessColumnValue("foo".getBytes()),
                 false);
         assertThat(resolvedJavaValue).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldResolveBlobToBytes() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.BLOB),
+                new VitessColumnValue("foo".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isEqualTo("foo".getBytes());
+    }
+
+    @Test
+    public void shouldResolveBinaryToBytes() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.BINARY),
+                new VitessColumnValue("foo".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isEqualTo("foo".getBytes());
     }
 
     @Test
     public void shouldResolveFloatToFloat() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.FLOAT),
-                new VitessColumnValue("1.1"),
+                new VitessColumnValue("1.1".getBytes()),
                 false);
         assertThat(resolvedJavaValue).isEqualTo(1.1F);
     }
@@ -65,7 +83,7 @@ public class ReplicationMessageColumnValueResolverTest {
     public void shouldResolveDoubleToDouble() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.DOUBLE),
-                new VitessColumnValue("1.1"),
+                new VitessColumnValue("1.1".getBytes()),
                 false);
         assertThat(resolvedJavaValue).isEqualTo(1.1D);
     }
@@ -74,7 +92,7 @@ public class ReplicationMessageColumnValueResolverTest {
     public void shouldResolveUnknownToStringWhenNeeded() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.OTHER),
-                new VitessColumnValue("foo"),
+                new VitessColumnValue("foo".getBytes()),
                 true);
         assertThat(resolvedJavaValue).isEqualTo("foo");
     }
@@ -83,7 +101,7 @@ public class ReplicationMessageColumnValueResolverTest {
     public void shouldResolveUnknownToNullWhenNeeded() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.OTHER),
-                new VitessColumnValue("foo"),
+                new VitessColumnValue("foo".getBytes()),
                 false);
         assertThat(resolvedJavaValue).isNull();
     }

--- a/src/test/java/io/debezium/connector/vitess/connection/VitessColumnValueTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VitessColumnValueTest.java
@@ -16,50 +16,56 @@ import io.debezium.connector.vitess.VitessType;
 public class VitessColumnValueTest {
 
     @Test
+    public void shouldConvertRawValueToBytes() {
+        VitessColumnValue value = new VitessColumnValue("1".getBytes());
+        assertThat(value.asBytes()).isEqualTo("1".getBytes());
+    }
+
+    @Test
     public void shouldConvertRawValueToString() {
-        VitessColumnValue value = new VitessColumnValue("1");
+        VitessColumnValue value = new VitessColumnValue("1".getBytes());
         assertThat(value.asString()).isEqualTo("1");
     }
 
     @Test
     public void shouldConvertRawValueToShort() {
-        VitessColumnValue value = new VitessColumnValue("1");
+        VitessColumnValue value = new VitessColumnValue("1".getBytes());
         assertThat(value.asShort()).isEqualTo((short) 1);
     }
 
     @Test
     public void shouldConvertRawValueToInteger() {
-        VitessColumnValue value = new VitessColumnValue("1");
+        VitessColumnValue value = new VitessColumnValue("1".getBytes());
         assertThat(value.asInteger()).isEqualTo(1);
     }
 
     @Test
     public void shouldConvertRawValueToLong() {
-        VitessColumnValue value = new VitessColumnValue("1");
+        VitessColumnValue value = new VitessColumnValue("1".getBytes());
         assertThat(value.asLong()).isEqualTo(1L);
     }
 
     @Test
     public void shouldConvertRawValueToFloat() {
-        VitessColumnValue value = new VitessColumnValue("1.2");
+        VitessColumnValue value = new VitessColumnValue("1.2".getBytes());
         assertThat(value.asFloat()).isEqualTo(1.2F);
     }
 
     @Test
     public void shouldConvertRawValueToDouble() {
-        VitessColumnValue value = new VitessColumnValue("1.2");
+        VitessColumnValue value = new VitessColumnValue("1.2".getBytes());
         assertThat(value.asDouble()).isEqualTo(1.2D);
     }
 
     @Test
     public void shouldConvertRawValueToStringWhenUnknownIsSet() {
-        VitessColumnValue value = new VitessColumnValue("1");
+        VitessColumnValue value = new VitessColumnValue("1".getBytes());
         assertThat(value.asDefault(new VitessType("foo", Types.OTHER), true)).isEqualTo("1");
     }
 
     @Test
     public void shouldConvertRawValueToNullWhenUnknownIsUnset() {
-        VitessColumnValue value = new VitessColumnValue("1");
+        VitessColumnValue value = new VitessColumnValue("1".getBytes());
         assertThat(value.asDefault(new VitessType("foo", Types.OTHER), false)).isNull();
     }
 }


### PR DESCRIPTION
- Store raw bytes instead of string in `VitessColumnValue` and `ReplicationMessageColumn` used internally in value resolving and converters
- Add bytes support for blob and binary types
- Add support for binary.handling.mode and enable it in config

This fixes: https://issues.redhat.com/browse/DBZ-4705

cc @y5w @keweishang 