### PR TITLE
DBZ-5579: Vitess: Handle VStream close unexpectedly

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
@@ -36,8 +36,10 @@ public class VitessErrorHandler extends ErrorHandler {
                 case UNAVAILABLE:
                     return true;
                 case UNKNOWN:
-                    // Stream timeout error due to idle VStream.
-                    if (description != null && description.equals("stream timeout")) {
+                    // Stream timeout error due to idle VStream or vstream ended unexpectedly.
+                    if (description != null &&
+                            (description.equals("stream timeout") ||
+                                    description.contains("vstream ended unexpectedly"))) {
                         return true;
                     }
                     return false;


### PR DESCRIPTION
Make 'vstream ended unexpectedly' a retriable error to handle the below
exception:

2022-08-31 20:39:36,039 INFO  Vitess|dev|streaming VStream streaming onError. Status: Status{code=UNKNOWN, description=vstream ended unexpectedly, cause=null}  [io.debezium.connector.vitess.connection.VitessReplicationConnection]
io.grpc.StatusRuntimeException: UNKNOWN: vstream ended unexpectedly
    at io.grpc.Status.asRuntimeException(Status.java:533)
    at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:478)
    at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:463)
    at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:427)
    at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:460)
    at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:616)
    at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:69)
    at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:802)
    at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:781)
    at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
    at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
2022-08-31 20:39:36,849 ERROR Vitess|dev|streaming Error during streaming  [io.debezium.connector.vitess.VitessStreamingChangeEventSource]
io.grpc.StatusRuntimeException: UNKNOWN: vstream ended unexpectedly