### PR TITLE
DBZ-6939 Retry on NOT_FOUND status code for down/nonexistent tablet

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
@@ -33,6 +33,11 @@ public class VitessErrorHandler extends ErrorHandler {
                         return true;
                     }
                     return false;
+                case NOT_FOUND:
+                    if (description != null && description.contains("either down or nonexistent")) {
+                        return true;
+                    }
+                    return false;
                 case UNAVAILABLE:
                     return true;
                 case UNKNOWN:

--- a/src/test/java/io/debezium/connector/vitess/VitessErrorHandlerTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessErrorHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+public class VitessErrorHandlerTest {
+
+    @Test
+    public void shouldRetryCancelledOnClosedClient() {
+        Status status = Status.CANCELLED.withDescription("target: byuser.-4000.master: vttablet: rpc error: code = " +
+                "Canceled desc = grpc: the client connection is closing");
+        StatusRuntimeException notFoundException = new StatusRuntimeException(status);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isTrue();
+    }
+
+    @Test
+    public void shouldNotRetryCancelledWithOtherDescription() {
+        Status status = Status.CANCELLED.withDescription("any other cancel");
+        StatusRuntimeException notFoundException = new StatusRuntimeException(status);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isFalse();
+    }
+
+    @Test
+    public void shouldNotRetryCancelled() {
+        Status status = Status.CANCELLED;
+        StatusRuntimeException notFoundException = new StatusRuntimeException(status);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isFalse();
+    }
+
+    @Test
+    public void shouldRetryNotFoundWithTabletDownDescription() {
+        Status status = Status.NOT_FOUND.withDescription("tablet: cell:\"cell_1\" uid:123 is either down or nonexistent");
+        StatusRuntimeException notFoundException = new StatusRuntimeException(status);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isTrue();
+    }
+
+    @Test
+    public void shouldNotRetryNotFound() {
+        StatusRuntimeException notFoundException = new StatusRuntimeException(Status.NOT_FOUND);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isFalse();
+    }
+
+    @Test
+    public void shouldRetryUnavailable() {
+        StatusRuntimeException notFoundException = new StatusRuntimeException(Status.UNAVAILABLE);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isTrue();
+    }
+
+    @Test
+    public void shouldRetryUnknownWithStreamTimeoutDescription() {
+        Status status = Status.UNKNOWN.withDescription("stream timeout");
+        StatusRuntimeException notFoundException = new StatusRuntimeException(status);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isTrue();
+    }
+
+    @Test
+    public void shouldRetryUnknownWithStreamEndedUnexpectedly() {
+        Status status = Status.UNKNOWN.withDescription("vstream ended unexpectedly");
+        StatusRuntimeException notFoundException = new StatusRuntimeException(status);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isTrue();
+    }
+
+    @Test
+    public void shouldNotRetryUnknown() {
+        Status status = Status.UNKNOWN;
+        StatusRuntimeException notFoundException = new StatusRuntimeException(status);
+        VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
+        assertThat(vitessErrorHandler.isRetriable(notFoundException)).isFalse();
+    }
+
+}


### PR DESCRIPTION
Add case to retry on NOT_FOUND status code for down/nonexistent. Also add unit test to make this testable for vitess error handler (and backfill other test cases).

We want to retry to connect in case that tablet is temporarily down/nonexistent, i.e., retry for this exception:

```
2023-09-15 20:01:22,367 ERROR  ||  WorkerSourceTask{id=byuser-connector-23} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted   [org.apache.kafka.connect.runtime.WorkerTask]
org.apache.kafka.connect.errors.ConnectException: An exception occurred in the change event producer. This connector will be stopped.
        at io.debezium.pipeline.ErrorHandler.setProducerThrowable(ErrorHandler.java:72)
        at io.debezium.connector.vitess.VitessStreamingChangeEventSource.execute(VitessStreamingChangeEventSource.java:78)
        at io.debezium.connector.vitess.VitessStreamingChangeEventSource.execute(VitessStreamingChangeEventSource.java:29)
        at io.debezium.pipeline.ChangeEventSourceCoordinator.streamEvents(ChangeEventSourceCoordinator.java:205)
        at io.debezium.pipeline.ChangeEventSourceCoordinator.executeChangeEventSources(ChangeEventSourceCoordinator.java:172)
        at io.debezium.pipeline.ChangeEventSourceCoordinator.lambda$start$0(ChangeEventSourceCoordinator.java:118)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.grpc.StatusRuntimeException: NOT_FOUND: tablet: cell:"us_east_1e" uid:300240074 is either down or nonexistent
        at io.grpc.Status.asRuntimeException(Status.java:533)
        at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:478)
        at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:463)
        at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:427)
        at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:460)
        at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:616)
        at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:69)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:802)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:781)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        ... 3 more
2023-09-15 20:01:22,367 INFO   ||  Stopping down connector   [io.debezium.connector.common.BaseSourceTask] 
```