### PR TITLE
DBZ-6510 Use event processing failure handling mode in VitessReplicationConnection

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -175,15 +175,6 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
     }
 
-    public EventProcessingFailureHandlingMode getEventProcessingFailureHandlingMode() {
-        if (super.getEventProcessingFailureHandlingMode() == null) {
-            return EventProcessingFailureHandlingMode.FAIL;
-        }
-        else {
-            return super.getEventProcessingFailureHandlingMode();
-        }
-    }
-
     public static final Field VTGATE_HOST = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.HOSTNAME)
             .withDisplayName("Vitess database hostname")
             .withType(Type.STRING)

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -175,6 +175,15 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
     }
 
+    public EventProcessingFailureHandlingMode getEventProcessingFailureHandlingMode() {
+        if (super.getEventProcessingFailureHandlingMode() == null) {
+            return EventProcessingFailureHandlingMode.FAIL;
+        }
+        else {
+            return super.getEventProcessingFailureHandlingMode();
+        }
+    }
+
     public static final Field VTGATE_HOST = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.HOSTNAME)
             .withDisplayName("Vitess database hostname")
             .withType(Type.STRING)

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -223,10 +223,21 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
             @Override
             public void onError(Throwable t) {
-                LOGGER.info("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
-                // Only propagate the first error
-                error.compareAndSet(null, t);
-                reset();
+                switch (config.getEventProcessingFailureHandlingMode()) {
+                    case FAIL:
+                        LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                        // Only propagate the first error
+                        error.compareAndSet(null, t);
+                        reset();
+                        break;
+                    case WARN:
+                        LOGGER.warn("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                        break;
+                    case SKIP:
+                    case IGNORE:
+                        LOGGER.debug("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                        break;
+                }
             }
 
             @Override

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -59,7 +59,7 @@ public class TestHelper {
             "CREATE TABLE t1 (id BIGINT NOT NULL AUTO_INCREMENT, int_col INT, PRIMARY KEY (id));");
 
     public static Configuration.Builder defaultConfig() {
-        return defaultConfig(false, false, 1, -1, -1, null, VitessConnectorConfig.SnapshotMode.NEVER, TEST_SHARD);
+        return defaultConfig(false, false, 1, -1, -1, null, VitessConnectorConfig.SnapshotMode.NEVER, TEST_SHARD, "", "");
     }
 
     /**
@@ -82,6 +82,8 @@ public class TestHelper {
                 prevNumTasks,
                 tableInclude,
                 snapshotMode,
+                "",
+                "",
                 "");
     }
 
@@ -93,6 +95,28 @@ public class TestHelper {
                                                       String tableInclude,
                                                       VitessConnectorConfig.SnapshotMode snapshotMode,
                                                       String shards) {
+        return defaultConfig(hasMultipleShards,
+                offsetStoragePerTask,
+                numTasks,
+                gen,
+                prevNumTasks,
+                tableInclude,
+                snapshotMode,
+                shards,
+                "",
+                "");
+    }
+
+    public static Configuration.Builder defaultConfig(boolean hasMultipleShards,
+                                                      boolean offsetStoragePerTask,
+                                                      int numTasks,
+                                                      int gen,
+                                                      int prevNumTasks,
+                                                      String tableInclude,
+                                                      VitessConnectorConfig.SnapshotMode snapshotMode,
+                                                      String shards,
+                                                      String grpcMaxInboundMessageSize,
+                                                      String eventProcessingFailureHandlingMode) {
         Configuration.Builder builder = Configuration.create();
         builder = builder
                 .with(CommonConnectorConfig.TOPIC_PREFIX, TEST_SERVER)
@@ -122,6 +146,12 @@ public class TestHelper {
         }
         if (snapshotMode != null) {
             builder = builder.with(VitessConnectorConfig.SNAPSHOT_MODE, snapshotMode.getValue());
+        }
+        if (grpcMaxInboundMessageSize != null) {
+            builder = builder.with(VitessConnectorConfig.GRPC_MAX_INBOUND_MESSAGE_SIZE, grpcMaxInboundMessageSize);
+        }
+        if (eventProcessingFailureHandlingMode != null) {
+            builder = builder.with(VitessConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE, eventProcessingFailureHandlingMode);
         }
         return builder;
     }

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -59,7 +59,7 @@ public class TestHelper {
             "CREATE TABLE t1 (id BIGINT NOT NULL AUTO_INCREMENT, int_col INT, PRIMARY KEY (id));");
 
     public static Configuration.Builder defaultConfig() {
-        return defaultConfig(false, false, 1, -1, -1, null, VitessConnectorConfig.SnapshotMode.NEVER, TEST_SHARD, "", "");
+        return defaultConfig(false, false, 1, -1, -1, null, VitessConnectorConfig.SnapshotMode.NEVER, TEST_SHARD, null, null);
     }
 
     /**
@@ -103,8 +103,8 @@ public class TestHelper {
                 tableInclude,
                 snapshotMode,
                 shards,
-                "",
-                "");
+                null,
+                null);
     }
 
     public static Configuration.Builder defaultConfig(boolean hasMultipleShards,

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -49,6 +49,129 @@ public class VitessReplicationConnectionIT {
     }
 
     @Test
+    public void shouldNotErrorOutWhenSkipEnabled() throws Exception {
+        // setup fixture
+        final VitessConnectorConfig conf = new VitessConnectorConfig(
+                TestHelper.defaultConfig(false, false, 1, -1, -1,
+                        null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
+                        "1", "skip").build());
+        final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema);
+        Vgtid startingVgtid = Vgtid.of(
+                Binlogdata.VGtid.newBuilder()
+                        .addShardGtids(
+                                Binlogdata.ShardGtid.newBuilder()
+                                        .setKeyspace(conf.getKeyspace())
+                                        .setShard(conf.getShard().get(0))
+                                        .setGtid(Vgtid.CURRENT_GTID)
+                                        .build())
+                        .build());
+
+        BlockingQueue<MessageAndVgtid> consumedMessages = new ArrayBlockingQueue<>(100);
+        AtomicBoolean started = new AtomicBoolean(false);
+        connection.startStreaming(
+                startingVgtid,
+                (message, vgtid, isLastRowEventOfTransaction) -> {
+                    if (!started.get()) {
+                        started.set(true);
+                    }
+                    consumedMessages.add(new MessageAndVgtid(message, vgtid));
+                },
+                error);
+        // Since we are using the "current" as the starting position, there is a race here
+        // if we execute INSERT_STMT before the vstream starts we will never receive the update
+        // therefore, we wait until the stream is setup and then do the insertion
+        Thread.sleep(1000);
+        assertThat(error.get()).isNull();
+    }
+
+    @Test
+    public void shouldNotErrorOutWhenWarnEnabled() throws Exception {
+        // setup fixture
+        final VitessConnectorConfig conf = new VitessConnectorConfig(
+                TestHelper.defaultConfig(false, false, 1, -1, -1,
+                        null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
+                        "1", "warn").build());
+        final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema);
+        Vgtid startingVgtid = Vgtid.of(
+                Binlogdata.VGtid.newBuilder()
+                        .addShardGtids(
+                                Binlogdata.ShardGtid.newBuilder()
+                                        .setKeyspace(conf.getKeyspace())
+                                        .setShard(conf.getShard().get(0))
+                                        .setGtid(Vgtid.CURRENT_GTID)
+                                        .build())
+                        .build());
+
+        BlockingQueue<MessageAndVgtid> consumedMessages = new ArrayBlockingQueue<>(100);
+        AtomicBoolean started = new AtomicBoolean(false);
+        connection.startStreaming(
+                startingVgtid,
+                (message, vgtid, isLastRowEventOfTransaction) -> {
+                    if (!started.get()) {
+                        started.set(true);
+                    }
+                    consumedMessages.add(new MessageAndVgtid(message, vgtid));
+                },
+                error);
+        // Since we are using the "current" as the starting position, there is a race here
+        // if we execute INSERT_STMT before the vstream starts we will never receive the update
+        // therefore, we wait until the stream is setup and then do the insertion
+        Thread.sleep(1000);
+        assertThat(error.get()).isNull();
+    }
+
+    @Test
+    public void shouldFailWhenFailEnabled() throws Exception {
+        // setup fixture
+        final VitessConnectorConfig conf = new VitessConnectorConfig(
+                TestHelper.defaultConfig(false, false, 1, -1, -1,
+                        null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
+                        "1", "fail").build());
+        final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema);
+        Vgtid startingVgtid = Vgtid.of(
+                Binlogdata.VGtid.newBuilder()
+                        .addShardGtids(
+                                Binlogdata.ShardGtid.newBuilder()
+                                        .setKeyspace(conf.getKeyspace())
+                                        .setShard(conf.getShard().get(0))
+                                        .setGtid(Vgtid.CURRENT_GTID)
+                                        .build())
+                        .build());
+
+        BlockingQueue<MessageAndVgtid> consumedMessages = new ArrayBlockingQueue<>(100);
+        AtomicBoolean started = new AtomicBoolean(false);
+        connection.startStreaming(
+                startingVgtid,
+                (message, vgtid, isLastRowEventOfTransaction) -> {
+                    if (!started.get()) {
+                        started.set(true);
+                    }
+                    consumedMessages.add(new MessageAndVgtid(message, vgtid));
+                },
+                error);
+        // Since we are using the "current" as the starting position, there is a race here
+        // if we execute INSERT_STMT before the vstream starts we will never receive the update
+        // therefore, we wait until the stream is setup and then do the insertion
+        Awaitility
+                .await()
+                .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
+                .until(() -> error.get() != null);
+        assertThat(error.get()).isNotNull();
+    }
+
+    @Test
     public void shouldHaveVgtidInResponse() throws Exception {
         // setup fixture
         final VitessConnectorConfig conf = new VitessConnectorConfig(TestHelper.defaultConfig().build());


### PR DESCRIPTION
### Summary

Use the event processing failure handling mode for handling errors appropriately in the VitessReplicationConnection. This is similar to what is done for [Postgres](https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java#L457). We follow the standard behaviors for error/skip/warn/ignore.


### Verification

Add a few integration tests for each branch of error/skip/warn/ignore. Check that the error throwable is set/not set appropriately. Use the example use case of an oversized grpc message to be the guaranteed failure (by setting byte max very low).