### PR TITLE
DBZ-6365 Support streaming a list of shards/gtids with multiple tasks

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/Vgtid.java
+++ b/src/main/java/io/debezium/connector/vitess/Vgtid.java
@@ -21,6 +21,7 @@ import binlogdata.Binlogdata;
 /** Vitess source position coordinates. */
 public class Vgtid {
     public static final String CURRENT_GTID = "current";
+    public static final String EMPTY_GTID = "";
     public static final String KEYSPACE_KEY = "keyspace";
     public static final String SHARD_KEY = "shard";
     public static final String GTID_KEY = "gtid";

--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -100,8 +100,8 @@ public class VitessConnector extends RelationalBaseSourceConnector {
         LOGGER.info("Calculating taskConfigs for {} tasks", maxTasks);
         List<String> shards = null;
         if (connectorConfig.offsetStoragePerTask()) {
-            List<String> shard = connectorConfig.getShard();
-            if (shard == null) {
+            shards = connectorConfig.getShard();
+            if (shards == null) {
                 shards = getVitessShards(connectorConfig);
             }
         }

--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -151,9 +151,9 @@ public class VitessConnector extends RelationalBaseSourceConnector {
                 LOGGER.warn("Some shards for the previous generation {} are not persisted.  Expected shards: {}",
                         prevGtidsPerShard.keySet(), currentShards);
                 if (prevGtidsPerShard.keySet().containsAll(currentShards)) {
-                    LOGGER.warn("Previous shards: %s is the superset of current shards: %s.  "
+                    throw new IllegalArgumentException(String.format("Previous shards: %s is the superset of current shards: %s.  "
                             + "We will lose gtid positions for some shards if we continue",
-                            prevGtidsPerShard.keySet(), currentShards);
+                            prevGtidsPerShard.keySet(), currentShards));
                 }
             }
             final String keyspace = connectorConfig.getKeyspace();

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -275,11 +275,13 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
 
     private static ObjectName getMetricsObjectNameWithTags(String connector, Map<String, String> tags) {
         try {
-            return new ObjectName("debezium." + connector + ":type=connector-metrics,"
-                    + tags.entrySet()
-                            .stream()
-                            .map(e -> e.getKey() + "=" + e.getValue())
-                            .collect(Collectors.joining(",")));
+            return new ObjectName(
+                    String.format("debezium.%s:%s,type=connector-metrics",
+                            connector,
+                            tags.entrySet()
+                                    .stream()
+                                    .map(e -> e.getKey() + "=" + e.getValue())
+                                    .collect(Collectors.joining(","))));
         }
         catch (MalformedObjectNameException e) {
             throw new RuntimeException(e);

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -156,7 +156,7 @@ public class VitessConnectorTest {
             }
         };
         connector.start(props);
-        List<Map<String, String>> taskConfigs = connector.taskConfigs(1, shards);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(1);
         assertThat(taskConfigs.size() == 1);
         Map<String, String> firstConfig = taskConfigs.get(0);
         assertThat(firstConfig.size() == 3);
@@ -188,7 +188,7 @@ public class VitessConnectorTest {
             }
         };
         connector.start(props);
-        List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks, shards);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks);
         int expectedConfigSize = 9;
         assertEquals(taskConfigs.size(), maxTasks);
         Map<String, String> firstConfig = taskConfigs.get(0);
@@ -300,7 +300,7 @@ public class VitessConnectorTest {
             }
         };
         connector.start(props);
-        List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks, shards);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks);
         int expectedConfigSize = 10;
         assertEquals(taskConfigs.size(), maxTasks);
         Map<String, String> firstConfig = taskConfigs.get(0);

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -759,13 +759,14 @@ public class VitessConnectorTest {
         final List<String> shards = Arrays.asList("s0", "s1");
         Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "current", "current"));
-        final Map<String, Object> expectedVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), vgtid.toString());
 
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
-        Testing.print(String.format("vgtids: %s", vgtids));
-        assertEquals(vgtids.size(), 1);
-        assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+        try {
+            getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
+            fail("This call should not reach here.");
+        }
+        catch (IllegalArgumentException ex) {
+            Testing.print(String.format("Got expected exception: {}", ex));
+        }
     }
 
     @Test


### PR DESCRIPTION
### Summary

We added support previously for single thread mode for reading in a string of csv shards. Now we extend that to also work with multiple tasks

### Verification
Added unit tests & acceptance tests for verifying things work as expected when multiple tasks are used with the shard config csv string.
Note: for the registration of the metrics in the integration test, they were always registered under `task_0_1_0` despite the fact that `task_0_2_0` would be the expected name for a connector with 2 max tasks. When I checked the logs the `taskConfigs` function was always being called with 1 even if our config said 2. From what I can tell this is a limitation of the integration tests using the embedded engine, so I just overrode the numTasks for generating the task ID to always be 1.