### PR TITLE
DBZ-5572: Specify table.include.list during VStream subscription

### DIFF
--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Strings;
 import com.google.common.primitives.Bytes;
 import com.google.protobuf.ByteString;
 
@@ -56,7 +57,7 @@ public class TestHelper {
             "CREATE TABLE t1 (id BIGINT NOT NULL AUTO_INCREMENT, int_col INT, PRIMARY KEY (id));");
 
     public static Configuration.Builder defaultConfig() {
-        return defaultConfig(false, false, 1, -1, -1);
+        return defaultConfig(false, false, 1, -1, -1, null);
     }
 
     /**
@@ -69,7 +70,8 @@ public class TestHelper {
                                                       boolean offsetStoragePerTask,
                                                       int numTasks,
                                                       int gen,
-                                                      int prevNumTasks) {
+                                                      int prevNumTasks,
+                                                      String tableInclude) {
         Configuration.Builder builder = Configuration.create();
         builder = builder
                 .with(RelationalDatabaseConnectorConfig.SERVER_NAME, TEST_SERVER)
@@ -78,6 +80,9 @@ public class TestHelper {
                 .with(VitessConnectorConfig.VTGATE_USER, USERNAME)
                 .with(VitessConnectorConfig.VTGATE_PASSWORD, PASSWORD)
                 .with(VitessConnectorConfig.POLL_INTERVAL_MS, 100);
+        if (!Strings.isNullOrEmpty(tableInclude)) {
+            builder.with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, tableInclude);
+        }
         if (hasMultipleShards) {
             builder = builder.with(VitessConnectorConfig.KEYSPACE, TEST_SHARDED_KEYSPACE);
         }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -451,6 +451,16 @@ public class VitessConnectorTest {
         assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
     }
 
+    @Test
+    public void testTableIncludeList() {
+        String keyspace = "ks";
+        List<String> allTables = Arrays.asList("t1", "t22", "t3");
+        String tableIncludeList = new String("ks.t1,ks.t2.*");
+        List<String> includedTables = VitessConnector.getIncludedTables(keyspace, tableIncludeList, allTables);
+        List<String> expectedTables = Arrays.asList("t1", "t22");
+        assertEquals(expectedTables, includedTables);
+    }
+
     private void storeOffsets(OffsetBackingStore offsetStore, String serverVgtid, Map<String, Object> prevVgtids) {
         if (serverVgtid == null && (prevVgtids == null || prevVgtids.isEmpty())) {
             Testing.print("Empty gtids to store to offset.");

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -493,7 +493,7 @@ public class VitessConnectorTest {
 
     private Map<String, String> getTaskOffsets(OffsetBackingStore offsetStore, int numTasks, List<String> shards,
                                                int gen, int prevNumTasks) {
-        final Configuration config = TestHelper.defaultConfig(false, true, numTasks, gen, prevNumTasks).build();
+        final Configuration config = TestHelper.defaultConfig(false, true, numTasks, gen, prevNumTasks, null).build();
         final String engineName = "testOffset";
         final Converter keyConverter = new JsonConverter();
         Map<String, Object> converterConfig = Collect.hashMapOf("schemas.enable", false);


### PR DESCRIPTION
When table.include.list was used to only subscribe to changes to a subset of tables in the database, the filtering is currently done in debezium VM.  This is less efficient comparing to the filtering at the VtTablet level.   During VStream subscription, you can specify which tables you are interested, the VtTable will only send the changes to these tables to you.  The benefit of doing filtering in VtTable level is:

1. There are much less network bytes sending over the network,
2. it also has the advantage of avoiding errors related to tables you are not interested.  For example, we had seen errors related to schema mismatch on gh-ost (online schema migration) metadata table, we are not really interested in those tables.  By specifying to subscribe to only the data tables we are interested in, we can avoid those problems as well.

The fix is relatively straightforward by using Binlogdata.Filter during VStreamRequest building.  The details of those filters can be found in: https://github.com/vitessio/vitess/blob/release-14.0/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go#L316 .   Note that when you provide the table name for the filtering, you also need to provide a SELECT query to further restrict the rows/columns from that table, we are currently not filtering on row/column level.

New integration tests are added to cover the table.include.list filtering.

The change only applies when you specify table.include.list config params.

For reference, sometimes we saw the errors not related to our tables like below:

Errors like the following (that _ghc table is the temp table created during gh-ost migration process)
VStream streaming onError. Status: Status{code=UNKNOWN, description=target: byuser.-4000.replica: vttablet: rpc error: code = Unknown desc = stream (at source tablet) error @ 08fb1cf3-0ce5-11ed-b921-0a8939501751:1-1443715: unknown table _mentions_unread_ghc in schema, cause=null}