### PR TITLE
DBZ-6680 Add setting to disable transaction topic

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -295,6 +295,16 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                             + "'false' (the default) omits the fields; "
                             + "'true' converts the field into an implementation dependent binary representation.");
 
+    public static final Field ENABLE_TRANSACTION_TOPIC = Field.create("enable.transaction.topic")
+            .withDisplayName("Disable publishing to transaction topic")
+            .withType(Type.BOOLEAN)
+            .withDefault(true)
+            .withWidth(Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription(
+                    "When 'provide.transaaction.metadata' is true, this setting toggles publishing transaction " +
+                            "metadata to the topic in 'topic.transactoin'");
+
     public static final Field OFFSET_STORAGE_PER_TASK = Field.create(VITESS_CONFIG_GROUP_PREFIX + "offset.storage.per.task")
             .withDisplayName("Store offsets per task")
             .withType(Type.BOOLEAN)
@@ -549,6 +559,10 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getBoolean(INCLUDE_UNKNOWN_DATATYPES);
     }
 
+    public boolean isTransactionTopicEnabled() {
+        return getConfig().getBoolean(ENABLE_TRANSACTION_TOPIC);
+    }
+
     public boolean offsetStoragePerTask() {
         return getConfig().getBoolean(OFFSET_STORAGE_PER_TASK);
     }
@@ -582,4 +596,5 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         return BigIntUnsignedHandlingMode.parse(getConfig().getString(BIGINT_UNSIGNED_HANDLING_MODE),
                 BIGINT_UNSIGNED_HANDLING_MODE.defaultValueAsString());
     }
+
 }

--- a/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
@@ -94,11 +94,11 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
             if (message.isTransactionalMessage()) {
                 // Tx BEGIN/END event
                 offsetContext.rotateVgtid(newVgtid, message.getCommitTime());
-                if (message.getOperation() == ReplicationMessage.Operation.BEGIN) {
+                if (message.getOperation() == ReplicationMessage.Operation.BEGIN && connectorConfig.isTransactionTopicEnabled()) {
                     // send to transaction topic
                     dispatcher.dispatchTransactionStartedEvent(partition, message.getTransactionId(), offsetContext, message.getCommitTime());
                 }
-                else if (message.getOperation() == ReplicationMessage.Operation.COMMIT) {
+                else if (message.getOperation() == ReplicationMessage.Operation.COMMIT && connectorConfig.isTransactionTopicEnabled()) {
                     // send to transaction topic
                     dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext, message.getCommitTime());
                 }


### PR DESCRIPTION
This is an initial version. There are a few parts we need to address mentioned in https://issues.redhat.com/browse/DBZ-6680

This handles disabling the transaction topic. However, we may want to do this in debezium-core, if we want to support this for all connectors. ie also a  check a common setting here https://github.com/debezium/debezium/blob/main/debezium-core/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java#L135