### PR TITLE
DBZ-5382: Support multiple tasks in vitess connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
                                     <color>yellow</color>
                                 </log>
                                 <wait>
-                                    <time>120000</time> <!-- 120 seconds max -->
+                                    <time>240000</time> <!-- 240 seconds max -->
                                     <log>vtgate is up</log>
                                 </wait>
                             </run>

--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -235,16 +235,17 @@ public class VitessConnector extends RelationalBaseSourceConnector {
         LOGGER.info("Validating config: {}", config);
         Map<String, ConfigValue> results = config.validate(VitessConnectorConfig.ALL_FIELDS);
         Integer maxTasks = config.getInteger(VitessConnectorConfig.TASKS_MAX_CONFIG);
+        VitessConnectorConfig tempConnectorConfig = new VitessConnectorConfig(config);
         if (maxTasks != null && maxTasks > 1) {
-            if (!connectorConfig.offsetStoragePerTask()) {
+            if (!tempConnectorConfig.offsetStoragePerTask()) {
                 String configName = VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name();
                 results.computeIfAbsent(configName, k -> new ConfigValue(configName));
                 results.get(configName).addErrorMessage(String.format(
                         "%s needs to be enabled when %s > 1", configName, VitessConnectorConfig.TASKS_MAX_CONFIG));
             }
         }
-        if (connectorConfig.offsetStoragePerTask()) {
-            if (connectorConfig.getOffsetStorageTaskKeyGen() < 0) {
+        if (tempConnectorConfig.offsetStoragePerTask()) {
+            if (tempConnectorConfig.getOffsetStorageTaskKeyGen() < 0) {
                 String configName = VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name();
                 results.computeIfAbsent(configName, k -> new ConfigValue(configName));
                 results.get(configName).addErrorMessage(String.format(
@@ -252,8 +253,8 @@ public class VitessConnector extends RelationalBaseSourceConnector {
                         configName, VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name()));
             }
         }
-        if (connectorConfig.getOffsetStorageTaskKeyGen() >= 0) {
-            if (connectorConfig.getPrevNumTasks() <= 0) {
+        if (tempConnectorConfig.getOffsetStorageTaskKeyGen() >= 0) {
+            if (tempConnectorConfig.getPrevNumTasks() <= 0) {
                 String configName = VitessConnectorConfig.PREV_NUM_TASKS.name();
                 results.computeIfAbsent(configName, k -> new ConfigValue(configName));
                 results.get(configName).addErrorMessage(String.format(

--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -76,7 +76,7 @@ public class VitessConnector extends RelationalBaseSourceConnector {
             for (int tid : shardsPerTask.keySet()) {
                 List<String> taskShards = shardsPerTask.get(tid);
                 Map<String, String> taskProps = new HashMap<>(properties);
-                taskProps.put(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG, String.format("task%d_%d", tid, tasks));
+                taskProps.put(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG, getTaskKeyName(tid, tasks));
                 taskProps.put(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG, String.join(",", taskShards));
                 allTaskProps.add(taskProps);
             }
@@ -89,6 +89,10 @@ public class VitessConnector extends RelationalBaseSourceConnector {
             }
             return Collections.singletonList(properties);
         }
+    }
+
+    protected static final String getTaskKeyName(int tid, int numTasks) {
+        return String.format("task%d_%d", tid, numTasks);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -245,13 +245,13 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     // The vitess.task.shards config, the value is a comma separated vitess shard names
     // VitessConnector will populate the value of this param and pass on to VitessConnectorTask
-    protected static final String VITESS_TASK_KEY_SHARDS_CONFIG = "vitess.task.shards";
+    protected static final String VITESS_TASK_SHARDS_CONFIG = "vitess.task.shards";
 
     // The vgtid assigned to the given task in the json format, this is the same format as we would see
     // in the Kafka offset storage.
     // e.g. [{\"keyspace\":\"ks\",\"shard\":\"-80\",\"gtid\":\"MySQL56/0001:1-114\"},
     // {\"keyspace\":\"ks\",\"shard\":\"80-\",\"gtid\":\"MySQL56/0002:1-122\"}]
-    protected static final String VITESS_KEY_KEY_VGTID_CONFIG = "vitess.task.vgtid";
+    protected static final String VITESS_TASK_VGTID_CONFIG = "vitess.task.vgtid";
 
     /**
      * The set of {@link Field}s defined as part of this configuration.
@@ -369,11 +369,11 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     public List<String> getVitessTaskKeyShards() {
-        return getConfig().getStrings(VITESS_TASK_KEY_SHARDS_CONFIG, ",");
+        return getConfig().getStrings(VITESS_TASK_SHARDS_CONFIG, ",");
     }
 
     public Vgtid getVitessTaskVgtid() {
-        String vgtidStr = getConfig().getString(VITESS_KEY_KEY_VGTID_CONFIG);
+        String vgtidStr = getConfig().getString(VITESS_TASK_VGTID_CONFIG);
         return vgtidStr == null ? null : Vgtid.of(vgtidStr);
     }
 }

--- a/src/main/java/io/debezium/connector/vitess/VitessPartition.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessPartition.java
@@ -10,15 +10,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.util.Collect;
 
 public class VitessPartition implements Partition {
-    private static final Logger LOGGER = LoggerFactory.getLogger(VitessPartition.class);
-
     protected static final String SERVER_PARTITION_KEY = "server";
     protected static final String TASK_KEY_PARTITION_KEY = "task_key";
 
@@ -72,7 +67,7 @@ public class VitessPartition implements Partition {
             if (connectorConfig.offsetStoragePerTask()) {
                 String taskKey = connectorConfig.getVitessTaskKey();
                 if (taskKey == null) {
-                    throw new RuntimeException("No vitess.task.key in: {}" + connectorConfig.getConfig());
+                    throw new RuntimeException("No vitess.task.key in: " + connectorConfig.getConfig());
                 }
                 return Collections.singleton(new VitessPartition(connectorConfig.getLogicalName(), taskKey));
             }

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -326,11 +326,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
         Vgtid vgtid;
         if (config.offsetStoragePerTask()) {
             List<String> shards = config.getVitessTaskKeyShards();
-            List<String> gtids = new ArrayList<>();
-            for (int i = 0; i < shards.size(); i++) {
-                gtids.add(Vgtid.CURRENT_GTID);
-            }
-            vgtid = buildVgtid(config.getKeyspace(), shards, gtids);
+            vgtid = config.getVitessTaskVgtid();
             LOGGER.info("VGTID '{}' is set for the keyspace: {} shards: {}",
                     vgtid, config.getKeyspace(), shards);
         }

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -293,7 +293,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
         }
     }
 
-    private static Vgtid buildVgtid(String keyspace, List<String> shards, List<String> gtids) {
+    public static Vgtid buildVgtid(String keyspace, List<String> shards, List<String> gtids) {
         Binlogdata.VGtid.Builder builder = Binlogdata.VGtid.newBuilder();
         Vgtid vgtid;
         if (shards == null || shards.isEmpty()) {

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -56,7 +56,7 @@ public class TestHelper {
             "CREATE TABLE t1 (id BIGINT NOT NULL AUTO_INCREMENT, int_col INT, PRIMARY KEY (id));");
 
     public static Configuration.Builder defaultConfig() {
-        return defaultConfig(false);
+        return defaultConfig(false, false, 1);
     }
 
     /**
@@ -65,7 +65,9 @@ public class TestHelper {
      * @param hasMultipleShards whether the keyspace has multiple shards
      * @return Configuration builder
      */
-    public static Configuration.Builder defaultConfig(boolean hasMultipleShards) {
+    public static Configuration.Builder defaultConfig(boolean hasMultipleShards,
+                                                      boolean offsetStoragePerTask,
+                                                      int numTasks) {
         Configuration.Builder builder = Configuration.create();
         builder = builder
                 .with(RelationalDatabaseConnectorConfig.SERVER_NAME, TEST_SERVER)
@@ -75,12 +77,17 @@ public class TestHelper {
                 .with(VitessConnectorConfig.VTGATE_PASSWORD, PASSWORD)
                 .with(VitessConnectorConfig.POLL_INTERVAL_MS, 100);
         if (hasMultipleShards) {
-            return builder.with(VitessConnectorConfig.KEYSPACE, TEST_SHARDED_KEYSPACE);
+            builder = builder.with(VitessConnectorConfig.KEYSPACE, TEST_SHARDED_KEYSPACE);
         }
         else {
-            return builder.with(VitessConnectorConfig.KEYSPACE, TEST_UNSHARDED_KEYSPACE)
+            builder = builder.with(VitessConnectorConfig.KEYSPACE, TEST_UNSHARDED_KEYSPACE)
                     .with(VitessConnectorConfig.SHARD, TEST_SHARD);
         }
+        if (offsetStoragePerTask) {
+            builder = builder.with(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK, "true")
+                    .with(VitessConnectorConfig.TASKS_MAX_CONFIG, Integer.toString(numTasks));
+        }
+        return builder;
     }
 
     public static void execute(List<String> statements) {

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -56,7 +56,7 @@ public class TestHelper {
             "CREATE TABLE t1 (id BIGINT NOT NULL AUTO_INCREMENT, int_col INT, PRIMARY KEY (id));");
 
     public static Configuration.Builder defaultConfig() {
-        return defaultConfig(false, false, 1);
+        return defaultConfig(false, false, 1, -1, -1);
     }
 
     /**
@@ -67,7 +67,9 @@ public class TestHelper {
      */
     public static Configuration.Builder defaultConfig(boolean hasMultipleShards,
                                                       boolean offsetStoragePerTask,
-                                                      int numTasks) {
+                                                      int numTasks,
+                                                      int gen,
+                                                      int prevNumTasks) {
         Configuration.Builder builder = Configuration.create();
         builder = builder
                 .with(RelationalDatabaseConnectorConfig.SERVER_NAME, TEST_SERVER)
@@ -85,7 +87,9 @@ public class TestHelper {
         }
         if (offsetStoragePerTask) {
             builder = builder.with(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK, "true")
-                    .with(VitessConnectorConfig.TASKS_MAX_CONFIG, Integer.toString(numTasks));
+                    .with(VitessConnectorConfig.TASKS_MAX_CONFIG, Integer.toString(numTasks))
+                    .with(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN, Integer.toString(gen))
+                    .with(VitessConnectorConfig.PREV_NUM_TASKS, Integer.toString(prevNumTasks));
         }
         return builder;
     }

--- a/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
@@ -154,6 +154,6 @@ public class VitessChangeRecordEmitterTest {
     }
 
     private VitessPartition initializePartition() {
-        return new VitessPartition("test");
+        return new VitessPartition("test", null);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.vitess;
 
+import static io.debezium.connector.vitess.TestHelper.TEST_SERVER;
+import static io.debezium.connector.vitess.TestHelper.TEST_UNSHARDED_KEYSPACE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -13,14 +15,32 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.source.SourceConnectorContext;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
+import org.apache.kafka.connect.storage.OffsetBackingStore;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.apache.kafka.connect.storage.OffsetStorageReaderImpl;
+import org.apache.kafka.connect.storage.OffsetStorageWriter;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.common.OffsetReader;
+import io.debezium.connector.vitess.connection.VitessReplicationConnection;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.util.Collect;
+import io.debezium.util.Testing;
 
 public class VitessConnectorTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(VitessConnectorTest.class);
@@ -159,5 +179,130 @@ public class VitessConnectorTest {
         ConfigValue configValue = results.get(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name());
         assertThat(configValue != null);
         assertThat(configValue.errorMessages().size() == 1);
+    }
+
+    @Test
+    public void testEmptyOffsetStorage() {
+        final int numTasks = 2;
+        final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s2"), Arrays.asList("current", "current"));
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s1", "s3"), Arrays.asList("current", "current"));
+
+        final Map<String, String> expectedVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks), vgtid0.toString(),
+                VitessConnector.getTaskKeyName(1, numTasks), vgtid1.toString());
+        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, null);
+        Testing.print(String.format("vgtids: %s", vgtids));
+        assertEquals(vgtids.size(), 2);
+        assertEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+    }
+
+    @Test
+    public void testPreviousOffsetStorage() {
+        final int numTasks = 2;
+        final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s2"), Arrays.asList("gt0", "gt2"));
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
+
+        final Map<String, Object> expectedVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks), vgtid0.toString(),
+                VitessConnector.getTaskKeyName(1, numTasks), vgtid1.toString());
+        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, expectedVgtids);
+        Testing.print(String.format("vgtids: %s", vgtids));
+        assertEquals(vgtids.size(), 2);
+        assertEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+    }
+
+    private Map<String, String> getOffsetFromStorage(int numTasks, List<String> shards, Map<String, Object> prevVgtids) {
+        final Configuration config = TestHelper.defaultConfig(false, true, numTasks).build();
+        final OffsetBackingStore offsetStore = new MemoryOffsetBackingStore();
+        offsetStore.start();
+        final String engineName = "testOffset";
+        final Converter keyConverter = new JsonConverter();
+        Map<String, Object> converterConfig = Collect.hashMapOf("schemas.enable", false);
+        keyConverter.configure(converterConfig, true);
+        final Converter valueConverter = new JsonConverter();
+        valueConverter.configure(converterConfig, false);
+        if (prevVgtids != null) {
+            Testing.print(String.format("Previous vgtids: %s", prevVgtids));
+            OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetStore, engineName,
+                    keyConverter, valueConverter);
+            for (String key : prevVgtids.keySet()) {
+                Map<String, Object> sourcePartition = Collect.hashMapOf(
+                        VitessPartition.SERVER_PARTITION_KEY, TEST_SERVER,
+                        VitessPartition.TASK_KEY_PARTITION_KEY, key);
+                Map<String, Object> offset = new HashMap<>();
+                offset.put(SourceInfo.VGTID_KEY, prevVgtids.get(key));
+                offsetWriter.offset(sourcePartition, offset);
+                offsetWriter.beginFlush();
+                Future f = offsetWriter.doFlush(null);
+                try {
+                    f.get(100, TimeUnit.MILLISECONDS);
+                }
+                catch (Exception ex) {
+                    fail(ex.getMessage());
+                }
+            }
+        }
+        final OffsetStorageReader offsetReader = new OffsetStorageReaderImpl(offsetStore, engineName,
+                keyConverter, valueConverter);
+
+        VitessConnector connector = new VitessConnector();
+        SourceConnectorContext connectorContext = new SourceConnectorContext() {
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return offsetReader;
+            }
+
+            @Override
+            public void requestTaskReconfiguration() {
+            }
+
+            @Override
+            public void raiseError(Exception e) {
+                LOGGER.error("Unexpected exception", e);
+                fail(e.getMessage());
+            }
+        };
+        connector.initialize(connectorContext);
+        connector.start(config.asMap());
+
+        SourceTaskContext sourceTaskContext = new SourceTaskContext() {
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return offsetReader;
+            }
+
+            public Map<String, String> configs() {
+                return config.asMap();
+            }
+        };
+
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(numTasks, shards);
+        Map<String, String> vgtids = new HashMap<>();
+        for (Map<String, String> taskConfig : taskConfigs) {
+            VitessConnectorTask task = new VitessConnectorTask();
+            task.initialize(sourceTaskContext);
+
+            final VitessConnectorConfig connectorConfig = new VitessConnectorConfig(Configuration.from(taskConfig));
+            Set<VitessPartition> partitions = new VitessPartition.Provider(connectorConfig).getPartitions();
+            OffsetReader<VitessPartition, VitessOffsetContext, OffsetContext.Loader<VitessOffsetContext>> reader = new OffsetReader<>(
+                    sourceTaskContext.offsetStorageReader(), new VitessOffsetContext.Loader(
+                            connectorConfig));
+            Map<VitessPartition, VitessOffsetContext> offsets = reader.offsets(partitions);
+            Offsets<VitessPartition, VitessOffsetContext> previousOffsets = Offsets.of(offsets);
+
+            final VitessOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
+            Vgtid vgtid = previousOffset == null ? VitessReplicationConnection.defaultVgtid(connectorConfig)
+                    : previousOffset.getRestartVgtid();
+            vgtids.put(taskConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), vgtid.toString());
+        }
+        connector.stop();
+        offsetStore.stop();
+        return vgtids;
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.vitess;
 import static io.debezium.connector.vitess.TestHelper.TEST_SERVER;
 import static io.debezium.connector.vitess.TestHelper.TEST_UNSHARDED_KEYSPACE;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -59,7 +60,7 @@ public class VitessConnectorTest {
     @Test
     public void testTaskConfigsSingle() {
         VitessConnector connector = new VitessConnector();
-        Map<String, String> props = new HashMap<String, String>() {
+        Map<String, String> props = new HashMap<>() {
             {
                 put("key", "value");
             }
@@ -73,7 +74,7 @@ public class VitessConnectorTest {
     @Test
     public void testTaskConfigsNegativeOffsetStorageModeUnset() {
         VitessConnector connector = new VitessConnector();
-        Map<String, String> props = new HashMap<String, String>() {
+        Map<String, String> props = new HashMap<>() {
             {
                 put("key", "value");
             }
@@ -85,14 +86,14 @@ public class VitessConnectorTest {
         }
         catch (IllegalArgumentException ex) {
             // This is expected();
-            LOGGER.info("Expected exception: {}", ex);
+            LOGGER.info("Expected exception: ", ex);
         }
     }
 
     @Test
     public void testTaskConfigsNegativeOffsetStorageModeFalse() {
         VitessConnector connector = new VitessConnector();
-        Map<String, String> props = new HashMap<String, String>() {
+        Map<String, String> props = new HashMap<>() {
             {
                 put("key", "value");
                 put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "false");
@@ -105,17 +106,20 @@ public class VitessConnectorTest {
         }
         catch (IllegalArgumentException ex) {
             // This is expected();
-            LOGGER.info("Expected exception: {}", ex);
+            LOGGER.info("Expected exception: ", ex);
         }
     }
 
     @Test
     public void testTaskConfigsOffsetStorageModeSingle() {
         VitessConnector connector = new VitessConnector();
-        Map<String, String> props = new HashMap<String, String>() {
+        Map<String, String> props = new HashMap<>() {
             {
                 put("key", "value");
+                put(VitessConnectorConfig.KEYSPACE.name(), TEST_UNSHARDED_KEYSPACE);
                 put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+                put(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name(), "0");
+                put(VitessConnectorConfig.PREV_NUM_TASKS.name(), "1");
             }
         };
         connector.start(props);
@@ -124,19 +128,27 @@ public class VitessConnectorTest {
         assertThat(taskConfigs.size() == 1);
         Map<String, String> firstConfig = taskConfigs.get(0);
         assertThat(firstConfig.size() == 4);
-        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task0_1");
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG),
+                VitessConnector.getTaskKeyName(0, 1, 0));
         assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG),
                 String.join(",", shards));
-        assertEquals(firstConfig.get("key"), "value");
+        List<String> gtidStrs = Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID,
+                Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID);
+        Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        assertEquals(vgtid.toString(), firstConfig.get(VitessConnectorConfig.VITESS_KEY_KEY_VGTID_CONFIG));
+        assertEquals("value", firstConfig.get("key"));
     }
 
     @Test
     public void testTaskConfigsOffsetStorageModeDouble() {
         VitessConnector connector = new VitessConnector();
-        Map<String, String> props = new HashMap<String, String>() {
+        Map<String, String> props = new HashMap<>() {
             {
                 put("key", "value");
+                put(VitessConnectorConfig.KEYSPACE.name(), TEST_UNSHARDED_KEYSPACE);
                 put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+                put(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name(), "0");
+                put(VitessConnectorConfig.PREV_NUM_TASKS.name(), "1");
             }
         };
         connector.start(props);
@@ -145,21 +157,27 @@ public class VitessConnectorTest {
         assertThat(taskConfigs.size() == 2);
         Map<String, String> firstConfig = taskConfigs.get(0);
         assertThat(firstConfig.size() == 4);
-        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task0_2");
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task0_2_0");
         assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG), "-4000,8000-c000");
+        List<String> gtidStrs = Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID);
+        List<String> shards0 = Arrays.asList("-4000", "8000-c000");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs);
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_KEY_KEY_VGTID_CONFIG), vgtid0.toString());
         assertEquals(firstConfig.get("key"), "value");
         Map<String, String> secondConfig = taskConfigs.get(1);
         assertThat(secondConfig.size() == 4);
-        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task1_2");
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task1_2_0");
         assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG), "4000-8000,c000-");
+        List<String> shards1 = Arrays.asList("4000-8000", "c000-");
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs);
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_KEY_KEY_VGTID_CONFIG), vgtid1.toString());
         assertEquals(secondConfig.get("key"), "value");
     }
 
     @Test
     public void testMultiTaskOnlyAllowedWithOffsetStoragePerTask() {
-        Map<String, String> props = new HashMap<String, String>() {
+        Map<String, String> props = new HashMap<>() {
             {
-                put("key", "value");
                 put("connector.class", "io.debezium.connector.vitess.VitessConnector");
                 put("database.hostname", "host1");
                 put("database.port", "15999");
@@ -168,39 +186,256 @@ public class VitessConnectorTest {
                 put("vitess.keyspace", "byuser");
                 put("vitess.tablet.type", "MASTER");
                 put("database.server.name", "dummy");
-                put("message.key.columns", "c1");
                 put(VitessConnectorConfig.TASKS_MAX_CONFIG, "2");
+                put(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name(), "0");
+                put(VitessConnectorConfig.PREV_NUM_TASKS.name(), "1");
             }
         };
         VitessConnector connector = new VitessConnector();
+        connector.start(props);
         Configuration config = Configuration.from(props);
         Map<String, ConfigValue> results = connector.validateAllFields(config);
         LOGGER.info("results: {}", results);
         ConfigValue configValue = results.get(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name());
-        assertThat(configValue != null);
-        assertThat(configValue.errorMessages().size() == 1);
+        assertThat(configValue != null && configValue.errorMessages() != null && configValue.errorMessages().size() == 1);
+    }
+
+    @Test
+    public void testTaskConfigsNegativeOffsetStorageTaskKeyGen() {
+        Map<String, String> props = new HashMap<>() {
+            {
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+            }
+        };
+        VitessConnector connector = new VitessConnector();
+        connector.start(props);
+        Configuration config = Configuration.from(props);
+        Map<String, ConfigValue> results = connector.validateAllFields(config);
+        LOGGER.info("results: {}", results);
+        ConfigValue configValue = results.get(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name());
+        assertThat(configValue != null && configValue.errorMessages() != null && configValue.errorMessages().size() == 1);
+    }
+
+    @Test
+    public void testTaskConfigsNegativePrevNumTasks() {
+        Map<String, String> props = new HashMap<>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+                put(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name(), "0");
+            }
+        };
+        VitessConnector connector = new VitessConnector();
+        connector.start(props);
+        Configuration config = Configuration.from(props);
+        Map<String, ConfigValue> results = connector.validateAllFields(config);
+        LOGGER.info("results: {}", results);
+        ConfigValue configValue = results.get(VitessConnectorConfig.PREV_NUM_TASKS.name());
+        assertThat(configValue != null && configValue.errorMessages() != null && configValue.errorMessages().size() == 1);
+    }
+
+    @Test
+    public void testTaskConfigsSameNumTasks() {
+        VitessConnector connector = new VitessConnector();
+        Map<String, String> props = new HashMap<>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.KEYSPACE.name(), TEST_UNSHARDED_KEYSPACE);
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+                put(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name(), "2");
+                put(VitessConnectorConfig.PREV_NUM_TASKS.name(), "2");
+            }
+        };
+        connector.start(props);
+        try {
+            List<String> shards = Arrays.asList("s1", "s2");
+            List<Map<String, String>> taskProps = connector.taskConfigs(2, shards);
+            fail("Should not reach here because prev.num.tasks and num.tasks are the same, taskProps:"
+                    + taskProps);
+        }
+        catch (IllegalArgumentException ex) {
+            // This is expected();
+            LOGGER.info("Expected exception: ", ex);
+        }
+    }
+
+    @Test
+    public void testTaskConfigsOffsetMigrationSingle() {
+        List<String> shards = Arrays.asList("s0", "s1");
+        List<String> gtidStrs = Arrays.asList("gtid0", "gtid1");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        final int gen = 1;
+        final int numTasks = 1;
+        try {
+            Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, numTasks, vgtid0.toString(), null);
+            fail("Should not reach here because prev.num.tasks and num.tasks are the same, vgtids:"
+                    + vgtids);
+        }
+        catch (IllegalArgumentException ex) {
+            // This is expected();
+            LOGGER.info("Expected exception: ", ex);
+
+        }
+    }
+
+    @Test
+    public void testTaskConfigsOffsetMigrationDouble() {
+        List<String> shards = Arrays.asList("s0", "s1");
+        List<String> gtidStrs = Arrays.asList("gtid0", "gtid1");
+        Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "gtid1");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        final int gen = 1;
+        final int numTasks = 2;
+        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, 1, vgtid0.toString(), null);
+        assertThat(vgtids.size() == numTasks);
+        Map<String, String> gtidPerShard = new HashMap<>();
+        for (int tid = 0; tid < numTasks; tid++) {
+            String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
+            String gtidStr = vgtids.get(key);
+            assertThat(gtidStr != null);
+            Vgtid vgtid = Vgtid.of(gtidStr);
+            assertThat(vgtid.getShardGtids().size() == 1);
+            for (int i = 0; i < vgtid.getShardGtids().size(); i++) {
+                Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
+                gtidPerShard.put(shardGtid.getShard(), shardGtid.getGtid());
+            }
+        }
+        assertEquals(expectedGtidPerShard, gtidPerShard);
+    }
+
+    @Test
+    public void testTaskConfigsOffsetRestartDouble() {
+        List<String> shards = Arrays.asList("s0", "s1");
+        // Note we are not able to fetch old0/old1 since prevGtids takes precedence over serverVgtid
+        List<String> gtidStrs = Arrays.asList("old0", "old1");
+        Vgtid serverVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        final int gen = 1;
+        final int numTasks = 2;
+        final int prevNumTasks = 1;
+        List<String> shards0 = List.of("s0");
+        List<String> shards1 = List.of("s1");
+        List<String> gtidStrs0 = List.of("gtid0");
+        List<String> gtidStrs1 = List.of("gtid1");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs0);
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs1);
+        final Map<String, Object> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen), vgtid0.toString(),
+                VitessConnector.getTaskKeyName(1, numTasks, gen), vgtid1.toString());
+        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, serverVgtid.toString(), prevVgtids);
+        assertThat(vgtids.size() == numTasks);
+        Map<String, String> gtidPerShard = new HashMap<>();
+        for (int tid = 0; tid < numTasks; tid++) {
+            String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
+            String gtidStr = vgtids.get(key);
+            assertThat(gtidStr != null);
+            Vgtid vgtid = Vgtid.of(gtidStr);
+            assertThat(vgtid.getShardGtids().size() == 1);
+            for (int i = 0; i < vgtid.getShardGtids().size(); i++) {
+                Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
+                gtidPerShard.put(shardGtid.getShard(), shardGtid.getGtid());
+            }
+        }
+        Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "gtid1");
+        assertEquals(expectedGtidPerShard, gtidPerShard);
+    }
+
+    @Test
+    public void testTaskConfigsOffsetRestartDoubleIncomplete() {
+        List<String> shards = Arrays.asList("s0", "s1");
+        List<String> gtidStrs = Arrays.asList("old0", "old1");
+        Vgtid serverVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        final int gen = 1;
+        final int numTasks = 2;
+        final int prevNumTasks = 1;
+        List<String> shards0 = List.of("s0");
+        List<String> gtidStrs0 = List.of("gtid0");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs0);
+        // Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs1);
+        // Note that we omit the vgtid1 in prevVgtids so it will fallback to the serverVgtid
+        final Map<String, Object> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen), vgtid0.toString());
+        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, serverVgtid.toString(), prevVgtids);
+        assertThat(vgtids.size() == numTasks);
+        Map<String, String> gtidPerShard = new HashMap<>();
+        for (int tid = 0; tid < numTasks; tid++) {
+            String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
+            String gtidStr = vgtids.get(key);
+            assertThat(gtidStr != null);
+            Vgtid vgtid = Vgtid.of(gtidStr);
+            assertThat(vgtid.getShardGtids().size() == 1);
+            for (int i = 0; i < vgtid.getShardGtids().size(); i++) {
+                Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
+                gtidPerShard.put(shardGtid.getShard(), shardGtid.getGtid());
+            }
+        }
+        // Note we got gtid0 from prevGtids, but got old1 from serverGtid
+        Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "old1");
+        assertEquals(expectedGtidPerShard, gtidPerShard);
+    }
+
+    @Test
+    public void testTaskConfigsOffsetMigrationQuad() {
+        List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
+        Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "gtid1",
+                "s2", "gtid2", "s3", "gtid3");
+        List<String> shards0 = Arrays.asList("s0", "s2");
+        List<String> shards1 = Arrays.asList("s1", "s3");
+        List<String> gtidStrs0 = Arrays.asList("gtid0", "gtid2");
+        List<String> gtidStrs1 = Arrays.asList("gtid1", "gtid3");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs0);
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs1);
+        final int gen = 2;
+        final int numTasks = 4;
+        final int prevNumTasks = 2;
+        final Map<String, Object> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen - 1), vgtid0.toString(),
+                VitessConnector.getTaskKeyName(1, prevNumTasks, gen - 1), vgtid1.toString());
+
+        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, null, prevVgtids);
+        assertThat(vgtids.size() == numTasks);
+        Map<String, String> gtidPerShard = new HashMap<>();
+        for (int tid = 0; tid < numTasks; tid++) {
+            String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
+            String gtidStr = vgtids.get(key);
+            assertThat(gtidStr != null);
+            Vgtid vgtid = Vgtid.of(gtidStr);
+            assertThat(vgtid.getShardGtids().size() == 1);
+            for (int i = 0; i < vgtid.getShardGtids().size(); i++) {
+                Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
+                gtidPerShard.put(shardGtid.getShard(), shardGtid.getGtid());
+            }
+        }
+        assertEquals(expectedGtidPerShard, gtidPerShard);
     }
 
     @Test
     public void testEmptyOffsetStorage() {
         final int numTasks = 2;
+        final int gen = 0;
         final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
         Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
-                Arrays.asList("s0", "s2"), Arrays.asList("current", "current"));
+                Arrays.asList("s0", "s2"), Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID));
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
-                Arrays.asList("s1", "s3"), Arrays.asList("current", "current"));
+                Arrays.asList("s1", "s3"), Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID));
 
         final Map<String, String> expectedVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, numTasks), vgtid1.toString());
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, null);
+                VitessConnector.getTaskKeyName(0, numTasks, gen), vgtid0.toString(),
+                VitessConnector.getTaskKeyName(1, numTasks, gen), vgtid1.toString());
+        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, -1, null, null);
         Testing.print(String.format("vgtids: %s", vgtids));
         assertEquals(vgtids.size(), 2);
-        assertEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+        assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
     }
 
     @Test
     public void testPreviousOffsetStorage() {
+        final int gen = 0;
+        final int prevNumTasks = 1;
+        Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
+        final Map<String, Object> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), vgtid.toString());
+
         final int numTasks = 2;
         final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
         Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
@@ -209,46 +444,64 @@ public class VitessConnectorTest {
                 Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
 
         final Map<String, Object> expectedVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, numTasks), vgtid1.toString());
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, expectedVgtids);
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), vgtid0.toString(),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), vgtid1.toString());
+        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
         Testing.print(String.format("vgtids: %s", vgtids));
         assertEquals(vgtids.size(), 2);
-        assertEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+        assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
     }
 
-    private Map<String, String> getOffsetFromStorage(int numTasks, List<String> shards, Map<String, Object> prevVgtids) {
-        final Configuration config = TestHelper.defaultConfig(false, true, numTasks).build();
-        final OffsetBackingStore offsetStore = new MemoryOffsetBackingStore();
-        offsetStore.start();
+    private void storeOffsets(OffsetBackingStore offsetStore, String serverVgtid, Map<String, Object> prevVgtids) {
+        if (serverVgtid == null && (prevVgtids == null || prevVgtids.isEmpty())) {
+            Testing.print("Empty gtids to store to offset.");
+            return;
+        }
         final String engineName = "testOffset";
         final Converter keyConverter = new JsonConverter();
         Map<String, Object> converterConfig = Collect.hashMapOf("schemas.enable", false);
         keyConverter.configure(converterConfig, true);
         final Converter valueConverter = new JsonConverter();
         valueConverter.configure(converterConfig, false);
+        OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetStore, engineName,
+                keyConverter, valueConverter);
+        if (serverVgtid != null) {
+            Testing.print(String.format("Server vgtids: %s", serverVgtid));
+            Map<String, Object> sourcePartition = Collect.hashMapOf(
+                    VitessPartition.SERVER_PARTITION_KEY, TEST_SERVER);
+            Map<String, Object> offset = Collect.hashMapOf(SourceInfo.VGTID_KEY, serverVgtid);
+            offsetWriter.offset(sourcePartition, offset);
+        }
         if (prevVgtids != null) {
             Testing.print(String.format("Previous vgtids: %s", prevVgtids));
-            OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetStore, engineName,
-                    keyConverter, valueConverter);
             for (String key : prevVgtids.keySet()) {
                 Map<String, Object> sourcePartition = Collect.hashMapOf(
                         VitessPartition.SERVER_PARTITION_KEY, TEST_SERVER,
                         VitessPartition.TASK_KEY_PARTITION_KEY, key);
-                Map<String, Object> offset = new HashMap<>();
-                offset.put(SourceInfo.VGTID_KEY, prevVgtids.get(key));
+                Map<String, Object> offset = Collect.hashMapOf(SourceInfo.VGTID_KEY, prevVgtids.get(key));
                 offsetWriter.offset(sourcePartition, offset);
-                offsetWriter.beginFlush();
-                Future f = offsetWriter.doFlush(null);
-                try {
-                    f.get(100, TimeUnit.MILLISECONDS);
-                }
-                catch (Exception ex) {
-                    fail(ex.getMessage());
-                }
             }
         }
-        final OffsetStorageReader offsetReader = new OffsetStorageReaderImpl(offsetStore, engineName,
+        offsetWriter.beginFlush();
+        Future<Void> f = offsetWriter.doFlush(null);
+        try {
+            f.get(100, TimeUnit.MILLISECONDS);
+        }
+        catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    private Map<String, String> getTaskOffsets(OffsetBackingStore offsetStore, int numTasks, List<String> shards,
+                                               int gen, int prevNumTasks) {
+        final Configuration config = TestHelper.defaultConfig(false, true, numTasks, gen, prevNumTasks).build();
+        final String engineName = "testOffset";
+        final Converter keyConverter = new JsonConverter();
+        Map<String, Object> converterConfig = Collect.hashMapOf("schemas.enable", false);
+        keyConverter.configure(converterConfig, true);
+        final Converter valueConverter = new JsonConverter();
+        valueConverter.configure(converterConfig, false);
+        final OffsetStorageReaderImpl offsetReader = new OffsetStorageReaderImpl(offsetStore, engineName,
                 keyConverter, valueConverter);
 
         VitessConnector connector = new VitessConnector();
@@ -302,6 +555,18 @@ public class VitessConnectorTest {
             vgtids.put(taskConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), vgtid.toString());
         }
         connector.stop();
+        offsetReader.close();
+        return vgtids;
+    }
+
+    private Map<String, String> getOffsetFromStorage(int numTasks, List<String> shards, int gen, int prevNumTasks,
+                                                     String serverVgtid, Map<String, Object> prevVgtids) {
+        final OffsetBackingStore offsetStore = new MemoryOffsetBackingStore();
+        offsetStore.start();
+
+        storeOffsets(offsetStore, serverVgtid, prevVgtids);
+        Map<String, String> vgtids = getTaskOffsets(offsetStore, numTasks, shards, gen, prevNumTasks);
+
         offsetStore.stop();
         return vgtids;
     }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -192,7 +192,6 @@ public class VitessConnectorTest {
             }
         };
         VitessConnector connector = new VitessConnector();
-        connector.start(props);
         Configuration config = Configuration.from(props);
         Map<String, ConfigValue> results = connector.validateAllFields(config);
         LOGGER.info("results: {}", results);

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -6,11 +6,24 @@
 package io.debezium.connector.vitess;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
 
 public class VitessConnectorTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VitessConnectorTest.class);
 
     @Test
     public void shouldReturnConfigurationDefinition() {
@@ -21,5 +34,130 @@ public class VitessConnectorTest {
     @Test
     public void shouldReturnVersion() {
         assertThat(new VitessConnector().version()).isNotNull();
+    }
+
+    @Test
+    public void testTaskConfigsSingle() {
+        VitessConnector connector = new VitessConnector();
+        Map<String, String> props = new HashMap<String, String>() {
+            {
+                put("key", "value");
+            }
+        };
+        connector.start(props);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(1, null);
+        assertThat(taskConfigs.size() == 1);
+        assertEquals(taskConfigs.get(0), props);
+    }
+
+    @Test
+    public void testTaskConfigsNegativeOffsetStorageModeUnset() {
+        VitessConnector connector = new VitessConnector();
+        Map<String, String> props = new HashMap<String, String>() {
+            {
+                put("key", "value");
+            }
+        };
+        connector.start(props);
+        try {
+            connector.taskConfigs(2, null);
+            fail("Should not reach here because we don't support multi-tasks when offset.storage.per.task is not set");
+        }
+        catch (IllegalArgumentException ex) {
+            // This is expected();
+            LOGGER.info("Expected exception: {}", ex);
+        }
+    }
+
+    @Test
+    public void testTaskConfigsNegativeOffsetStorageModeFalse() {
+        VitessConnector connector = new VitessConnector();
+        Map<String, String> props = new HashMap<String, String>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "false");
+            }
+        };
+        connector.start(props);
+        try {
+            connector.taskConfigs(2, null);
+            fail("Should not reach here because we don't support multi-tasks when offset.storage.per.task is false");
+        }
+        catch (IllegalArgumentException ex) {
+            // This is expected();
+            LOGGER.info("Expected exception: {}", ex);
+        }
+    }
+
+    @Test
+    public void testTaskConfigsOffsetStorageModeSingle() {
+        VitessConnector connector = new VitessConnector();
+        Map<String, String> props = new HashMap<String, String>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+            }
+        };
+        connector.start(props);
+        List<String> shards = Arrays.asList("-4000", "4000-8000", "8000-c000", "c000-");
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(1, shards);
+        assertThat(taskConfigs.size() == 1);
+        Map<String, String> firstConfig = taskConfigs.get(0);
+        assertThat(firstConfig.size() == 4);
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task0_1");
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG),
+                String.join(",", shards));
+        assertEquals(firstConfig.get("key"), "value");
+    }
+
+    @Test
+    public void testTaskConfigsOffsetStorageModeDouble() {
+        VitessConnector connector = new VitessConnector();
+        Map<String, String> props = new HashMap<String, String>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+            }
+        };
+        connector.start(props);
+        List<String> shards = Arrays.asList("-4000", "4000-8000", "8000-c000", "c000-");
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(2, shards);
+        assertThat(taskConfigs.size() == 2);
+        Map<String, String> firstConfig = taskConfigs.get(0);
+        assertThat(firstConfig.size() == 4);
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task0_2");
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG), "-4000,8000-c000");
+        assertEquals(firstConfig.get("key"), "value");
+        Map<String, String> secondConfig = taskConfigs.get(1);
+        assertThat(secondConfig.size() == 4);
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task1_2");
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG), "4000-8000,c000-");
+        assertEquals(secondConfig.get("key"), "value");
+    }
+
+    @Test
+    public void testMultiTaskOnlyAllowedWithOffsetStoragePerTask() {
+        Map<String, String> props = new HashMap<String, String>() {
+            {
+                put("key", "value");
+                put("connector.class", "io.debezium.connector.vitess.VitessConnector");
+                put("database.hostname", "host1");
+                put("database.port", "15999");
+                put("database.user", "vitess");
+                put("database.password", "vitess-password");
+                put("vitess.keyspace", "byuser");
+                put("vitess.tablet.type", "MASTER");
+                put("database.server.name", "dummy");
+                put("message.key.columns", "c1");
+                put(VitessConnectorConfig.TASKS_MAX_CONFIG, "2");
+            }
+        };
+        VitessConnector connector = new VitessConnector();
+        Configuration config = Configuration.from(props);
+        Map<String, ConfigValue> results = connector.validateAllFields(config);
+        LOGGER.info("results: {}", results);
+        ConfigValue configValue = results.get(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name());
+        assertThat(configValue != null);
+        assertThat(configValue.errorMessages().size() == 1);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -130,12 +130,12 @@ public class VitessConnectorTest {
         assertThat(firstConfig.size() == 4);
         assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG),
                 VitessConnector.getTaskKeyName(0, 1, 0));
-        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG),
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_SHARDS_CONFIG),
                 String.join(",", shards));
         List<String> gtidStrs = Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID,
                 Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID);
         Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
-        assertEquals(vgtid.toString(), firstConfig.get(VitessConnectorConfig.VITESS_KEY_KEY_VGTID_CONFIG));
+        assertEquals(vgtid.toString(), firstConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG));
         assertEquals("value", firstConfig.get("key"));
     }
 
@@ -158,19 +158,19 @@ public class VitessConnectorTest {
         Map<String, String> firstConfig = taskConfigs.get(0);
         assertThat(firstConfig.size() == 4);
         assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task0_2_0");
-        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG), "-4000,8000-c000");
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_SHARDS_CONFIG), "-4000,8000-c000");
         List<String> gtidStrs = Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID);
         List<String> shards0 = Arrays.asList("-4000", "8000-c000");
         Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs);
-        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_KEY_KEY_VGTID_CONFIG), vgtid0.toString());
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG), vgtid0.toString());
         assertEquals(firstConfig.get("key"), "value");
         Map<String, String> secondConfig = taskConfigs.get(1);
         assertThat(secondConfig.size() == 4);
         assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task1_2_0");
-        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_SHARDS_CONFIG), "4000-8000,c000-");
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_SHARDS_CONFIG), "4000-8000,c000-");
         List<String> shards1 = Arrays.asList("4000-8000", "c000-");
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs);
-        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_KEY_KEY_VGTID_CONFIG), vgtid1.toString());
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG), vgtid1.toString());
         assertEquals(secondConfig.get("key"), "value");
     }
 

--- a/src/test/java/io/debezium/connector/vitess/VitessPartitionTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessPartitionTest.java
@@ -5,17 +5,45 @@
  */
 package io.debezium.connector.vitess;
 
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+
 import io.debezium.connector.common.AbstractPartitionTest;
+import io.debezium.util.Collect;
 
 public class VitessPartitionTest extends AbstractPartitionTest<VitessPartition> {
 
     @Override
     protected VitessPartition createPartition1() {
-        return new VitessPartition("server1");
+        return new VitessPartition("server1", null);
     }
 
     @Override
     protected VitessPartition createPartition2() {
-        return new VitessPartition("server2");
+        return new VitessPartition("server2", null);
+    }
+
+    @Test
+    public void testTaskKeyInPartition() {
+        VitessPartition par1 = new VitessPartition("server1", "task1");
+        VitessPartition par2 = new VitessPartition("server1", "task2");
+        VitessPartition par3 = new VitessPartition("server1", null);
+        assertThat(par1).isNotEqualTo(par2);
+        assertThat(par1).isNotEqualTo(par3);
+        assertThat(par2).isNotEqualTo(par3);
+        assertThat(par1.hashCode()).isNotEqualTo(par2.hashCode());
+        assertThat(par1.hashCode()).isNotEqualTo(par3.hashCode());
+        assertThat(par2.hashCode()).isNotEqualTo(par3.hashCode());
+        Map<String, String> parNoTaskKey = Collect.hashMapOf(VitessPartition.SERVER_PARTITION_KEY, "server1");
+        Map<String, String> parTask1 = Collect.hashMapOf(VitessPartition.SERVER_PARTITION_KEY, "server1",
+                VitessPartition.TASK_KEY_PARTITION_KEY, "task1");
+        Map<String, String> parTask2 = Collect.hashMapOf(VitessPartition.SERVER_PARTITION_KEY, "server1",
+                VitessPartition.TASK_KEY_PARTITION_KEY, "task2");
+        assertThat(par1.getSourcePartition()).isEqualTo(parTask1);
+        assertThat(par2.getSourcePartition()).isEqualTo(parTask2);
+        assertThat(par3.getSourcePartition()).isEqualTo(parNoTaskKey);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -61,7 +61,7 @@ public class VitessReplicationConnectionIT {
                                     Binlogdata.ShardGtid.newBuilder()
                                             .setKeyspace(conf.getKeyspace())
                                             .setShard(conf.getShard())
-                                            .setGtid("current")
+                                            .setGtid(Vgtid.CURRENT_GTID)
                                             .build())
                             .build());
 
@@ -126,7 +126,7 @@ public class VitessReplicationConnectionIT {
                                     Binlogdata.ShardGtid.newBuilder()
                                             .setKeyspace(conf.getKeyspace())
                                             .setShard(conf.getShard())
-                                            .setGtid("current")
+                                            .setGtid(Vgtid.CURRENT_GTID)
                                             .build())
                             .build());
 


### PR DESCRIPTION
The current Vitess Connector can be launched in two modes:

1. Don't specify Vitess shard info, this will make the connector task to subscribe to ViTess VStream for all shards in the given KeySpace;
2. Specify a particular Vitess shard info, this will make the connector task to subscribe to VStream just for this shard;

In both modes, the connector will only launch one source task (VitessConnectorTask) to do the actual VStream processing.

For a bigger Vitess installation which has many shards, one vitess-dbzium connector with only one source task (mode 1) is not going to be able to sustains the event stream from Vitess.  For mode 2, the operation person needs to manually figure out all the shards in the vitess and manually launch many vitess-dbzium connectors (one connector for one Vitess shard).  This is very error prone and might end up with 1000 connectors to launch and manage.

In Kafka-Connect's deployment model, the recommendation is to launch one connector and have the connector do the service discovery of Vitess shards and launch appropriate number of source tasks to manage the traffic load from Vitess side.

Enable the multi-tasking support by specifying the connect config param tasks.max > 1 and :

1. Add a new config vitess.offset.storage.per.task to incidate that we
   want to partition the offset.storage (stored in kafka topic
   connect-offsets) and the partition key is the task id;  When this new
   config param is turned on, the offset storage is going to be changed
   from keyed by database.server name to task ids:

   Old offset storage:
```
        Key ["vitess-connector",{"server":"dbServer"}],
        Value: {"transaction_id":null,"vgtid":"[
            {\"keyspace\":\"byuser\",\"shard\":\"-4000\",\"gtid\":\"MySQL56/027c67a2-c0b0-11ec-8a34-0ed0087913a5:1-11418261\"},
            {\"keyspace\":\"byuser\",\"shard\":\"4000-8000\",\"gtid\":\"MySQL56/1221c6f4-c0b0-11ec-990f-0e78f7c0adfb:1-7301701\"},
            {\"keyspace\":\"byuser\",\"shard\":\"8000-c000\",\"gtid\":\"MySQL56/00b87c67-369a-11ec-8de9-12b6db74a3c3:1-28\"},
            {\"keyspace\":\"byuser\",\"shard\":\"c000-\",\"gtid\":\"MySQL56/037f120a-369a-11ec-b886-06529ac1b6b1:1-199888\"}]"}
```
   New offset storage partioned into two partitions (assuming the user specified tasks.max = 2):
```
        Key ["vitess-connector",{"server":"task0_2"}],
        Value: {"transaction_id":null,"vgtid":"[
            {\"keyspace\":\"byuser\",\"shard\":\"-4000\",\"gtid\":\"MySQL56/027c67a2-c0b0-11ec-8a34-0ed0087913a5:1-11418261\"},
            {\"keyspace\":\"byuser\",\"shard\":\"8000-c000\",\"gtid\":\"MySQL56/00b87c67-369a-11ec-8de9-12b6db74a3c3:1-28\"}]"}
        Key ["vitess-connector",{"server":"task1_2"}],
        Value: {"transaction_id":null,"vgtid":"[
            {\"keyspace\":\"byuser\",\"shard\":\"4000-8000\",\"gtid\":\"MySQL56/1221c6f4-c0b0-11ec-990f-0e78f7c0adfb:1-7301701\"},
            {\"keyspace\":\"byuser\",\"shard\":\"c000-\",\"gtid\":\"MySQL56/037f120a-369a-11ec-b886-06529ac1b6b1:1-199888\"}]"}
```
   The partition key is essentially the taskId appended by total number of tasks

2. A new method VitessConnector#getVitessShards is added to retrieve the
   current set of vitess shards for the configured keyspace.  This is
   achieved by parsing the query result from query: "SHOW VITESS_SHARDS"

3. VitessConnector#taskConfigs(int maxTasks) method is modified to break the space into multiple partitions and assign each partition to each task by returning a List of config maps (one map for each connector source task)
   e.g. for maxTasks=2 and current vitess shards = ["-4000","4000-8000","8000-c000","c000-"], the connector will break the space into two partitions and return a List with 2 elements for the Kafka Connect framework to launch two source tasks:
```
   [
      {
         "vitess.task.key": "task0_2",   // format: taskId_numOfTasks
         "vitess.task.shards": "-4000,8000-c000",   // format: comma separated vitess shard names
         ... other connector configs ...
      },
      {
         "vitess.task.key": "task1_2",
         "vitess.task.shards": "4000-8000,c000-",
         ... other connector configs ...
      }
   ]
```

4. When the source task (VitessConnectorTask) starts, it will find the "vitess.task.key" value (e.g. task0_2) assigned to the task, and will use this value (task0_2) to find the previous offsets stored in OffsetStorage.  If no previous offsets were found, VitessReplicationConnection#defaultVGtid() method will be invoked which will generate the default vgtid ("current") for the shards assigned to the task (the list of shards are passed in through "vitess.task.shard" param, in this case the value is "-4000,8000-c000").  VStream will be subscribed using this VGtid, When the VStream flows with the new Vgtids, the new VGtids will be persisted in the current task partition space (in this case: "task0_2").  When the tasks (or the whole connector runtime) restarts, "task0_2" might be assigned to a differen source task object, but this is fine since each source task will be assigned with a unique 'vitess.task.key" and each one will respectively retrieve the old VGtids stored in OffsetStorage for that partition key and continues.

5. The vitess shards to task assignment is a simple round-robin distribution (shard 0,2,4,... will be given to task 0, shards 1,3,5,... will go to task 1), in the future more advanced assignment algorithm can be introduced.  In the case when the number of vitess shards is less than the number of tasks, tasks.max will be reduced to the number of shards.  The connector is not expected to return the list with the exact tasks.max elements;

6. Some validations are added to make sure we only support multi-task mode (tasks.max > 1) when vitess.offset.storage.per.task=true

Note this PR does not address the automatic offset migration when the tasks.max is changing nor the initial migration when vitess.offset.storage.per.task is first set to true.  In both situations, the vitess connector will report no previous offsets were found in offset storage and will default VGtid to "current" for those shards.  Handling offset auto migration is not trivial since Kafka Connect framework only exposes reader API. Changing task scale factor is not going to be a frequent operation, and we recommend using an external script to directly update the Kafka offset topic (e.g. using kafkacat command as in the below example):
```
    a. sudo apt install kafkacat
    b. reading the current content of kafka connect offset topic (cdc-connect-offsets) (the below command will also print out the kafka key and partition number of the message):
          kafkacat -b localhost:9092 -C -t cdc-connect-offsets -f 'Topic %t [%p] at offset %o: Key %k, Value: %s\n'
    c. updating the content of kafka connect offset topic (this example is updating the partition key from old dbServerName to taskId_numTasks: "task0_1"):
          echo "[\"vitess-connector\",{\"server\":\"task0_1\"}]={"transaction_id":null,"vgtid":"<old-vgtid-from-previous-command"}" | kafkacat -b localhost:9092 -t cdc-connect-offsets -p 22 -K=
       note the above command also specify the kafka partition number 22 (retrieved from the previous read command) to make sure the script is using the same partition number as the Kafkak Connect java code
```