### PR TITLE
DBZ-6347: Duplicate JMX MBean names when multiple vitess tasks running in the same JVM

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -224,7 +224,7 @@ public class VitessConnector extends RelationalBaseSourceConnector {
         }
     }
 
-    protected static final String getTaskKeyName(int tid, int numTasks, int gen) {
+    public static final String getTaskKeyName(int tid, int numTasks, int gen) {
         return String.format("task%d_%d_%d", tid, numTasks, gen);
     }
 

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorTask.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorTask.java
@@ -19,6 +19,7 @@ import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
 import io.debezium.connector.vitess.connection.ReplicationConnection;
 import io.debezium.connector.vitess.connection.VitessReplicationConnection;
+import io.debezium.connector.vitess.metrics.VitessChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
@@ -103,7 +104,7 @@ public class VitessConnectorTask extends BaseSourceTask<VitessPartition, VitessO
                     connectorConfig,
                     new VitessChangeEventSourceFactory(
                             connectorConfig, errorHandler, dispatcher, clock, schema, replicationConnection),
-                    new DefaultChangeEventSourceMetricsFactory<>(),
+                    connectorConfig.offsetStoragePerTask() ? new VitessChangeEventSourceMetricsFactory() : new DefaultChangeEventSourceMetricsFactory<>(),
                     dispatcher,
                     schema);
 

--- a/src/main/java/io/debezium/connector/vitess/VitessTaskContext.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessTaskContext.java
@@ -11,6 +11,10 @@ import io.debezium.connector.common.CdcSourceTaskContext;
 public class VitessTaskContext extends CdcSourceTaskContext {
 
     public VitessTaskContext(VitessConnectorConfig config, VitessDatabaseSchema schema) {
-        super(config.getContextName(), config.getLogicalName(), schema::tableIds);
+        super(config.getContextName(), config.getLogicalName(), getTaskId(config), schema::tableIds);
+    }
+
+    public static String getTaskId(VitessConnectorConfig config) {
+        return config.offsetStoragePerTask() ? config.getVitessTaskKey() : "0";
     }
 }

--- a/src/main/java/io/debezium/connector/vitess/metrics/VitessChangeEventSourceMetricsFactory.java
+++ b/src/main/java/io/debezium/connector/vitess/metrics/VitessChangeEventSourceMetricsFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess.metrics;
+
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.vitess.VitessPartition;
+import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+
+/**
+ * @author Chris Cranford
+ */
+public class VitessChangeEventSourceMetricsFactory extends DefaultChangeEventSourceMetricsFactory<VitessPartition> {
+
+    @Override
+    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics<VitessPartition> getSnapshotMetrics(T taskContext,
+                                                                                                                 ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                 EventMetadataProvider eventMetadataProvider) {
+        return new VitessSnapshotChangeEventSourceMetrics(taskContext, changeEventQueueMetrics, eventMetadataProvider);
+    }
+
+    @Override
+    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics<VitessPartition> getStreamingMetrics(T taskContext,
+                                                                                                                   ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                   EventMetadataProvider eventMetadataProvider) {
+        return new VitessStreamingChangeEventSourceMetrics(taskContext, changeEventQueueMetrics, eventMetadataProvider);
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/metrics/VitessSnapshotChangeEventSourceMetrics.java
+++ b/src/main/java/io/debezium/connector/vitess/metrics/VitessSnapshotChangeEventSourceMetrics.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess.metrics;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.vitess.VitessPartition;
+import io.debezium.pipeline.metrics.DefaultSnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.util.Collect;
+
+/**
+ * @author Chris Cranford
+ */
+@ThreadSafe
+public class VitessSnapshotChangeEventSourceMetrics extends DefaultSnapshotChangeEventSourceMetrics<VitessPartition> {
+
+    public <T extends CdcSourceTaskContext> VitessSnapshotChangeEventSourceMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                   EventMetadataProvider metadataProvider) {
+        super(taskContext, changeEventQueueMetrics, metadataProvider,
+                Collect.linkMapOf("context", "snapshot", "server", taskContext.getConnectorName(), "task", taskContext.getTaskId()));
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/metrics/VitessStreamingChangeEventSourceMetrics.java
+++ b/src/main/java/io/debezium/connector/vitess/metrics/VitessStreamingChangeEventSourceMetrics.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess.metrics;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.vitess.VitessPartition;
+import io.debezium.pipeline.metrics.DefaultStreamingChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.util.Collect;
+
+/**
+ * @author Chris Cranford
+ */
+@ThreadSafe
+public class VitessStreamingChangeEventSourceMetrics extends DefaultStreamingChangeEventSourceMetrics<VitessPartition> {
+
+    public <T extends CdcSourceTaskContext> VitessStreamingChangeEventSourceMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                    EventMetadataProvider eventMetadataProvider) {
+        super(taskContext, changeEventQueueMetrics, eventMetadataProvider,
+                Collect.linkMapOf("context", "streaming", "server", taskContext.getConnectorName(), "task", taskContext.getTaskId()));
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -593,7 +593,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         };
         start(VitessConnector.class, TestHelper.defaultConfig().build(), completionCallback);
         assertConnectorIsRunning();
-        waitForStreamingRunning();
+        waitForStreamingRunning(null);
 
         // Connector receives a row whose column name is not valid, task should fail
         TestHelper.execute("ALTER TABLE numeric_table ADD `@1` INT;");
@@ -946,12 +946,13 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         final LogInterceptor logInterceptor = new LogInterceptor(VitessReplicationConnection.class);
         start(VitessConnector.class, configBuilder.build());
         assertConnectorIsRunning();
-        waitForStreamingRunning();
+        String taskId = offsetStoragePerTask ? VitessConnector.getTaskKeyName(0, numTasks, gen) : null;
+        waitForStreamingRunning(taskId);
         waitForVStreamStarted(logInterceptor);
     }
 
-    private void waitForStreamingRunning() throws InterruptedException {
-        waitForStreamingRunning(Module.name(), TEST_SERVER);
+    private void waitForStreamingRunning(String taskId) throws InterruptedException {
+        waitForStreamingRunning(taskId, Module.name(), TEST_SERVER);
     }
 
     private SourceRecord assertInsert(


### PR DESCRIPTION
In vitess multitasking mode (VitessConnectorConfig.offsetStoragePerTask=true),  multiple tasks can be run inside the same JVM.  And we will see the following duplicate mbean warnings:

```
2023-04-11 04:52:29,453 WARN   Vitess|dev.byuser|snapshot  Unable to register metrics as an old set with the same name debezium.vitess:type=connector-metrics,context=snapshot,server=dev.byuser exists, retrying in PT5S (attempt 1 out of 12)  [io.debezium.metrics.Metrics]
```

This is because the means from different tasks are using the same mbean name (the mbean name only has the connector name, but the task name).

This pollutes the log, slows down the startup time and cause some beans not registered.

Debezium connectors which supports multiple tasks deal with this problem by adding taskId as part of the mbean name (e.g. MongoDbConnector).

The fix pretty much follows MongoDBConnector by adding Vitess's own VitessChangeEventSourceMetricsFactory, VitessSnapshotChangeEventSourceMetrics and VitessStreamingChangeEventSourceMetrics which adds the taskId as part of mean name.

When the multiTasking mode is on, the taskId is composed from VitessConnector.getTaskKeyName(taskId, numOfTasks, generation_number).

When the multiTasking mode is off, we keep the old logic (which doesn't include taskId in the mbean name) for backward compatibility.

Integration tests are modified to watch for the new mbean name.

After the fix, this is the new logging lines:

```
2023-04-18 06:35:03,099 INFO   Vitess|dev.byuser|snapshot  JMX bean 'debezium.vitess:type=connector-metrics,context=snapshot,server=dev.byuser,task=task1_2_1' registered   [io.debezium.metrics.Metrics]
2023-04-18 06:35:03,099 INFO   Vitess|dev.byuser|snapshot  JMX bean 'debezium.vitess:type=connector-metrics,context=snapshot,server=dev.byuser,task=task0_2_1' registered   [io.debezium.metrics.Metrics]
2023-04-18 06:35:03,099 INFO   Vitess|dev.byuser|snapshot  JMX bean 'debezium.vitess:type=connector-metrics,context=streaming,server=dev.byuser,task=task1_2_1' registered   [io.debezium.metrics.Metrics]

```