### PR TITLE
DBZ-6011 Vitess: Handle the shard list difference between current db shards and persisted shards

### DIFF
--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -8,9 +8,7 @@ package io.debezium.connector.vitess;
 import static io.debezium.connector.vitess.TestHelper.TEST_SERVER;
 import static io.debezium.connector.vitess.TestHelper.TEST_UNSHARDED_KEYSPACE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -540,6 +538,21 @@ public class VitessConnectorTest {
         Testing.print(String.format("vgtids: %s", vgtids));
         assertEquals(vgtids.size(), 2);
         assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+    }
+
+    @Test
+    public void testHashSameShards() {
+        List<String> shardsOne = Arrays.asList("-c0", "c0+");
+        List<String> shardsTwo = Arrays.asList("c0+", "-c0");
+        assertTrue(VitessConnector.hasSameShards(shardsOne, shardsTwo));
+
+        shardsOne = Arrays.asList("-c0", "c0+", "-c0");
+        shardsTwo = Arrays.asList("c0+", "-c0");
+        assertTrue(!VitessConnector.hasSameShards(shardsOne, shardsTwo));
+
+        shardsOne = null;
+        shardsTwo = Arrays.asList("c0+", "-c0");
+        assertTrue(!VitessConnector.hasSameShards(shardsOne, shardsTwo));
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -8,7 +8,10 @@ package io.debezium.connector.vitess;
 import static io.debezium.connector.vitess.TestHelper.TEST_SERVER;
 import static io.debezium.connector.vitess.TestHelper.TEST_UNSHARDED_KEYSPACE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.HashMap;


### PR DESCRIPTION
When dbzium connector went offline for some time and Vitess shard splits during that time (e.g. s1 split into s10 and s11), the current shard list from v$session will have latest (s10, s11) however the shard list persisted Kafka offset topic only contains old shard s1 (pointed at an old position gt1).

When vitess connector restarts, the current logic in VitessConnector.taskConfigs() will use the latest shard list (s10, s11) to do the task assignment and it will use "current" (i.e. tail of the binlog queue) for s10/s11.  The correct behavior should use the old shard (s1) and old position (e.g. gt1) from persisted Kafka offset storage, this way the connector would subscribe to the exact point when it was stopped before.

When the vtgate continue playing the binlog events from vttablet, it will eventually encounter the shard split binlog event where tablet stream from s1 vttablet will be closed and be replaced with tablet streams from s10 and s11. All these will happen transparently for vitess connector, vitess connector will seamlessly receives the new events from new shards from vtgate (as if it was connected online all the time).

The fix is to enhance the logic iin VitessConnector.taskConfigs() to favor the shards from persisted offset storage.  However there are a few caveats:

1. If the tasks persisted in offset storage is empty (this can happen the first time when the task assignment initiated for the current generation of task number), we fall back to the shards from the previous generation of task assignment.

2. When the task persited in offset storage for the current gen is not complete (this can happen when some task worker crashed before it even gets the chance to persist its offset), we would need to fall back to use the current db shard list from v$session.

3. In the case the shards from offset storage diverges from the ones from current db list from v$session (they don't form a superset relationship), we would have to use the ones from offset storage.  But in this case we would need to require all tasks are persisted in offset storage to make sure we didn't miss any shards, otherwise the connector had to abort and wait for manual intervention.

Several new unit tests are added to handle the new edge cases.