### PR TITLE
DBZ-6523 Only use event processing failure handling mode on gRPC size error

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -228,22 +228,22 @@ public class VitessReplicationConnection implements ReplicationConnection {
                         status.getDescription().matches("gRPC message exceeds maximum size.*")) {
                     switch (config.getEventProcessingFailureHandlingMode()) {
                         case FAIL:
-                            LOGGER.error("VStream streaming onError. Status: " + status, t);
+                            LOGGER.error("VStream streaming onError. Status: {}", status, t);
                             // Only propagate the first error
                             error.compareAndSet(null, t);
                             reset();
                             break;
                         case WARN:
-                            LOGGER.warn("VStream streaming onError. Status: " + status, t);
+                            LOGGER.warn("VStream streaming onError. Status: {}", status, t);
                             break;
                         case SKIP:
                         case IGNORE:
-                            LOGGER.debug("VStream streaming onError. Status: " + status, t);
+                            LOGGER.debug("VStream streaming onError. Status: {}", status, t);
                             break;
                     }
                 }
                 else {
-                    LOGGER.error("VStream streaming onError. Status: " + status, t);
+                    LOGGER.error("VStream streaming onError. Status: {}", status, t);
                     // Only propagate the first error
                     error.compareAndSet(null, t);
                     reset();

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -223,20 +223,28 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
             @Override
             public void onError(Throwable t) {
-                switch (config.getEventProcessingFailureHandlingMode()) {
-                    case FAIL:
-                        LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
-                        // Only propagate the first error
-                        error.compareAndSet(null, t);
-                        reset();
-                        break;
-                    case WARN:
-                        LOGGER.warn("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
-                        break;
-                    case SKIP:
-                    case IGNORE:
-                        LOGGER.debug("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
-                        break;
+                if (Status.fromThrowable(t).getDescription().matches("gRPC message exceeds maximum size.*")) {
+                    switch (config.getEventProcessingFailureHandlingMode()) {
+                        case FAIL:
+                            LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                            // Only propagate the first error
+                            error.compareAndSet(null, t);
+                            reset();
+                            break;
+                        case WARN:
+                            LOGGER.warn("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                            break;
+                        case SKIP:
+                        case IGNORE:
+                            LOGGER.debug("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                            break;
+                    }
+                }
+                else {
+                    LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                    // Only propagate the first error
+                    error.compareAndSet(null, t);
+                    reset();
                 }
             }
 

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -223,25 +223,27 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
             @Override
             public void onError(Throwable t) {
-                if (Status.fromThrowable(t).getDescription().matches("gRPC message exceeds maximum size.*")) {
+                Status status = Status.fromThrowable(t);
+                if (status.getCode().equals(Status.Code.RESOURCE_EXHAUSTED) &&
+                        status.getDescription().matches("gRPC message exceeds maximum size.*")) {
                     switch (config.getEventProcessingFailureHandlingMode()) {
                         case FAIL:
-                            LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                            LOGGER.error("VStream streaming onError. Status: " + status, t);
                             // Only propagate the first error
                             error.compareAndSet(null, t);
                             reset();
                             break;
                         case WARN:
-                            LOGGER.warn("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                            LOGGER.warn("VStream streaming onError. Status: " + status, t);
                             break;
                         case SKIP:
                         case IGNORE:
-                            LOGGER.debug("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                            LOGGER.debug("VStream streaming onError. Status: " + status, t);
                             break;
                     }
                 }
                 else {
-                    LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                    LOGGER.error("VStream streaming onError. Status: " + status, t);
                     // Only propagate the first error
                     error.compareAndSet(null, t);
                     reset();


### PR DESCRIPTION
This is also similar to [postgres](https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java#L441) where we match on certain error patterns.

As of right now, we know that grpc message size we should use the processing handling mode setting. But for other errors (e.g., connection unavailable) we should preserve the original behavior (reset the connection).