### PR TITLE
DBZ-6830 Switch INFO level to DEBUG for partial & multi-response transactions

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -185,11 +185,11 @@ public class VitessReplicationConnection implements ReplicationConnection {
                 // We only proceed when we receive a complete transaction after seeing both BEGIN and COMMIT events,
                 // OR if sendNow flag is true (meaning we should process buffered events immediately).
                 if ((!beginEventSeen || !commitEventSeen) && !sendNow) {
-                    LOGGER.info("Received partial transaction: number of responses so far is {}", numResponses);
+                    LOGGER.debug("Received partial transaction: number of responses so far is {}", numResponses);
                     return;
                 }
                 if (numResponses > 1) {
-                    LOGGER.info("Processing multi-response transaction: number of responses is {}", numResponses);
+                    LOGGER.debug("Processing multi-response transaction: number of responses is {}", numResponses);
                 }
                 if (newVgtid == null) {
                     LOGGER.warn("Skipping because no vgtid is found in buffered event types: {}",


### PR DESCRIPTION
See https://issues.redhat.com/browse/DBZ-6830 these logs can be very frequent for large keyspaces with many multi-response/partial transactions and clutter the logs. Similar to other logic in this class, if a log message could be logged for each message received, it should be a debug level log not info.