### PR TITLE
DBZ-6800 Add TableTopicNamingStrategy

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/TableTopicNamingStrategy.java
+++ b/src/main/java/io/debezium/connector/vitess/TableTopicNamingStrategy.java
@@ -5,12 +5,12 @@
  */
 package io.debezium.connector.vitess;
 
+import java.util.Properties;
+
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Collect;
-
-import java.util.Properties;
 
 /**
  * Topic naming strategy where only the table name is added. This is used to avoid including

--- a/src/main/java/io/debezium/connector/vitess/TableTopicNamingStrategy.java
+++ b/src/main/java/io/debezium/connector/vitess/TableTopicNamingStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.relational.TableId;
+import io.debezium.schema.AbstractTopicNamingStrategy;
+import io.debezium.util.Collect;
+
+import java.util.Properties;
+
+/**
+ * Topic naming strategy where only the table name is added. This is used to avoid including
+ * the shard which is now part of the catalog of the table ID and would be included if
+ * the DefaultTopicNamingStrategy is being used.
+ */
+public class TableTopicNamingStrategy extends AbstractTopicNamingStrategy<TableId> {
+
+    public TableTopicNamingStrategy(Properties props) {
+        super(props);
+    }
+
+    public static TableTopicNamingStrategy create(CommonConnectorConfig config) {
+        return new TableTopicNamingStrategy(config.getConfig().asProperties());
+    }
+
+    @Override
+    public String dataChangeTopic(TableId id) {
+        String topicName = mkString(Collect.arrayListOf(prefix, id.table()), delimiter);
+        return topicNames.computeIfAbsent(id, t -> sanitizedTopicName(topicName));
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
@@ -6,13 +6,14 @@
 
 package io.debezium.connector.vitess;
 
-import io.debezium.relational.TableId;
-import io.debezium.spi.topic.TopicNamingStrategy;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+import io.debezium.relational.TableId;
+import io.debezium.spi.topic.TopicNamingStrategy;
 
 public class TableTopicNamingStrategyTest {
 
@@ -22,7 +23,7 @@ public class TableTopicNamingStrategyTest {
         final Properties props = new Properties();
         props.put("topic.delimiter", ".");
         props.put("topic.prefix", "prefix");
-        TopicNamingStrategy strategy =  new TableTopicNamingStrategy(props);
+        TopicNamingStrategy strategy = new TableTopicNamingStrategy(props);
         String topicName = strategy.dataChangeTopic(tableId);
         assertThat(topicName).isEqualTo("prefix.table");
     }

--- a/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import io.debezium.relational.TableId;
+import io.debezium.spi.topic.TopicNamingStrategy;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TableTopicNamingStrategyTest {
+
+    @Test
+    public void shouldGetTopicNameWithoutShard() {
+        TableId tableId = new TableId("shard", "keyspace", "table");
+        final Properties props = new Properties();
+        props.put("topic.delimiter", ".");
+        props.put("topic.prefix", "prefix");
+        TopicNamingStrategy strategy =  new TableTopicNamingStrategy(props);
+        String topicName = strategy.dataChangeTopic(tableId);
+        assertThat(topicName).isEqualTo("prefix.table");
+    }
+
+}


### PR DESCRIPTION
See [DBZ-6800](https://issues.redhat.com/browse/DBZ-6800) for more details

Add a topic naming strategy that can remove the shard information for users of the vitess connector. Also maintain parity with previous versions such that users do not need to change their topic.prefix and lose connector state.