### PR TITLE
DBZ-6356 Support streaming a list of shards and accompanying GTIDs

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -220,9 +220,10 @@ public class VitessConnector extends RelationalBaseSourceConnector {
             if (maxTasks > 1) {
                 throw new IllegalArgumentException("Only a single connector task may be started");
             }
+            final List<String> gtids = connectorConfig.getGtid();
             if (connectorConfig.getShard() != null &&
-                    !connectorConfig.getGtid().equals(List.of(VitessConnectorConfig.GTID.defaultValueAsString())) &&
-                    !connectorConfig.getGtid().equals(List.of("")) &&
+                    gtids != VitessConnectorConfig.DEFAULT_GTID_LIST &&
+                    gtids != VitessConnectorConfig.EMPTY_GTID_LIST &&
                     connectorConfig.getShard().size() != connectorConfig.getGtid().size()) {
                 throw new IllegalArgumentException("If GTIDs are specified must be specified for all shards");
             }

--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -205,7 +205,7 @@ public class VitessConnector extends RelationalBaseSourceConnector {
                         gtidStr = prevGtidsPerShard != null ? prevGtidsPerShard.get(shard) : null;
                     }
                     if (gtidStr == null) {
-                        gtidStr = connectorConfig.getGtid();
+                        gtidStr = connectorConfig.getGtid().get(0);
                         LOGGER.warn("No previous gtid found either for shard: {}, fallback to '{}'", shard, gtidStr);
                     }
                     shardGtids.add(new Vgtid.ShardGtid(keyspace, shard, gtidStr));
@@ -219,6 +219,12 @@ public class VitessConnector extends RelationalBaseSourceConnector {
         else {
             if (maxTasks > 1) {
                 throw new IllegalArgumentException("Only a single connector task may be started");
+            }
+            if (connectorConfig.getShard() != null &&
+                    !connectorConfig.getGtid().equals(List.of(VitessConnectorConfig.GTID.defaultValueAsString())) &&
+                    !connectorConfig.getGtid().equals(List.of("")) &&
+                    connectorConfig.getShard().size() != connectorConfig.getGtid().size()) {
+                throw new IllegalArgumentException("If GTIDs are specified must be specified for all shards");
             }
             return Collections.singletonList(properties);
         }

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -35,6 +35,9 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
  */
 public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
 
+    public static final List<String> EMPTY_GTID_LIST = List.of("");
+    public static final List<String> DEFAULT_GTID_LIST = List.of(Vgtid.CURRENT_GTID);
+
     private static final Logger LOGGER = LoggerFactory.getLogger(VitessConnectorConfig.class);
 
     private static final String VITESS_CONFIG_GROUP_PREFIX = "vitess.";
@@ -454,10 +457,10 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public List<String> getGtid() {
         if (getSnapshotMode() == SnapshotMode.INITIAL) {
-            return List.of("");
+            return EMPTY_GTID_LIST;
         }
         List<String> value = getConfig().getStrings(GTID, ",");
-        return value != null ? value : List.of(GTID.defaultValueAsString());
+        return (value != null && !GTID.defaultValueAsString().equals(value)) ? value : DEFAULT_GTID_LIST;
     }
 
     public String getVtgateHost() {

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -448,15 +448,16 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getString(KEYSPACE);
     }
 
-    public String getShard() {
-        return getConfig().getString(SHARD);
+    public List<String> getShard() {
+        return getConfig().getStrings(SHARD, ",");
     }
 
-    public String getGtid() {
+    public List<String> getGtid() {
         if (getSnapshotMode() == SnapshotMode.INITIAL) {
-            return "";
+            return List.of("");
         }
-        return getConfig().getString(GTID);
+        List<String> value = getConfig().getStrings(GTID, ",");
+        return value != null ? value : List.of(GTID.defaultValueAsString());
     }
 
     public String getVtgateHost() {

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -371,7 +371,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
         else {
             if (config.getShard() == null || config.getShard().isEmpty()) {
                 // This case is not supported by the Vitess, so our workaround is to get all the shards from vtgate.
-                if (config.getGtid().equals(List.of(""))) {
+                if (config.getGtid() == VitessConnectorConfig.EMPTY_GTID_LIST) {
                     List<String> shards = VitessConnector.getVitessShards(config);
                     List<String> gtids = Collections.nCopies(shards.size(), config.getGtid().get(0));
                     vgtid = buildVgtid(config.getKeyspace(), shards, gtids);
@@ -385,8 +385,8 @@ public class VitessReplicationConnection implements ReplicationConnection {
             else {
                 List<String> shards = config.getShard();
                 List<String> gtids = config.getGtid();
-                if (gtids.equals(List.of(VitessConnectorConfig.GTID.defaultValueAsString())) ||
-                        gtids.equals(List.of(""))) {
+                if (gtids == VitessConnectorConfig.DEFAULT_GTID_LIST ||
+                        gtids == VitessConnectorConfig.EMPTY_GTID_LIST) {
                     gtids = Collections.nCopies(shards.size(), gtids.get(0));
                 }
                 vgtid = buildVgtid(config.getKeyspace(), shards, gtids);

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -40,6 +40,7 @@ public class TestHelper {
     public static final String TEST_UNSHARDED_KEYSPACE = "test_unsharded_keyspace";
     public static final String TEST_SHARDED_KEYSPACE = "test_sharded_keyspace";
     public static final String TEST_SHARD = "0";
+    public static final String TEST_GTID = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000a:1-1513";
     public static final String TEST_TABLE = "test_table";
     private static final String TEST_VITESS_FULL_TABLE = TEST_UNSHARDED_KEYSPACE + "." + TEST_TABLE;
     protected static final String PK_FIELD = "id";
@@ -58,7 +59,7 @@ public class TestHelper {
             "CREATE TABLE t1 (id BIGINT NOT NULL AUTO_INCREMENT, int_col INT, PRIMARY KEY (id));");
 
     public static Configuration.Builder defaultConfig() {
-        return defaultConfig(false, false, 1, -1, -1, null, VitessConnectorConfig.SnapshotMode.NEVER);
+        return defaultConfig(false, false, 1, -1, -1, null, VitessConnectorConfig.SnapshotMode.NEVER, TEST_SHARD);
     }
 
     /**
@@ -74,6 +75,24 @@ public class TestHelper {
                                                       int prevNumTasks,
                                                       String tableInclude,
                                                       VitessConnectorConfig.SnapshotMode snapshotMode) {
+        return defaultConfig(hasMultipleShards,
+                offsetStoragePerTask,
+                numTasks,
+                gen,
+                prevNumTasks,
+                tableInclude,
+                snapshotMode,
+                "");
+    }
+
+    public static Configuration.Builder defaultConfig(boolean hasMultipleShards,
+                                                      boolean offsetStoragePerTask,
+                                                      int numTasks,
+                                                      int gen,
+                                                      int prevNumTasks,
+                                                      String tableInclude,
+                                                      VitessConnectorConfig.SnapshotMode snapshotMode,
+                                                      String shards) {
         Configuration.Builder builder = Configuration.create();
         builder = builder
                 .with(CommonConnectorConfig.TOPIC_PREFIX, TEST_SERVER)
@@ -89,9 +108,12 @@ public class TestHelper {
             builder = builder.with(VitessConnectorConfig.KEYSPACE, TEST_SHARDED_KEYSPACE);
         }
         else {
-            builder = builder.with(VitessConnectorConfig.KEYSPACE, TEST_UNSHARDED_KEYSPACE)
-                    .with(VitessConnectorConfig.SHARD, TEST_SHARD);
+            builder = builder.with(VitessConnectorConfig.KEYSPACE, TEST_UNSHARDED_KEYSPACE);
         }
+        if (shards != null && !shards.isEmpty()) {
+            builder.with(VitessConnectorConfig.SHARD, shards);
+        }
+
         if (offsetStoragePerTask) {
             builder = builder.with(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK, "true")
                     .with(VitessConnectorConfig.TASKS_MAX_CONFIG, Integer.toString(numTasks))

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -62,7 +62,7 @@ public class VitessReplicationConnectionIT {
                             .addShardGtids(
                                     Binlogdata.ShardGtid.newBuilder()
                                             .setKeyspace(conf.getKeyspace())
-                                            .setShard(conf.getShard())
+                                            .setShard(conf.getShard().get(0))
                                             .setGtid(Vgtid.CURRENT_GTID)
                                             .build())
                             .build());
@@ -102,7 +102,7 @@ public class VitessReplicationConnectionIT {
                     });
 
             // verify outcome
-            messages.forEach(m -> assertValidVgtid(m.getVgtid(), conf.getKeyspace(), conf.getShard()));
+            messages.forEach(m -> assertValidVgtid(m.getVgtid(), conf.getKeyspace(), conf.getShard().get(0)));
             assertThat(messages.get(0).getMessage().getOperation().name()).isEqualTo("BEGIN");
             assertThat(messages.get(1).getMessage().getOperation().name()).isEqualTo("INSERT");
             assertThat(messages.get(2).getMessage().getOperation().name()).isEqualTo("COMMIT");
@@ -131,7 +131,7 @@ public class VitessReplicationConnectionIT {
                             .addShardGtids(
                                     Binlogdata.ShardGtid.newBuilder()
                                             .setKeyspace(conf.getKeyspace())
-                                            .setShard(conf.getShard())
+                                            .setShard(conf.getShard().get(0))
                                             .setGtid("")
                                             .build())
                             .build());
@@ -159,7 +159,7 @@ public class VitessReplicationConnectionIT {
                     });
 
             // verify outcome from the copy operation
-            messages.forEach(m -> assertValidVgtid(m.getVgtid(), conf.getKeyspace(), conf.getShard()));
+            messages.forEach(m -> assertValidVgtid(m.getVgtid(), conf.getKeyspace(), conf.getShard().get(0)));
             assertThat(messages.get(0).getMessage().getOperation().name()).isEqualTo("BEGIN");
             assertThat(messages.get(1).getMessage().getOperation().name()).isEqualTo("INSERT");
             assertThat(messages.get(2).getMessage().getOperation().name()).isEqualTo("COMMIT");
@@ -181,7 +181,7 @@ public class VitessReplicationConnectionIT {
                     });
 
             // verify outcome from the replicate operation
-            messages.forEach(m -> assertValidVgtid(m.getVgtid(), conf.getKeyspace(), conf.getShard()));
+            messages.forEach(m -> assertValidVgtid(m.getVgtid(), conf.getKeyspace(), conf.getShard().get(0)));
             assertThat(messages.get(0).getMessage().getOperation().name()).isEqualTo("BEGIN");
             assertThat(messages.get(1).getMessage().getOperation().name()).isEqualTo("INSERT");
             assertThat(messages.get(2).getMessage().getOperation().name()).isEqualTo("COMMIT");
@@ -206,7 +206,7 @@ public class VitessReplicationConnectionIT {
                             .addShardGtids(
                                     Binlogdata.ShardGtid.newBuilder()
                                             .setKeyspace(conf.getKeyspace())
-                                            .setShard(conf.getShard())
+                                            .setShard(conf.getShard().get(0))
                                             .setGtid(Vgtid.CURRENT_GTID)
                                             .build())
                             .build());


### PR DESCRIPTION
### Summary
With the Vitess connector, the shard setting can only stream a single shard or all shards. It would be helpful to extend this to support a shard list such that gradual scale up/roll out can be done safely with the Vitess connector. This is read in as a CSV list and the accompanying GTIDs can also be specified.

### Verification
Added unit tests & an integration test verifying we can read multiple shards when they are specified as CSV config.

Note: We implement this feature specifically for the single task mode currently. In a subsequent PR we will implement support for streaming a list of shards and handling multiple tasks. Want to keep the scope of this one just to single task and multi shard streaming.