### PR TITLE
DBZ-6852 Always fail/reset GRPC channel on error

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -223,7 +223,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
             @Override
             public void onError(Throwable t) {
-                LOGGER.info("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
                 // Only propagate the first error
                 error.compareAndSet(null, t);
                 reset();

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -223,7 +223,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
             @Override
             public void onError(Throwable t) {
-                LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                LOGGER.error("VStream streaming onError. Status: {}", Status.fromThrowable(t), t);
                 // Only propagate the first error
                 error.compareAndSet(null, t);
                 reset();

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -223,31 +223,10 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
             @Override
             public void onError(Throwable t) {
-                Status status = Status.fromThrowable(t);
-                if (status.getCode().equals(Status.Code.RESOURCE_EXHAUSTED) &&
-                        status.getDescription().matches("gRPC message exceeds maximum size.*")) {
-                    switch (config.getEventProcessingFailureHandlingMode()) {
-                        case FAIL:
-                            LOGGER.error("VStream streaming onError. Status: {}", status, t);
-                            // Only propagate the first error
-                            error.compareAndSet(null, t);
-                            reset();
-                            break;
-                        case WARN:
-                            LOGGER.warn("VStream streaming onError. Status: {}", status, t);
-                            break;
-                        case SKIP:
-                        case IGNORE:
-                            LOGGER.debug("VStream streaming onError. Status: {}", status, t);
-                            break;
-                    }
-                }
-                else {
-                    LOGGER.error("VStream streaming onError. Status: {}", status, t);
-                    // Only propagate the first error
-                    error.compareAndSet(null, t);
-                    reset();
-                }
+                LOGGER.info("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+                // Only propagate the first error
+                error.compareAndSet(null, t);
+                reset();
             }
 
             @Override

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -52,7 +52,7 @@ public class VitessReplicationConnectionIT {
     }
 
     @Test
-    public void shouldNotErrorOutWhenSkipEnabled() throws Exception {
+    public void shouldErrorOutWhenSkipEnabled() throws Exception {
         // setup fixture
         final LogInterceptor logInterceptor = new LogInterceptor(VitessReplicationConnection.class);
         logInterceptor.setLoggerLevel(VitessReplicationConnection.class, Level.DEBUG);
@@ -92,12 +92,12 @@ public class VitessReplicationConnectionIT {
         Awaitility
                 .await()
                 .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
-                .until(() -> logInterceptor.containsMessage("VStream streaming onError"));
-        assertThat(error.get()).isNull();
+                .until(() -> error.get() != null);
+        assertThat(error.get()).isNotNull();
     }
 
     @Test
-    public void shouldNotErrorOutWhenWarnEnabled() throws Exception {
+    public void shouldErrorOutWhenWarnEnabled() throws Exception {
         // setup fixture
         final LogInterceptor logInterceptor = new LogInterceptor(VitessReplicationConnection.class);
         final VitessConnectorConfig conf = new VitessConnectorConfig(
@@ -136,8 +136,8 @@ public class VitessReplicationConnectionIT {
         Awaitility
                 .await()
                 .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
-                .until(() -> logInterceptor.containsWarnMessage("VStream streaming onError"));
-        assertThat(error.get()).isNull();
+                .until(() -> error.get() != null);
+        assertThat(error.get()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
It is not possible to skip messages if they are over the [max inbound message size](https://grpc.github.io/grpc-java/javadoc/io/grpc/ManagedChannelBuilder.html#maxInboundMessageSize(int)) on the channel. If an error is received, the channel doesn't continue streaming, so we should always error out and reset.