### PR TITLE
DBZ-5063 Fix inconsistent transaction id

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -417,11 +417,6 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
         this.transactionId = transactionId;
     }
 
-    @VisibleForTesting
-    String getTransactionId() {
-        return this.transactionId;
-    }
-
     private static String validateColumnName(String columnName, String schemaName, String tableName) {
         int length = columnName.length();
         if (length == 0) {

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -108,8 +108,9 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
             throws InterruptedException {
         this.commitTimestamp = Instant.ofEpochSecond(vEvent.getTimestamp());
         // Use the entire VGTID as transaction id.
-        // If newVgtid is null, reset transactionId to null.
-        this.transactionId = newVgtid == null ? null : newVgtid.toString();
+        if (newVgtid != null) {
+            this.transactionId = newVgtid.toString();
+        }
         // Transaction ID must not be null in TransactionalMessage.
         if (this.transactionId == null) {
             LOGGER.info("Skip processing BEGIN because no VGTID was received");
@@ -132,8 +133,6 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
         LOGGER.trace("Commit timestamp of commit transaction: {}", commitTimestamp);
         processor.process(
                 new TransactionalMessage(Operation.COMMIT, transactionId, commitTimestamp), newVgtid, false);
-        // Reset the transaction ID after COMMIT.
-        this.transactionId = null;
     }
 
     private void decodeRows(Binlogdata.VEvent vEvent, ReplicationMessageProcessor processor, Vgtid newVgtid, boolean isLastRowEventOfTransaction)

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,9 +146,10 @@ public class VitessReplicationConnection implements ReplicationConnection {
                 }
                 if (vgtids.size() == 0) {
                     // The VStreamResponse that contains an VERSION vEvent does not have VGTID.
-                    // We do not update lastReceivedVgtid in this case.
                     // It can also be null if the 1st grpc response does not have vgtid upon restart
-                    LOGGER.trace("No vgtid found in response {}...", response.toString().substring(0, Math.min(100, response.toString().length())));
+                    LOGGER.warn("No vgtid found in response of event types: {}",
+                            response.getEventsList().stream().map(VEvent::getType).map(Objects::toString).collect(Collectors.joining(", ")));
+                    LOGGER.debug("No vgtid found in response {}...", response.toString().substring(0, Math.min(100, response.toString().length())));
                     LOGGER.debug("Full response is {}", response);
                     return null;
                 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -23,8 +23,10 @@ import java.util.stream.IntStream;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
+import org.fest.assertions.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -316,7 +318,9 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
             }
             else {
                 // last row event has the new vgtid
-                assertRecordOffset(record, RecordOffset.fromSourceInfo(record));
+                String newVgtid = RecordOffset.fromSourceInfo(record).getVgtid();
+                assertThat(newVgtid).isNotNull();
+                assertThat(newVgtid).isNotEqualTo(baseVgtid.toString());
             }
             assertSourceInfo(record, TestHelper.TEST_SERVER, TestHelper.TEST_UNSHARDED_KEYSPACE, table.table());
             assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
@@ -331,10 +335,10 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         assertConnectorIsRunning();
 
         Vgtid baseVgtid = TestHelper.getCurrentVgtid();
-        // Insert 1000 rows
+        // Insert 10000 rows to make sure we will get multiple gRPC responses.
         // We should get multiple gRPC responses:
         // The first response contains BEGIN and ROW events; The last response contains ROW, VGTID and COMMIT events.
-        int expectedRecordsCount = 1000;
+        int expectedRecordsCount = 10000;
         consumer = testConsumer(expectedRecordsCount);
         String rowValue = "(1, 1, 12, 12, 123, 123, 1234, 1234, 12345, 12345, 18446744073709551615, 1.5, 2.5, 12.34, true)";
         StringBuilder insertRows = new StringBuilder().append("INSERT INTO numeric_table ("
@@ -370,9 +374,69 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
                 }
                 else {
                     // last row event has the new vgtid
-                    assertRecordOffset(actualRecord, RecordOffset.fromSourceInfo(actualRecord));
+                    String newVgtid = RecordOffset.fromSourceInfo(actualRecord).getVgtid();
+                    assertThat(newVgtid).isNotNull();
+                    assertThat(newVgtid).isNotEqualTo(baseVgtid.toString());
                 }
             }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Testing.Print.enable();
+    }
+
+    @Test
+    @FixFor("DBZ-5063")
+    public void shouldUseSameTransactionIdWhenMultiGrpcResponses() throws Exception {
+        Testing.Print.disable();
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(CommonConnectorConfig.PROVIDE_TRANSACTION_METADATA, true), false);
+        assertConnectorIsRunning();
+
+        Vgtid baseVgtid = TestHelper.getCurrentVgtid();
+        // Insert 10000 rows to make sure we will get multiple gRPC responses.
+        // The first response contains BEGIN and ROW events; The last response contains ROW, VGTID and COMMIT events.
+        int expectedRecordsCount = 10000;
+        // Expect 10000 inserts + 2 transaction metadata.
+        consumer = testConsumer(expectedRecordsCount + 2);
+        String rowValue = "(1, 1, 12, 12, 123, 123, 1234, 1234, 12345, 12345, 18446744073709551615, 1.5, 2.5, 12.34, true)";
+        StringBuilder insertRows = new StringBuilder().append("INSERT INTO numeric_table ("
+                + "tinyint_col,"
+                + "tinyint_unsigned_col,"
+                + "smallint_col,"
+                + "smallint_unsigned_col,"
+                + "mediumint_col,"
+                + "mediumint_unsigned_col,"
+                + "int_col,"
+                + "int_unsigned_col,"
+                + "bigint_col,"
+                + "bigint_unsigned_col,"
+                + "bigint_unsigned_overflow_col,"
+                + "float_col,"
+                + "double_col,"
+                + "decimal_col,"
+                + "boolean_col)"
+                + " VALUES " + rowValue);
+        for (int i = 1; i < expectedRecordsCount; i++) {
+            insertRows.append(", ").append(rowValue);
+        }
+
+        String insertRowsStatement = insertRows.toString();
+        try {
+            // exercise SUT
+            executeAndWait(insertRowsStatement);
+            String expectedTxId = assertRecordBegin();
+            for (int i = 1; i <= expectedRecordsCount; i++) {
+                SourceRecord record = assertRecordInserted(TestHelper.TEST_UNSHARDED_KEYSPACE + ".numeric_table", TestHelper.PK_FIELD);
+                final Struct txn = ((Struct) record.value()).getStruct("transaction");
+                String txId = txn.getString("id");
+                assertThat(txId).isNotNull();
+                assertThat(txId).isEqualTo(expectedTxId);
+                Vgtid actualVgtid = Vgtid.of(txId);
+                assertThat(actualVgtid).isNotEqualTo(baseVgtid);
+            }
+            assertRecordEnd(expectedTxId, expectedRecordsCount);
         }
         catch (Exception e) {
             throw new RuntimeException(e);
@@ -715,6 +779,34 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     private SourceRecord assertRecordUpdated(SourceRecord updatedRecord) {
         VerifyRecord.isValidUpdate(updatedRecord);
         return updatedRecord;
+    }
+
+    /**
+     * Assert that the connector receives a valid BEGIN event.
+     *
+     * @return The transaction id
+     */
+    private String assertRecordBegin() {
+        assertFalse("records not generated", consumer.isEmpty());
+        SourceRecord record = consumer.remove();
+        final Struct end = (Struct) record.value();
+        Assertions.assertThat(end.getString("status")).isEqualTo("BEGIN");
+        return end.getString("id");
+    }
+
+    /**
+     * Assert that the connector receives a valid END event.
+     *
+     * @param expectedTxId The expected transaction id
+     * @param expectedEventCount The expected event count
+     */
+    private void assertRecordEnd(String expectedTxId, long expectedEventCount) {
+        assertFalse("records not generated", consumer.isEmpty());
+        SourceRecord record = consumer.remove();
+        final Struct end = (Struct) record.value();
+        Assertions.assertThat(end.getString("status")).isEqualTo("END");
+        Assertions.assertThat(end.getString("id")).isEqualTo(expectedTxId);
+        Assertions.assertThat(end.getInt64("event_count")).isEqualTo(expectedEventCount);
     }
 
     private void executeAndWait(String statement) throws Exception {

--- a/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
@@ -69,7 +69,6 @@ public class VStreamOutputMessageDecoderTest {
                 newVgtid,
                 false);
         assertThat(processed[0]).isTrue();
-        assertThat(decoder.getTransactionId()).isEqualTo(newVgtid.toString());
     }
 
     @Test
@@ -83,7 +82,6 @@ public class VStreamOutputMessageDecoderTest {
 
         // exercise SUT
         final boolean[] processed = { false };
-        decoder.setTransactionId("dummy");
         decoder.processMessage(
                 event,
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -96,7 +94,6 @@ public class VStreamOutputMessageDecoderTest {
                 null,
                 false);
         assertThat(processed[0]).isFalse();
-        assertThat(decoder.getTransactionId()).isNull();
     }
 
     @Test
@@ -125,7 +122,6 @@ public class VStreamOutputMessageDecoderTest {
                 newVgtid,
                 false);
         assertThat(processed[0]).isTrue();
-        assertThat(decoder.getTransactionId()).isNull();
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
@@ -69,6 +69,7 @@ public class VStreamOutputMessageDecoderTest {
                 newVgtid,
                 false);
         assertThat(processed[0]).isTrue();
+        assertThat(decoder.getTransactionId()).isEqualTo(newVgtid.toString());
     }
 
     @Test
@@ -82,6 +83,7 @@ public class VStreamOutputMessageDecoderTest {
 
         // exercise SUT
         final boolean[] processed = { false };
+        decoder.setTransactionId("dummy");
         decoder.processMessage(
                 event,
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -94,6 +96,7 @@ public class VStreamOutputMessageDecoderTest {
                 null,
                 false);
         assertThat(processed[0]).isFalse();
+        assertThat(decoder.getTransactionId()).isNull();
     }
 
     @Test
@@ -122,6 +125,7 @@ public class VStreamOutputMessageDecoderTest {
                 newVgtid,
                 false);
         assertThat(processed[0]).isTrue();
+        assertThat(decoder.getTransactionId()).isNull();
     }
 
     @Test


### PR DESCRIPTION
# Symptom
We found that the following events (raw output using grpcurl from VStream gRPC endpoint) immediately following some row events could cause the connector to output transaction metadata with the wrong GTID.

This is because the transaction id is cached in VStreamOutputMessageDecoder. Whenever there is a normal response that contains `{BEGIN, VGTID and COMMIT}`, the cache will be updated the used according to send out transactional messages.
However, this cache is retained even after the normal response has been processed. If the next time some partial transaction responses like below are received, it will cause these BEGIN and COMMIT events to have the old transaction id from that previously processed response.

```
{  // response 1
  "events": [
    {
      "type": "BEGIN",
      "timestamp": "1651088385",
      "currentTime": "1651099396717227695",
      "keyspace": "ks1",
      "shard": "0"
    },
    {
      "type": "VERSION",
      "timestamp": "1651088385",
      "currentTime": "1651099396720350986",
      "keyspace": "ks1",
      "shard": "0"
    }
  ]
}
{  // response 2
  "events": [
    {
      "type": "VGTID",
      "vgtid": {
        "shardGtids": [
          {
            "keyspace": "ks1",
            "shard": "0",
            "gtid": "MySQL56/0b978551-8c72-4183-9d07-9383140bb3a9:1-149087591"
          }
        ]
      },
      "keyspace": "ks1",
      "shard": "0"
    },
    {
      "type": "COMMIT",
      "timestamp": "1651088385",
      "currentTime": "1651099396720376470",
      "keyspace": "ks1",
      "shard": "0"
    }
  ]
}
```
# Cause Analysis

![Vitess gRPC responses](https://raw.githubusercontent.com/debezium/debezium-connector-vitess/main/documentation/assets/Offsets.png)

As seen in the [README page](https://github.com/debezium/debezium-connector-vitess#managing-offset), a Vitess transaction could be split into multiple gRPC responses. The current code only handles multi-responses at offset level, meaning managing offset in both memory via VitessOffsetContext as well as emitting offset as part of the "source" field in the output records. However, the transaction IDs are not handled correctly. If a transaction is split into multiple responses, such as this [BEGIN, ROW1, ROW2] and [ROW2, VGTID, COMMIT], these events will be sent out using the previously cached transaction ID, which will cause the serious issues in the downstream consumers that rely on transaction ID to do transaction-level aggregation. 

The reason why a transaction can be received as multiple gRPC responses is that VStream will split large transactions into many chunks performance reasons:
* https://github.com/vitessio/vitess/blob/3d4f40041e34e781b4bf94b77ef70877b9f90c2d/go/vt/vttablet/tabletserver/vstreamer/packet_size.go#L27
* https://github.com/vitessio/vitess/blob/3d4f40041e34e781b4bf94b77ef70877b9f90c2d/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go#L254

# Fix

To handle split transactions, we need to buffer events until we receive a complete transaction. When we receive a complete transaction, we can get the VGTID as tranasction id and process every single event in between using this transaction id. This will guarantee correct transaction id is attached to all events that belong to that particular transaction.

There might be other unpredicted behaviors or bugs from Vitess VStream, e.g. duplicate responses, unpaired BEGIN/COMMIT events. Therefore, to make connector code robust, we catch these cases and throw an error to the error handler.

JIRA ticket: https://issues.redhat.com/browse/DBZ-5063