### PR TITLE
DBZ-5919: Refactor ComputePartition SMT to be more extensible on source info parsing

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/converters/VitessCloudEventsProvider.java
+++ b/src/main/java/io/debezium/connector/vitess/converters/VitessCloudEventsProvider.java
@@ -6,7 +6,6 @@
 package io.debezium.connector.vitess.converters;
 
 import io.debezium.connector.vitess.transforms.VitessAbstractRecordParserProvider;
-
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.CloudEventsProvider;
 import io.debezium.converters.spi.RecordParser;

--- a/src/main/java/io/debezium/connector/vitess/transforms/VitessAbstractRecordParserProvider.java
+++ b/src/main/java/io/debezium/connector/vitess/transforms/VitessAbstractRecordParserProvider.java
@@ -5,12 +5,13 @@
  */
 package io.debezium.connector.vitess.transforms;
 
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
 import io.debezium.connector.vitess.Module;
 import io.debezium.connector.vitess.converters.VitessRecordParser;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.transforms.spi.RecordParserProvider;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 
 public abstract class VitessAbstractRecordParserProvider implements RecordParserProvider {
 

--- a/src/main/java/io/debezium/connector/vitess/transforms/VitessQualifiedDataCollectionNameResolver.java
+++ b/src/main/java/io/debezium/connector/vitess/transforms/VitessQualifiedDataCollectionNameResolver.java
@@ -8,9 +8,9 @@ package io.debezium.connector.vitess.transforms;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.vitess.SourceInfo;
 import io.debezium.converters.spi.RecordParser;
-import io.debezium.transforms.spi.QualifiedTableNameResolver;
+import io.debezium.transforms.spi.QualifiedDataCollectionNameResolver;
 
-public class VitessQualifiedTableNameResolver extends VitessAbstractRecordParserProvider implements QualifiedTableNameResolver {
+public class VitessQualifiedDataCollectionNameResolver extends VitessAbstractRecordParserProvider implements QualifiedDataCollectionNameResolver {
     public static final String FULLY_QUALIFIED_NAME_FORMAT = "%s.%s";
 
     @Override

--- a/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedDataCollectionNameResolver
+++ b/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedDataCollectionNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.vitess.transforms.VitessQualifiedDataCollectionNameResolver

--- a/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,1 +1,0 @@
-io.debezium.connector.vitess.transforms.VitessQualifiedTableNameResolver

--- a/src/test/java/io/debezium/connector/vitess/transforms/ComputePartitionTest.java
+++ b/src/test/java/io/debezium/connector/vitess/transforms/ComputePartitionTest.java
@@ -5,22 +5,25 @@
  */
 package io.debezium.connector.vitess.transforms;
 
-import io.debezium.data.Envelope;
-import io.debezium.transforms.partitions.ComputePartition;
-import io.debezium.transforms.partitions.ComputePartitionException;
+import static io.debezium.data.Envelope.Operation.CREATE;
+import static io.debezium.data.Envelope.Operation.DELETE;
+import static io.debezium.data.Envelope.Operation.TRUNCATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
 
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-
-import static io.debezium.data.Envelope.Operation.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import io.debezium.data.Envelope;
+import io.debezium.transforms.partitions.ComputePartition;
+import io.debezium.transforms.partitions.ComputePartitionException;
 
 public class ComputePartitionTest {
 
@@ -154,7 +157,6 @@ public class ComputePartitionTest {
     }
 
     private SourceRecord buildSourceRecord(String keyspace, String tableName, Struct row, Envelope.Operation operation) {
-
 
         SchemaBuilder sourceSchemaBuilder = SchemaBuilder.struct()
                 .name("source")

--- a/src/test/resources/META-INF/services/io.debezium.transforms.spi.QualifiedDataCollectionNameResolver
+++ b/src/test/resources/META-INF/services/io.debezium.transforms.spi.QualifiedDataCollectionNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.vitess.transforms.VitessQualifiedDataCollectionNameResolver

--- a/src/test/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/src/test/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,1 +1,0 @@
-io.debezium.connector.vitess.transforms.VitessQualifiedTableNameResolver


### PR DESCRIPTION
Implement QualifiedTableNameResolver for ComputePartition SMT

Depends on [#DBZ-5919](https://github.com/debezium/debezium/pull/4361)