### PR TITLE
DBZ-6775 Apply schema changes per shard

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/Filters.java
+++ b/src/main/java/io/debezium/connector/vitess/Filters.java
@@ -28,8 +28,8 @@ public class Filters {
         // Define the filter using the include/exclude list for table names ...
         this.tableFilter = Tables.TableFilter.fromPredicate(
                 Selectors.tableSelector()
-                        .includeTables(config.tableIncludeList())
-                        .excludeTables(config.tableExcludeList())
+                        .includeTables(config.tableIncludeList(), new VitessTableIdToStringMapper())
+                        .excludeTables(config.tableExcludeList(), new VitessTableIdToStringMapper())
                         .excludeSchemas(SYSTEM_SCHEMA_EXCLUDE_LIST)
                         .build());
     }

--- a/src/main/java/io/debezium/connector/vitess/VitessDatabaseSchema.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessDatabaseSchema.java
@@ -84,4 +84,18 @@ public class VitessDatabaseSchema extends RelationalDatabaseSchema {
     public static TableId parse(String table) {
         return TableId.parse(table, false);
     }
+
+    /**
+     * Create a TableId where we use the shard name as the catalog name.
+     * This is needed to ensure that schema updates are applied to each shard individually.
+     * This is used in conjunction with {@link VitessTableIdToStringMapper} which excludes the shard/catalog name when
+     * determining if a table is in the include/exclude list.
+     * @param shard The shard of the table ID to build
+     * @param keyspace The keyspace of the table ID to build
+     * @param table The table name of the tbale ID to build
+     * @return TableId with shard (as catalog), keyspace (as schema), and table
+     */
+    public static TableId buildTableId(String shard, String keyspace, String table) {
+        return new TableId(shard, keyspace, table);
+    }
 }

--- a/src/main/java/io/debezium/connector/vitess/VitessTableIdToStringMapper.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessTableIdToStringMapper.java
@@ -1,0 +1,21 @@
+package io.debezium.connector.vitess;
+
+import io.debezium.relational.Selectors.TableIdToStringMapper;
+import io.debezium.relational.TableId;
+
+public class VitessTableIdToStringMapper implements TableIdToStringMapper {
+
+    /**
+     * Convert a table ID to the string used for table filtering.
+     *
+     * Since TableIDs include the shard as the catalog, the returned string used for include/exclude must exclude
+     * this shard such that we apply inclusion & exclusion logic uniformly across all shards.
+     * @param tableId {@link TableId} to convert to string
+     * @return String representation of the table
+     */
+    @Override
+    public String toString(TableId tableId) {
+        return tableId.schema() + "." + tableId.table();
+    }
+
+}

--- a/src/main/java/io/debezium/connector/vitess/VitessTableIdToStringMapper.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessTableIdToStringMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.connector.vitess;
 
 import io.debezium.relational.Selectors.TableIdToStringMapper;

--- a/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
@@ -24,7 +24,6 @@ import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
 import io.debezium.connector.vitess.connection.VStreamOutputReplicationMessage;
 import io.debezium.data.Envelope;
 import io.debezium.relational.Table;
-import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.schema.SchemaNameAdjuster;
@@ -89,7 +88,7 @@ public class VitessBigIntUnsignedTest {
         decoder = new VStreamOutputMessageDecoder(schema);
         // initialize schema by FIELD event
         decoder.processMessage(TestHelper.newFieldEvent(defaultColumnValues(mode)), null, null, false);
-        Table table = schema.tableFor(new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE));
+        Table table = schema.tableFor(TestHelper.defaultTableId());
         assertThat(table.columnWithName("bigint_unsigned_col").jdbcType() == Types.BIGINT);
 
         // setup fixture
@@ -97,8 +96,7 @@ public class VitessBigIntUnsignedTest {
                 ReplicationMessage.Operation.INSERT,
                 AnonymousValue.getInstant(),
                 AnonymousValue.getString(),
-                new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE)
-                        .toDoubleQuotedString(),
+                TestHelper.defaultTableId().toDoubleQuotedString(),
                 TestHelper.TEST_SHARD,
                 null,
                 defaultRelationMessageColumns(mode));

--- a/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
@@ -17,7 +17,6 @@ import io.debezium.connector.vitess.connection.TransactionalMessage;
 import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
 import io.debezium.connector.vitess.connection.VStreamOutputReplicationMessage;
 import io.debezium.data.Envelope;
-import io.debezium.relational.TableId;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.spi.topic.TopicNamingStrategy;
@@ -49,8 +48,7 @@ public class VitessChangeRecordEmitterTest {
                 ReplicationMessage.Operation.INSERT,
                 AnonymousValue.getInstant(),
                 AnonymousValue.getString(),
-                new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE)
-                        .toDoubleQuotedString(),
+                TestHelper.defaultTableId().toDoubleQuotedString(),
                 AnonymousValue.getString(),
                 null,
                 TestHelper.defaultRelationMessageColumns());
@@ -77,8 +75,7 @@ public class VitessChangeRecordEmitterTest {
                 ReplicationMessage.Operation.DELETE,
                 AnonymousValue.getInstant(),
                 AnonymousValue.getString(),
-                new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE)
-                        .toDoubleQuotedString(),
+                TestHelper.defaultTableId().toDoubleQuotedString(),
                 AnonymousValue.getString(),
                 TestHelper.defaultRelationMessageColumns(),
                 null);
@@ -105,8 +102,7 @@ public class VitessChangeRecordEmitterTest {
                 ReplicationMessage.Operation.UPDATE,
                 AnonymousValue.getInstant(),
                 AnonymousValue.getString(),
-                new TableId(null, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE)
-                        .toDoubleQuotedString(),
+                TestHelper.defaultTableId().toDoubleQuotedString(),
                 AnonymousValue.getString(),
                 TestHelper.defaultRelationMessageColumns(),
                 TestHelper.defaultRelationMessageColumns());


### PR DESCRIPTION
Schema changes happen per shard, so we should update the schemas accordingly in order to allow for us to correctly decode messages received for each shard without errors. First, add tests to reproduce the issues seen in [DBZ-6775](https://issues.redhat.com/browse/DBZ-6775)/[Zulip](https://debezium.zulipchat.com/#narrow/stream/348255-community-vitess/topic/Vitess.20Connector.20Error), then add the logic needed to resolve this. We add shard as a catalog, and use table string mapper to ensure our include/exclude list doesn't use this catalog/shard value, and we only use it for storing schemas.

Note: I looked into a way around not using the catalog variable as the shard. It seems quite complex to avoid this. There were a couple approaches I evaluated that ended up not being feasible:
1. Instead only store table IDs with a keyspace & table name, and then have a wrapper class that maps shards to `VitessDatabaseSchemas`
 - This means we aren't storing the shard as the catalog. However, when we first create the [dispatcher](https://github.com/debezium/debezium-connector-vitess/blob/main/src/main/java/io/debezium/connector/vitess/VitessConnectorTask.java#L95) we need to give it the database schema it will use for filtering/retrieving schemas. Therefore the table ID that is sent on the [dispatch call](https://github.com/debezium/debezium/blob/main/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java#L252) must have the shard information represented in it. So we cannot avoid using catalog as shard in this approach (or some other method e.g, concatenating shard to keyspace)
2. Make a custom data collection ID implementation (e..g, `VitessTableId` that has shard info represented)
- This is the idea based on the above learning that we need shard to be represented by the table ID in order for the dispatcher to use it correctly. So we could implement the interface for [DataCollectionId](https://github.com/debezium/debezium/blob/main/debezium-api/src/main/java/io/debezium/spi/schema/DataCollectionId.java) and have a properly constructed Id with fields for shard/keyspace/table. The issue here that we use several other classes which rely on us using the standard TableId and TableImpl (e.g., RelationalDatabaseSchema, Tables.java, etc.). There is lots of shared code from debezium-core that we use because we are a standard table/relational connector. We would need to reimplement all that.