### PR TITLE
DBZ-6944 Retry all StatusRuntimeException, use super method on others

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
@@ -23,34 +23,9 @@ public class VitessErrorHandler extends ErrorHandler {
     protected boolean isRetriable(Throwable throwable) {
         if (throwable instanceof StatusRuntimeException) {
             final StatusRuntimeException exception = (StatusRuntimeException) throwable;
-            final String description = exception.getStatus().getDescription();
-            LOGGER.info("Exception code: {} and description: {}", exception.getStatus().getCode(), description);
-            switch (exception.getStatus().getCode()) {
-                case CANCELLED:
-                    // Try to match this description string:
-                    // description=target: byuser.-4000.master: vttablet: rpc error: code = Canceled desc = grpc: the client connection is closing
-                    if (description != null && description.contains("client connection is closing")) {
-                        return true;
-                    }
-                    return false;
-                case NOT_FOUND:
-                    if (description != null && description.contains("either down or nonexistent")) {
-                        return true;
-                    }
-                    return false;
-                case UNAVAILABLE:
-                    return true;
-                case UNKNOWN:
-                    // Stream timeout error due to idle VStream or vstream ended unexpectedly.
-                    if (description != null &&
-                            (description.equals("stream timeout") ||
-                                    description.contains("vstream ended unexpectedly") ||
-                                    description.contains("unexpected server EOF"))) {
-                        return true;
-                    }
-                    return false;
-            }
+            LOGGER.error("Exception status: {}", exception.getStatus(), exception);
+            return true;
         }
-        return false;
+        return super.isRetriable(throwable);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessErrorHandlerTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessErrorHandlerTest.java
@@ -27,8 +27,8 @@ public class VitessErrorHandlerTest {
         StatusRuntimeException notFoundException = new StatusRuntimeException(status);
         VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(null, null, null);
         vitessErrorHandler.isRetriable(notFoundException);
-        assertThat(logInterceptor.containsMessage(expectedStatusCodeString)).isTrue();
-        assertThat(logInterceptor.containsMessage(expectedDescription)).isTrue();
+        assertThat(logInterceptor.containsErrorMessage(expectedStatusCodeString)).isTrue();
+        assertThat(logInterceptor.containsErrorMessage(expectedDescription)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
We should retry on all StatusRuntimeException which are a catch all for all errors from the vstream grpc go client.

For throwables that are not that, we can use the super method (retries on IO exceptions only), same as other Debezium connectors (e.g., mysql).