### PR TITLE
DBZ-6617 Add shard to source

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/vitess/SourceInfo.java
@@ -19,6 +19,7 @@ import io.debezium.relational.TableId;
 public class SourceInfo extends BaseSourceInfo {
     public static final String VGTID_KEY = "vgtid";
     public static final String KEYSPACE_NAME_KEY = "keyspace";
+    public static final String SHARD_KEY = "shard";
 
     private final String keyspace;
 
@@ -28,6 +29,7 @@ public class SourceInfo extends BaseSourceInfo {
     private Instant timestamp;
     // kafka offset topic stores restartVgtid, it is the previous commited transaction vgtid
     private Vgtid restartVgtid;
+    private String shard;
 
     public SourceInfo(VitessConnectorConfig config) {
         super(config);
@@ -47,6 +49,14 @@ public class SourceInfo extends BaseSourceInfo {
 
     protected String keyspace() {
         return keyspace;
+    }
+
+    public String shard() {
+        return shard;
+    }
+
+    public void setShard(String shard) {
+        this.shard = shard;
     }
 
     public TableId getTableId() {

--- a/src/main/java/io/debezium/connector/vitess/VitessOffsetContext.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessOffsetContext.java
@@ -69,6 +69,10 @@ public class VitessOffsetContext extends CommonOffsetContext<SourceInfo> {
         return sourceInfo.getRestartVgtid();
     }
 
+    public void setShard(String shard) {
+        sourceInfo.setShard(shard);
+    }
+
     /**
      * Calculate and return the offset that will be used to create the {@link SourceRecord}.
      *

--- a/src/main/java/io/debezium/connector/vitess/VitessSourceInfoStructMaker.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessSourceInfoStructMaker.java
@@ -23,6 +23,7 @@ public class VitessSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
                 .name("io.debezium.connector.vitess.Source")
                 .field(SourceInfo.KEYSPACE_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.TABLE_NAME_KEY, Schema.STRING_SCHEMA)
+                .field(SourceInfo.SHARD_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.VGTID_KEY, Schema.STRING_SCHEMA)
                 .build();
     }
@@ -37,6 +38,7 @@ public class VitessSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
         final Struct res = super.commonStruct(sourceInfo)
                 .put(SourceInfo.KEYSPACE_NAME_KEY, sourceInfo.keyspace())
                 .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table())
+                .put(SourceInfo.SHARD_KEY, sourceInfo.shard())
                 .put(SourceInfo.VGTID_KEY, sourceInfo.getCurrentVgtid().toString());
         return res;
     }

--- a/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
@@ -114,6 +114,7 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
                 Objects.requireNonNull(tableId);
 
                 offsetContext.event(tableId, message.getCommitTime());
+                offsetContext.setShard(message.getShard());
                 if (isLastRowOfTransaction) {
                     // Right before processing the last row, reset the previous offset to the new vgtid so the last row has the new vgtid as offset.
                     offsetContext.resetVgtid(newVgtid, message.getCommitTime());

--- a/src/main/java/io/debezium/connector/vitess/connection/DdlMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/DdlMessage.java
@@ -42,6 +42,11 @@ public class DdlMessage implements ReplicationMessage {
     }
 
     @Override
+    public String getShard() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<Column> getOldTupleList() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/debezium/connector/vitess/connection/OtherMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/OtherMessage.java
@@ -42,6 +42,11 @@ public class OtherMessage implements ReplicationMessage {
     }
 
     @Override
+    public String getShard() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<Column> getOldTupleList() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
@@ -73,6 +73,8 @@ public interface ReplicationMessage {
 
     String getTable();
 
+    String getShard();
+
     List<Column> getOldTupleList();
 
     List<Column> getNewTupleList();

--- a/src/main/java/io/debezium/connector/vitess/connection/TransactionalMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/TransactionalMessage.java
@@ -42,6 +42,11 @@ public class TransactionalMessage implements ReplicationMessage {
     }
 
     @Override
+    public String getShard() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<Column> getOldTupleList() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -148,6 +148,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
         else {
             String schemaName = schemaTableTuple[0];
             String tableName = schemaTableTuple[1];
+            String shard = rowEvent.getShard();
             int numOfRowChanges = rowEvent.getRowChangesCount();
             int numOfRowChangesEventSeen = 0;
             for (int i = 0; i < numOfRowChanges; i++) {
@@ -155,14 +156,14 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                 numOfRowChangesEventSeen++;
                 boolean isLastRowOfTransaction = isLastRowEventOfTransaction && numOfRowChangesEventSeen == numOfRowChanges ? true : false;
                 if (rowChange.hasAfter() && !rowChange.hasBefore()) {
-                    decodeInsert(rowChange.getAfter(), schemaName, tableName, processor, newVgtid, isLastRowOfTransaction);
+                    decodeInsert(rowChange.getAfter(), schemaName, tableName, shard, processor, newVgtid, isLastRowOfTransaction);
                 }
                 else if (rowChange.hasAfter() && rowChange.hasBefore()) {
                     decodeUpdate(
-                            rowChange.getBefore(), rowChange.getAfter(), schemaName, tableName, processor, newVgtid, isLastRowOfTransaction);
+                            rowChange.getBefore(), rowChange.getAfter(), schemaName, tableName, shard, processor, newVgtid, isLastRowOfTransaction);
                 }
                 else if (!rowChange.hasAfter() && rowChange.hasBefore()) {
-                    decodeDelete(rowChange.getBefore(), schemaName, tableName, processor, newVgtid, isLastRowOfTransaction);
+                    decodeDelete(rowChange.getBefore(), schemaName, tableName, shard, processor, newVgtid, isLastRowOfTransaction);
                 }
                 else {
                     LOGGER.error("{} decodeRow skipped.", vEvent);
@@ -175,6 +176,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                               Row row,
                               String schemaName,
                               String tableName,
+                              String shard,
                               ReplicationMessageProcessor processor,
                               Vgtid newVgtid,
                               boolean isLastRowEventOfTransaction)
@@ -200,6 +202,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                         commitTimestamp,
                         transactionId,
                         tableId.toDoubleQuotedString(),
+                        shard,
                         null,
                         columns),
                 newVgtid,
@@ -211,6 +214,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                               Row newRow,
                               String schemaName,
                               String tableName,
+                              String shard,
                               ReplicationMessageProcessor processor,
                               Vgtid newVgtid,
                               boolean isLastRowEventOfTransaction)
@@ -238,6 +242,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                         commitTimestamp,
                         transactionId,
                         tableId.toDoubleQuotedString(),
+                        shard,
                         oldColumns,
                         newColumns),
                 newVgtid,
@@ -248,6 +253,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                               Row row,
                               String schemaName,
                               String tableName,
+                              String shard,
                               ReplicationMessageProcessor processor,
                               Vgtid newVgtid,
                               boolean isLastRowOfTransaction)
@@ -274,6 +280,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                         commitTimestamp,
                         transactionId,
                         tableId.toDoubleQuotedString(),
+                        shard,
                         columns,
                         null),
                 newVgtid,

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputReplicationMessage.java
@@ -18,6 +18,7 @@ public class VStreamOutputReplicationMessage implements ReplicationMessage {
     private final Instant commitTimestamp;
     private final String transactionId;
     private final String table;
+    private final String shard;
     private final List<Column> oldColumns;
     private final List<Column> newColumns;
 
@@ -26,12 +27,14 @@ public class VStreamOutputReplicationMessage implements ReplicationMessage {
                                            Instant commitTimestamp,
                                            String transactionId,
                                            String table,
+                                           String shard,
                                            List<Column> oldColumns,
                                            List<Column> newColumns) {
         this.op = op;
         this.commitTimestamp = commitTimestamp;
         this.transactionId = transactionId;
         this.table = table;
+        this.shard = shard;
         this.oldColumns = oldColumns;
         this.newColumns = newColumns;
     }
@@ -54,6 +57,11 @@ public class VStreamOutputReplicationMessage implements ReplicationMessage {
     @Override
     public String getTable() {
         return table;
+    }
+
+    @Override
+    public String getShard() {
+        return shard;
     }
 
     @Override

--- a/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
@@ -59,6 +59,7 @@ public class SourceInfoTest {
                                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2))),
                 Instant.ofEpochMilli(1000));
         source.setTableId(new TableId("c", "s", "t"));
+        source.setShard(TEST_SHARD);
         source.setSnapshot(SnapshotRecord.FALSE);
     }
 
@@ -82,6 +83,11 @@ public class SourceInfoTest {
     @Test
     public void vgtidKeyspaceIsPresent() {
         assertThat(source.struct().getString(SourceInfo.VGTID_KEY)).isEqualTo(VGTID_JSON);
+    }
+
+    @Test
+    public void shardIsPresent() {
+        assertThat(source.struct().getString(SourceInfo.SHARD_KEY)).isEqualTo(TEST_SHARD);
     }
 
     @Test
@@ -123,6 +129,7 @@ public class SourceInfoTest {
                 .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("keyspace", Schema.STRING_SCHEMA)
                 .field("table", Schema.STRING_SCHEMA)
+                .field("shard", Schema.STRING_SCHEMA)
                 .field("vgtid", Schema.STRING_SCHEMA)
                 .build();
 

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -279,6 +279,7 @@ public class TestHelper {
                         Binlogdata.RowEvent.newBuilder()
                                 .addRowChanges(Binlogdata.RowChange.newBuilder().setAfter(row).build())
                                 .setTableName(TEST_VITESS_FULL_TABLE)
+                                .setShard(TEST_SHARD)
                                 .build())
                 .setTimestamp(AnonymousValue.getLong())
                 .build();

--- a/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
@@ -99,6 +99,7 @@ public class VitessBigIntUnsignedTest {
                 AnonymousValue.getString(),
                 new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE)
                         .toDoubleQuotedString(),
+                TestHelper.TEST_SHARD,
                 null,
                 defaultRelationMessageColumns(mode));
 

--- a/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
@@ -51,6 +51,7 @@ public class VitessChangeRecordEmitterTest {
                 AnonymousValue.getString(),
                 new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE)
                         .toDoubleQuotedString(),
+                AnonymousValue.getString(),
                 null,
                 TestHelper.defaultRelationMessageColumns());
 
@@ -78,6 +79,7 @@ public class VitessChangeRecordEmitterTest {
                 AnonymousValue.getString(),
                 new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE)
                         .toDoubleQuotedString(),
+                AnonymousValue.getString(),
                 TestHelper.defaultRelationMessageColumns(),
                 null);
 
@@ -105,6 +107,7 @@ public class VitessChangeRecordEmitterTest {
                 AnonymousValue.getString(),
                 new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE)
                         .toDoubleQuotedString(),
+                AnonymousValue.getString(),
                 TestHelper.defaultRelationMessageColumns(),
                 TestHelper.defaultRelationMessageColumns());
 

--- a/src/test/java/io/debezium/connector/vitess/VitessSourceInfoStructMakerTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessSourceInfoStructMakerTest.java
@@ -42,6 +42,8 @@ public class VitessSourceInfoStructMakerTest {
 
         assertThat(structMaker.schema().field(SourceInfo.KEYSPACE_NAME_KEY).schema())
                 .isEqualTo(Schema.STRING_SCHEMA);
+        assertThat(structMaker.schema().field(SourceInfo.SHARD_KEY).schema())
+                .isEqualTo(Schema.STRING_SCHEMA);
         assertThat(structMaker.schema().field(SourceInfo.TABLE_NAME_KEY).schema())
                 .isEqualTo(Schema.STRING_SCHEMA);
         assertThat(structMaker.schema().field(SourceInfo.VGTID_KEY).schema())
@@ -54,6 +56,7 @@ public class VitessSourceInfoStructMakerTest {
         // setup fixture
         String schemaName = "test_schema";
         String tableName = "test_table";
+        String shard = TEST_SHARD;
         SourceInfo sourceInfo = new SourceInfo(new VitessConnectorConfig(TestHelper.defaultConfig().build()));
         sourceInfo.resetVgtid(
                 Vgtid.of(
@@ -62,6 +65,7 @@ public class VitessSourceInfoStructMakerTest {
                                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2))),
                 AnonymousValue.getInstant());
         sourceInfo.setTableId(new TableId(null, schemaName, tableName));
+        sourceInfo.setShard(shard);
         sourceInfo.setTimestamp(AnonymousValue.getInstant());
 
         // exercise SUT
@@ -76,6 +80,7 @@ public class VitessSourceInfoStructMakerTest {
         // verify outcome
         assertThat(struct.getString(SourceInfo.KEYSPACE_NAME_KEY)).isEqualTo(TestHelper.TEST_UNSHARDED_KEYSPACE);
         assertThat(struct.getString(SourceInfo.TABLE_NAME_KEY)).isEqualTo(tableName);
+        assertThat(struct.getString(SourceInfo.SHARD_KEY)).isEqualTo(shard);
         assertThat(struct.getString(SourceInfo.VGTID_KEY)).isEqualTo(VGTID_JSON);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
@@ -231,6 +231,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
                     assertThat(message.getOperation()).isEqualTo(ReplicationMessage.Operation.INSERT);
                     assertThat(message.getOldTupleList()).isNull();
+                    assertThat(message.getShard()).isEqualTo(TestHelper.TEST_SHARD);
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                     processed[0] = true;
                 },


### PR DESCRIPTION
Add shard to source which is present in row events. Allows downstream users to determine what shard this event is for (we already include keyspace/table so we also include the shard). More context in [DBZ-6617](https://issues.redhat.com/browse/DBZ-6617).