### PR TITLE
DBZ-6748 Make VARCHAR binary collation field types have a VitessType of VARCHAR

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -101,9 +101,6 @@ public class VitessType {
                 if (field.getColumnType().toUpperCase().contains("VARCHAR")) {
                     return new VitessType(type, Types.VARCHAR);
                 }
-                else {
-                    return new VitessType(type, Types.BINARY);
-                }
             case "BINARY":
                 return new VitessType(type, Types.BINARY);
             case "UINT64":

--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -100,7 +100,8 @@ public class VitessType {
             case "VARBINARY":
                 if (field.getColumnType().toUpperCase().contains("VARCHAR")) {
                     return new VitessType(type, Types.VARCHAR);
-                } else {
+                }
+                else {
                     return new VitessType(type, Types.BINARY);
                 }
             case "BINARY":

--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -98,6 +98,11 @@ public class VitessType {
             case "BLOB":
                 return new VitessType(type, Types.BLOB);
             case "VARBINARY":
+                if (field.getColumnType().toUpperCase().contains("VARCHAR")) {
+                    return new VitessType(type, Types.VARCHAR);
+                } else {
+                    return new VitessType(type, Types.BINARY);
+                }
             case "BINARY":
                 return new VitessType(type, Types.BINARY);
             case "UINT64":

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -610,16 +610,16 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         String varbinaryColumn = "varbinary_col";
         String expectedVarchar = "foo";
         String query = String.format("INSERT INTO character_set_collate_table (%s, %s, %s, %s, %s) VALUES (\"%s\", \"%s\", \"%s\", \"%s\", \"%s\");",
-            varcharCharacterSetCollateColumnAsciiBin,
-            varcharCharacterSetCollateColumnAscii,
-            varcharCharacterSetCollateColumnLatin1Bin,
-            varcharColumn,
-            varbinaryColumn,
-            expectedVarchar,
-            expectedVarchar,
-            expectedVarchar,
-            expectedVarchar,
-            expectedVarchar);
+                varcharCharacterSetCollateColumnAsciiBin,
+                varcharCharacterSetCollateColumnAscii,
+                varcharCharacterSetCollateColumnLatin1Bin,
+                varcharColumn,
+                varbinaryColumn,
+                expectedVarchar,
+                expectedVarchar,
+                expectedVarchar,
+                expectedVarchar,
+                expectedVarchar);
         SourceRecord record = assertInsert(query, null, TEST_SHARDED_KEYSPACE, null, hasMultipleShards);
         Struct recordValueStruct = (Struct) record.value();
         Struct afterStruct = (Struct) recordValueStruct.get("after");
@@ -797,7 +797,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         // Remove system tables starts with _
         tables = tables.stream().filter(t -> !t.startsWith("_")).collect(Collectors.toSet());
         List<String> expectedTables = Arrays.asList("my_seq", "t1",
-                "numeric_table", "string_table","character_set_collate_table","enum_table", "set_table", "time_table",
+                "numeric_table", "string_table", "character_set_collate_table", "enum_table", "set_table", "time_table",
                 "no_pk_table", "pk_single_unique_key_table", "no_pk_multi_unique_keys_table",
                 "no_pk_multi_comp_unique_keys_table", "comp_pk_table");
         assertEquals(new HashSet<>(expectedTables), tables);

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -116,3 +116,15 @@ CREATE TABLE comp_pk_table
     int_col2        INT,
     PRIMARY KEY (id, int_col)
 );
+
+
+DROP TABLE IF EXISTS character_set_collate_table;
+CREATE TABLE character_set_collate_table
+(
+    id                                                   BIGINT NOT NULL,
+    `varchar_character_set_ascii_collate_ascii_bin_col`      VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    `varchar_character_set_ascii_collate_ascii_col`          VARCHAR(32) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    `varchar_character_set_ascii_collate_latin1_bin_col`     VARCHAR(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+    `varchar_col`                                            VARCHAR(32) NOT NULL,
+    `varbinary_col`                                          VARBINARY(32) NOT NULL
+);

--- a/src/test/resources/vitess_vschema.json
+++ b/src/test/resources/vitess_vschema.json
@@ -125,6 +125,18 @@
         "column": "id",
         "sequence": "my_seq"
       }
+    },
+    "character_set_collate_table": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ],
+      "autoIncrement": {
+        "column": "id",
+        "sequence": "my_seq"
+      }
     }
   }
 }


### PR DESCRIPTION
For VARCHAR columns with a binary collate function (ends in `_bin`) the SourceRecord output type is `BYTES`. In order to stay consistent with the [documentation](https://debezium.io/documentation/reference/stable/connectors/vitess.html#vitess-basic-types) and how [MySQL](https://debezium.io/documentation/reference/stable/connectors/vitess.html#vitess-basic-types) connector handles this, we need to ensure that we have an output type of `STRING`. Add the additional logic needed to do this. There are two cases when QUERY.FIELD type is a VARBINARY
1. The column type may be varchar (this is a varchar column with binary collation) in which case return varchar type
2. Column type is not varchar (e.g., a typical varbinary column), then fall through to next case and return varbinary as usual