### PR TITLE
DBZ-5551: Handle Vstream Connection reset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
                                     <color>yellow</color>
                                 </log>
                                 <wait>
-                                    <time>120000</time> <!-- 120 seconds max -->
+                                    <time>240000</time> <!-- 240 seconds max -->
                                     <log>vtgate is up</log>
                                 </wait>
                             </run>

--- a/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
@@ -19,6 +19,7 @@ public class VitessErrorHandler extends ErrorHandler {
         if (throwable instanceof StatusRuntimeException) {
             final StatusRuntimeException exception = (StatusRuntimeException) throwable;
             switch (exception.getStatus().getCode()) {
+                case CANCELLED:
                 case UNAVAILABLE:
                     return true;
                 case UNKNOWN:

--- a/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
@@ -5,11 +5,16 @@
  */
 package io.debezium.connector.vitess;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
 import io.grpc.StatusRuntimeException;
 
 public class VitessErrorHandler extends ErrorHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VitessErrorHandler.class);
+
     public VitessErrorHandler(VitessConnectorConfig connectorConfig, ChangeEventQueue<?> queue) {
         super(VitessConnector.class, connectorConfig, queue);
     }
@@ -18,16 +23,24 @@ public class VitessErrorHandler extends ErrorHandler {
     protected boolean isRetriable(Throwable throwable) {
         if (throwable instanceof StatusRuntimeException) {
             final StatusRuntimeException exception = (StatusRuntimeException) throwable;
+            final String description = exception.getStatus().getDescription();
+            LOGGER.info("Exception code: {} and description: {}", exception.getStatus().getCode(), description);
             switch (exception.getStatus().getCode()) {
                 case CANCELLED:
+                    // Try to match this description string:
+                    // description=target: byuser.-4000.master: vttablet: rpc error: code = Canceled desc = grpc: the client connection is closing
+                    if (description != null && description.contains("client connection is closing")) {
+                        return true;
+                    }
+                    return false;
                 case UNAVAILABLE:
                     return true;
                 case UNKNOWN:
-                    String description = exception.getStatus().getDescription();
                     // Stream timeout error due to idle VStream.
                     if (description != null && description.equals("stream timeout")) {
                         return true;
                     }
+                    return false;
             }
         }
         return false;

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -570,7 +570,6 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     @FixFor("DBZ-2836")
     public void shouldTaskFailIfColumnNameInvalid() throws Exception {
         TestHelper.executeDDL("vitess_create_tables.ddl");
-        TestHelper.execute("ALTER TABLE numeric_table ADD `@1` INT;");
 
         CountDownLatch latch = new CountDownLatch(1);
         EmbeddedEngine.CompletionCallback completionCallback = (success, message, error) -> {
@@ -586,6 +585,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         waitForStreamingRunning();
 
         // Connector receives a row whose column name is not valid, task should fail
+        TestHelper.execute("ALTER TABLE numeric_table ADD `@1` INT;");
         TestHelper.execute(INSERT_NUMERIC_TYPES_STMT);
         if (!latch.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS)) {
             fail("did not reach stop condition in time");


### PR DESCRIPTION
When there is a connection reset on Vitess side (e.g. restart VtGate, restart VtTablet, restart mysqlD), sometimes the client will grpc.StatusException: CANCELLED.  Currently we are not treating Cancelled StatusException as retriable which caused the Kafka Connect shuts down the connector eventually.

This error should be retriable.

The fix is relatively straightforward, adding Status.CANCELLED as one of the retrieable error.

The exception you can get are something like below:

2022-08-09 22:54:32,085 INFO  || [Consumer clientId=consumer-1-3, groupId=1] Discovered group coordinator slogs-c-kafka-dev-iad-b771.nebula.tinyspeck.com:9092 (id: 2147482636 rack: null)  [org.apache.kafka.clients.consumer.internals.ConsumerCoordinator]
2022-08-09 22:57:14,000 INFO  Vitess|dev|streaming VStream streaming onError. Status: Status{code=CANCELLED, description=target: byuser.-4000.master: vttablet: rpc error: code = Canceled desc = grpc: the client connection is closing, cause=null}  [io.debezium.connector.vitess.connection.VitessReplicationConnection]
io.grpc.StatusRuntimeException: CANCELLED: target: byuser.-4000.master: vttablet: rpc error: code = Canceled desc = grpc: the client connection is closing
    at io.grpc.Status.asRuntimeException(Status.java:533)
    at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:478)
    at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:463)
    at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:427)
    at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:460)
    at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:616)
    at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:69)
    at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:802)
    at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:781)
    at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
    at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)

2022-08-09 22:57:19,404 INFO  || Stopping down connector  [io.debezium.connector.common.BaseSourceTask]