### PR TITLE
DBZ-5930: Support snapshot feature without an automatic retry

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -96,7 +96,9 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withImportance(ConfigDef.Importance.HIGH)
             .withDescription(
                     "Single GTID from where to start reading from for a given shard."
-                            + " It has to be set together with vitess.shard");
+                            + " It has to be set together with vitess.shard."
+                            + " If set an empty string, the connector starts copying the tables for the given shard first."
+                            + " If not configured, the connector streams changes from the latest position for the given shard.");
 
     public static final Field TABLET_TYPE = Field.create(VITESS_CONFIG_GROUP_PREFIX + "tablet.type")
             .withDisplayName("Tablet type to get data-changes")


### PR DESCRIPTION
ref. https://issues.redhat.com/browse/DBZ-5930

This PR adjusts the event state machine in gRPC responses to support the snapshot feature.

The following two cases differ from the streaming and should be taken care of.

- Duplicate VGTID when the VStream Copy starts
- Duplicate BEGIN when the VStream Copy starts and the table has no rows