### PR TITLE
DBZ-5722: Vitess: Handle Vstream error: unexpected server EOF

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
@@ -39,7 +39,8 @@ public class VitessErrorHandler extends ErrorHandler {
                     // Stream timeout error due to idle VStream or vstream ended unexpectedly.
                     if (description != null &&
                             (description.equals("stream timeout") ||
-                                    description.contains("vstream ended unexpectedly"))) {
+                                    description.contains("vstream ended unexpectedly") ||
+                                    description.contains("unexpected server EOF"))) {
                         return true;
                     }
                     return false;


### PR DESCRIPTION
Setup 2 VtTablet servers behind the VtGate, have one of the VtTable have truncated binlogs (e.g. newly bootstrapped from a backup file), have the Debezium connects to the   VtGate using a relatively old Gtids.  On 50% the request will hit one of the VtTablet server which doesn't have the grid history, the Vstream will error out with error messages below.

We should treat this error as retriable error and retry to hopefully route the request to one of the good VtTable which has the gtid.

2022-10-12 10:00:17,440 INFO Vitess|dev|streaming Exception code: UNKNOWN and description: vttablet: rpc error: code = Unknown desc = stream (at source tablet) error @ 027c67a2-c0b0-11ec-8a34-0ed0087913a5:1-11418261,08fb1cf3-0ce5-11ed-b921-0a8939501751:1-1443715,0c4d44de-3bc1-11ed-af99-0ee57f5f6bdb:1-3035408,396a0037-51e5-11ec-b6d4-06e7d02a97f7:1-23131540,47e148fc-b58f-11ec-afdd-0a92e288553b:1-50908799,4b67241e-03d4-11ed-af16-0a82ff4428fb:1-2100765,7007b595-20d7-11ed-b227-0a96a0fa5379:1-26327638,79099da3-b59a-11ec-b407-121791d0ff3d:1-99004816,9ced45d8-3699-11ec-a94b-1290866dd717:1-122256212,b5f72b93-06cb-11ed-9102-12b3b7a9a0f3:1-46356613,c96e48e1-03da-11ed-973f-0e1efd5bebd5:1-11561105,c97f6052-b594-11ec-bc09-06fc71a256b7:1-6826162,d91ec27f-3bc8-11ed-b440-1218686a4bc1:1-21409798,dc43ce77-51df-11ec-b20f-12bb5fac9935:1-173860388,e3303cce-3698-11ec-8558-06a96d8a92e5:1-100485,efbe0dcb-3b6c-11ed-8683-0a4617a72d31:1-1077281,fe2dace5-2256-11ed-a3d4-12151ce13117:1-35314391: unexpected server EOF [io.debezium.connector.vitess.VitessErrorHandler]

2022-10-12 10:00:17,441 INFO Vitess|dev|streaming Closing replication connection [io.debezium.connector.vitess.connection.VitessReplicationConnection] 2022-10-12 10:00:17,443 INFO Vitess|dev|streaming VStream GRPC channel is shutdown in time.

Fix is relatively simple by adding error message to the retriable errors in VitessErrorHandler.java

Fix is very similar to this PR: https://github.com/debezium/debezium-connector-vitess/pull/98