### PR TITLE
DBZ-7050 Add automatic retry for snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>3.24.4</version>
+        </dependency>
+        <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-embedded</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -246,11 +246,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java-util</artifactId>
-            <version>3.24.4</version>
-        </dependency>
-        <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-embedded</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/debezium/connector/vitess/TablePrimaryKeys.java
+++ b/src/main/java/io/debezium/connector/vitess/TablePrimaryKeys.java
@@ -1,19 +1,20 @@
 package io.debezium.connector.vitess;
 
-import binlogdata.Binlogdata;
-import com.fasterxml.jackson.annotation.*;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.protobuf.ByteString;
-import io.vitess.proto.Query;
-
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+
+import io.vitess.proto.Query;
+
+import binlogdata.Binlogdata;
 
 public class TablePrimaryKeys {
 
@@ -35,7 +36,7 @@ public class TablePrimaryKeys {
     private final List<TableLastPrimaryKey> tableLastPrimaryKeys = new ArrayList<>();
 
     public TablePrimaryKeys(List<Binlogdata.TableLastPK> rawTableLastPrimaryKey) {
-        for (Binlogdata.TableLastPK tableLastPrimaryKey: rawTableLastPrimaryKey) {
+        for (Binlogdata.TableLastPK tableLastPrimaryKey : rawTableLastPrimaryKey) {
             this.rawTableLastPrimaryKeys.add(tableLastPrimaryKey);
             tableLastPrimaryKeys.add(new TableLastPrimaryKey(tableLastPrimaryKey.getTableName(), tableLastPrimaryKey.getLastpk()));
         }
@@ -43,14 +44,14 @@ public class TablePrimaryKeys {
 
     public static TablePrimaryKeys of(String tablePrimaryKeysJSON) {
         try {
-            List<TableLastPrimaryKey> tablePrimaryKeys = MAPPER.readValue(tablePrimaryKeysJSON, new TypeReference<List<TableLastPrimaryKey>>(){});
+            List<TableLastPrimaryKey> tablePrimaryKeys = MAPPER.readValue(tablePrimaryKeysJSON, new TypeReference<List<TableLastPrimaryKey>>() {
+            });
             return createFromTableLastPrimaryKeys(tablePrimaryKeys);
-        } catch (JsonProcessingException e) {
+        }
+        catch (JsonProcessingException e) {
             throw new IllegalStateException(e);
         }
     }
-
-
 
     public static TablePrimaryKeys createFromRawTableLastPrimaryKey(List<Binlogdata.TableLastPK> rawTableLastPrimaryKeys) {
         return new TablePrimaryKeys(rawTableLastPrimaryKeys);
@@ -62,7 +63,7 @@ public class TablePrimaryKeys {
             return tablePrimaryKeys;
         }
         tablePrimaryKeys.tableLastPrimaryKeys.addAll(tableLastPrimaryKeys);
-        for (TableLastPrimaryKey tableLastPrimaryKey: tableLastPrimaryKeys) {
+        for (TableLastPrimaryKey tableLastPrimaryKey : tableLastPrimaryKeys) {
             Binlogdata.TableLastPK rawTableLastPrimaryKey = tableLastPrimaryKey.getRawTableLastPrimaryKey();
             tablePrimaryKeys.rawTableLastPrimaryKeys.add(rawTableLastPrimaryKey);
         }
@@ -77,7 +78,8 @@ public class TablePrimaryKeys {
         return tableLastPrimaryKeys;
     }
 
-    public TablePrimaryKeys() {}
+    public TablePrimaryKeys() {
+    }
 
     @Override
     public String toString() {
@@ -102,7 +104,7 @@ public class TablePrimaryKeys {
                 Objects.equals(tableLastPrimaryKeys, tablePrimaryKeys.tableLastPrimaryKeys);
     }
 
-    @JsonPropertyOrder({TABLE_NAME_KEY, LASTPK_KEY})
+    @JsonPropertyOrder({ TABLE_NAME_KEY, LASTPK_KEY })
     public static class TableLastPrimaryKey {
 
         @JsonProperty(TABLE_NAME_KEY)
@@ -152,7 +154,7 @@ public class TablePrimaryKeys {
         }
     }
 
-    @JsonPropertyOrder({FIELDS_KEY, ROWS_KEY})
+    @JsonPropertyOrder({ FIELDS_KEY, ROWS_KEY })
     public static class LastPrimaryKey {
         public List<Field> getFields() {
             return fields;
@@ -173,9 +175,9 @@ public class TablePrimaryKeys {
 
         public LastPrimaryKey(Query.QueryResult queryResult) {
             for (Query.Field field : queryResult.getFieldsList()) {
-               fields.add(new Field(field));
+                fields.add(new Field(field));
             }
-            for (Query.Row row: queryResult.getRowsList()) {
+            for (Query.Row row : queryResult.getRowsList()) {
                 rows.add(new Row(row));
             }
         }
@@ -202,7 +204,7 @@ public class TablePrimaryKeys {
         }
     }
 
-    @JsonPropertyOrder({NAME_KEY, TYPE_KEY, CHARSET_KEY, FLAGS_KEY})
+    @JsonPropertyOrder({ NAME_KEY, TYPE_KEY, CHARSET_KEY, FLAGS_KEY })
     public static class Field {
         private String name;
         private String type;
@@ -267,7 +269,7 @@ public class TablePrimaryKeys {
         }
     }
 
-    @JsonPropertyOrder({LENGTHS_KEY, VALUES_KEY})
+    @JsonPropertyOrder({ LENGTHS_KEY, VALUES_KEY })
     public static class Row {
         private List<String> lengths;
         private String values;
@@ -305,7 +307,8 @@ public class TablePrimaryKeys {
                 return Query.Row.newBuilder()
                         .addAllLengths(lengths.stream().map(lengthStr -> Long.valueOf(lengthStr)).collect(Collectors.toList()))
                         .setValues(ByteString.copyFrom(values, "UTF-8")).build();
-            } catch (UnsupportedEncodingException e) {
+            }
+            catch (UnsupportedEncodingException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/src/main/java/io/debezium/connector/vitess/TablePrimaryKeys.java
+++ b/src/main/java/io/debezium/connector/vitess/TablePrimaryKeys.java
@@ -24,6 +24,11 @@ import io.vitess.proto.Query;
 
 import binlogdata.Binlogdata;
 
+/**
+ * Vitess table copy offsets. During a table copy phase, Vitess VGTID also includes the
+ * last primary keys' values for each table. The VGTID received from Vitess, which includes the
+ * progress of the table copy, is represented as this class. Used by `Vgtid.java`
+ */
 public class TablePrimaryKeys {
 
     public static final String TABLE_NAME_KEY = "table_name";

--- a/src/main/java/io/debezium/connector/vitess/TablePrimaryKeys.java
+++ b/src/main/java/io/debezium/connector/vitess/TablePrimaryKeys.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.connector.vitess;
 
 import java.io.UnsupportedEncodingException;
@@ -6,7 +11,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -92,6 +100,11 @@ public class TablePrimaryKeys {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(rawTableLastPrimaryKeys, tableLastPrimaryKeys);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -107,6 +120,9 @@ public class TablePrimaryKeys {
     @JsonPropertyOrder({ TABLE_NAME_KEY, LASTPK_KEY })
     public static class TableLastPrimaryKey {
 
+        private final String tableName;
+        private final LastPrimaryKey lastPrimaryKey;
+
         @JsonProperty(TABLE_NAME_KEY)
         public String getTableName() {
             return tableName;
@@ -116,10 +132,6 @@ public class TablePrimaryKeys {
         public LastPrimaryKey getLastPrimaryKey() {
             return lastPrimaryKey;
         }
-
-        private final String tableName;
-
-        private final LastPrimaryKey lastPrimaryKey;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         public TableLastPrimaryKey(@JsonProperty(TABLE_NAME_KEY) String tableName, @JsonProperty(LASTPK_KEY) LastPrimaryKey lastPrimaryKey) {
@@ -141,6 +153,11 @@ public class TablePrimaryKeys {
         }
 
         @Override
+        public int hashCode() {
+            return Objects.hash(tableName, lastPrimaryKey);
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -156,6 +173,9 @@ public class TablePrimaryKeys {
 
     @JsonPropertyOrder({ FIELDS_KEY, ROWS_KEY })
     public static class LastPrimaryKey {
+        private final List<Field> fields = new ArrayList<>();
+        private final List<Row> rows = new ArrayList<>();
+
         public List<Field> getFields() {
             return fields;
         }
@@ -163,9 +183,6 @@ public class TablePrimaryKeys {
         public List<Row> getRows() {
             return rows;
         }
-
-        private final List<Field> fields = new ArrayList<>();
-        private final List<Row> rows = new ArrayList<>();
 
         @JsonCreator
         public LastPrimaryKey(@JsonProperty(FIELDS_KEY) List<Field> fields, @JsonProperty(ROWS_KEY) List<Row> rows) {
@@ -188,6 +205,11 @@ public class TablePrimaryKeys {
                     .addAllFields(fields.stream().map(field -> field.getRawField()).collect(Collectors.toList()))
                     .addAllRows(rows.stream().map(row -> row.getRawRow()).collect(Collectors.toList()))
                     .build();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fields, rows);
         }
 
         @Override
@@ -254,6 +276,11 @@ public class TablePrimaryKeys {
         }
 
         @Override
+        public int hashCode() {
+            return Objects.hash(name, type, charset, flags);
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -314,6 +341,11 @@ public class TablePrimaryKeys {
         }
 
         @Override
+        public int hashCode() {
+            return Objects.hash(lengths, values);
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -326,5 +358,4 @@ public class TablePrimaryKeys {
                     Objects.equals(values, row.values);
         }
     }
-
 }

--- a/src/main/java/io/debezium/connector/vitess/TablePrimaryKeys.java
+++ b/src/main/java/io/debezium/connector/vitess/TablePrimaryKeys.java
@@ -1,0 +1,327 @@
+package io.debezium.connector.vitess;
+
+import binlogdata.Binlogdata;
+import com.fasterxml.jackson.annotation.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import io.vitess.proto.Query;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class TablePrimaryKeys {
+
+    public static final String TABLE_NAME_KEY = "table_name";
+    public static final String LASTPK_KEY = "lastpk";
+    public static final String FIELDS_KEY = "fields";
+    public static final String ROWS_KEY = "rows";
+    public static final String NAME_KEY = "name";
+    public static final String CHARSET_KEY = "charset";
+    public static final String TYPE_KEY = "type";
+    public static final String FLAGS_KEY = "flags";
+    public static final String LENGTHS_KEY = "lengths";
+    public static final String VALUES_KEY = "values";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @JsonIgnore
+    private final List<Binlogdata.TableLastPK> rawTableLastPrimaryKeys = new ArrayList<>();
+    private final List<TableLastPrimaryKey> tableLastPrimaryKeys = new ArrayList<>();
+
+    public TablePrimaryKeys(List<Binlogdata.TableLastPK> rawTableLastPrimaryKey) {
+        for (Binlogdata.TableLastPK tableLastPrimaryKey: rawTableLastPrimaryKey) {
+            this.rawTableLastPrimaryKeys.add(tableLastPrimaryKey);
+            tableLastPrimaryKeys.add(new TableLastPrimaryKey(tableLastPrimaryKey.getTableName(), tableLastPrimaryKey.getLastpk()));
+        }
+    }
+
+    public static TablePrimaryKeys of(String tablePrimaryKeysJSON) {
+        try {
+            List<TableLastPrimaryKey> tablePrimaryKeys = MAPPER.readValue(tablePrimaryKeysJSON, new TypeReference<List<TableLastPrimaryKey>>(){});
+            return createFromTableLastPrimaryKeys(tablePrimaryKeys);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+
+
+    public static TablePrimaryKeys createFromRawTableLastPrimaryKey(List<Binlogdata.TableLastPK> rawTableLastPrimaryKeys) {
+        return new TablePrimaryKeys(rawTableLastPrimaryKeys);
+    }
+
+    public static TablePrimaryKeys createFromTableLastPrimaryKeys(List<TableLastPrimaryKey> tableLastPrimaryKeys) {
+        TablePrimaryKeys tablePrimaryKeys = new TablePrimaryKeys();
+        if (tableLastPrimaryKeys == null || tableLastPrimaryKeys.size() == 0) {
+            return tablePrimaryKeys;
+        }
+        tablePrimaryKeys.tableLastPrimaryKeys.addAll(tableLastPrimaryKeys);
+        for (TableLastPrimaryKey tableLastPrimaryKey: tableLastPrimaryKeys) {
+            Binlogdata.TableLastPK rawTableLastPrimaryKey = tableLastPrimaryKey.getRawTableLastPrimaryKey();
+            tablePrimaryKeys.rawTableLastPrimaryKeys.add(rawTableLastPrimaryKey);
+        }
+        return tablePrimaryKeys;
+    }
+
+    public List<Binlogdata.TableLastPK> getRawTableLastPrimaryKeys() {
+        return rawTableLastPrimaryKeys;
+    }
+
+    public List<TableLastPrimaryKey> getTableLastPrimaryKeys() {
+        return tableLastPrimaryKeys;
+    }
+
+    public TablePrimaryKeys() {}
+
+    @Override
+    public String toString() {
+        try {
+            return MAPPER.writeValueAsString(tableLastPrimaryKeys);
+        }
+        catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TablePrimaryKeys tablePrimaryKeys = (TablePrimaryKeys) o;
+        return Objects.equals(rawTableLastPrimaryKeys, tablePrimaryKeys) &&
+                Objects.equals(tableLastPrimaryKeys, tablePrimaryKeys.tableLastPrimaryKeys);
+    }
+
+    @JsonPropertyOrder({TABLE_NAME_KEY, LASTPK_KEY})
+    public static class TableLastPrimaryKey {
+
+        @JsonProperty(TABLE_NAME_KEY)
+        public String getTableName() {
+            return tableName;
+        }
+
+        @JsonProperty(LASTPK_KEY)
+        public LastPrimaryKey getLastPrimaryKey() {
+            return lastPrimaryKey;
+        }
+
+        private final String tableName;
+
+        private final LastPrimaryKey lastPrimaryKey;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public TableLastPrimaryKey(@JsonProperty(TABLE_NAME_KEY) String tableName, @JsonProperty(LASTPK_KEY) LastPrimaryKey lastPrimaryKey) {
+            this.tableName = tableName;
+            this.lastPrimaryKey = lastPrimaryKey;
+        }
+
+        public TableLastPrimaryKey(String tableName, Query.QueryResult lastPrimaryKey) {
+            this.tableName = tableName;
+            this.lastPrimaryKey = new LastPrimaryKey(lastPrimaryKey);
+        }
+
+        @JsonIgnore
+        public Binlogdata.TableLastPK getRawTableLastPrimaryKey() {
+            return Binlogdata.TableLastPK.newBuilder()
+                    .setTableName(tableName)
+                    .setLastpk(lastPrimaryKey.getRawQueryResult())
+                    .build();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TableLastPrimaryKey tableLastPrimaryKey = (TableLastPrimaryKey) o;
+            return Objects.equals(tableName, tableLastPrimaryKey.tableName) &&
+                    Objects.equals(lastPrimaryKey, tableLastPrimaryKey.lastPrimaryKey);
+        }
+    }
+
+    @JsonPropertyOrder({FIELDS_KEY, ROWS_KEY})
+    public static class LastPrimaryKey {
+        public List<Field> getFields() {
+            return fields;
+        }
+
+        public List<Row> getRows() {
+            return rows;
+        }
+
+        private final List<Field> fields = new ArrayList<>();
+        private final List<Row> rows = new ArrayList<>();
+
+        @JsonCreator
+        public LastPrimaryKey(@JsonProperty(FIELDS_KEY) List<Field> fields, @JsonProperty(ROWS_KEY) List<Row> rows) {
+            this.fields.addAll(fields);
+            this.rows.addAll(rows);
+        }
+
+        public LastPrimaryKey(Query.QueryResult queryResult) {
+            for (Query.Field field : queryResult.getFieldsList()) {
+               fields.add(new Field(field));
+            }
+            for (Query.Row row: queryResult.getRowsList()) {
+                rows.add(new Row(row));
+            }
+        }
+
+        @JsonIgnore
+        public Query.QueryResult getRawQueryResult() {
+            return Query.QueryResult.newBuilder()
+                    .addAllFields(fields.stream().map(field -> field.getRawField()).collect(Collectors.toList()))
+                    .addAllRows(rows.stream().map(row -> row.getRawRow()).collect(Collectors.toList()))
+                    .build();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            LastPrimaryKey lastlastPrimaryKey = (LastPrimaryKey) o;
+            return Objects.equals(fields, lastlastPrimaryKey.fields) &&
+                    Objects.equals(rows, lastlastPrimaryKey.rows);
+        }
+    }
+
+    @JsonPropertyOrder({NAME_KEY, TYPE_KEY, CHARSET_KEY, FLAGS_KEY})
+    public static class Field {
+        private String name;
+        private String type;
+        private int charset;
+        private int flags;
+
+        @JsonCreator
+        public Field(@JsonProperty(NAME_KEY) String name, @JsonProperty(TYPE_KEY) String type,
+                     @JsonProperty(CHARSET_KEY) int charset, @JsonProperty(FLAGS_KEY) Integer flags) {
+            this.name = name;
+            this.type = type;
+            this.charset = charset;
+            this.flags = flags;
+
+        }
+
+        public Field(Query.Field field) {
+            name = field.getName();
+            type = field.getType().toString();
+            charset = field.getCharset();
+            flags = field.getFlags();
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public int getCharset() {
+            return charset;
+        }
+
+        public int getFlags() {
+            return flags;
+        }
+
+        @JsonIgnore
+        public Query.Field getRawField() {
+            return Query.Field.newBuilder()
+                    .setName(name)
+                    .setCharset(charset)
+                    .setType(Query.Type.valueOf(type))
+                    .setFlags(flags).build();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Field field = (Field) o;
+            return Objects.equals(name, field.name) &&
+                    Objects.equals(charset, field.charset) &&
+                    Objects.equals(type, field.type) &&
+                    Objects.equals(flags, field.flags);
+        }
+    }
+
+    @JsonPropertyOrder({LENGTHS_KEY, VALUES_KEY})
+    public static class Row {
+        private List<String> lengths;
+        private String values;
+
+        @JsonCreator
+        public Row(@JsonProperty(LENGTHS_KEY) List<String> lengths, @JsonProperty(VALUES_KEY) String values) {
+            this.lengths = lengths;
+            this.values = values;
+        }
+
+        public Row(Query.Row row) {
+            lengths = row.getLengthsList().stream().map(lengthLong -> lengthLong.toString()).collect(Collectors.toList());
+            values = row.getValues().toStringUtf8();
+        }
+
+        public List<String> getLengths() {
+            return lengths;
+        }
+
+        public void setLengths(List<String> lengths) {
+            this.lengths = lengths;
+        }
+
+        public String getValues() {
+            return values;
+        }
+
+        public void setValues(String values) {
+            this.values = values;
+        }
+
+        @JsonIgnore
+        public Query.Row getRawRow() {
+            try {
+                return Query.Row.newBuilder()
+                        .addAllLengths(lengths.stream().map(lengthStr -> Long.valueOf(lengthStr)).collect(Collectors.toList()))
+                        .setValues(ByteString.copyFrom(values, "UTF-8")).build();
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Row row = (Row) o;
+            return Objects.equals(lengths, row.lengths) &&
+                    Objects.equals(values, row.values);
+        }
+    }
+
+}

--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -242,13 +242,13 @@ public class VitessConnector extends RelationalBaseSourceConnector {
     }
 
     private Map<String, String> getConfigGtidsPerShard(List<String> shards) {
-        String gtids = connectorConfig.getGtid();
+        String gtids = connectorConfig.getVgtid();
         Map<String, String> configGtidsPerShard = null;
         if (shards != null && gtids.equals(Vgtid.EMPTY_GTID)) {
             Function<Integer, String> emptyGtid = x -> Vgtid.EMPTY_GTID;
             configGtidsPerShard = buildMap(shards, emptyGtid);
         }
-        else if (shards != null && gtids.equals(VitessConnectorConfig.DEFAULT_GTID)) {
+        else if (shards != null && gtids.equals(Vgtid.CURRENT_GTID)) {
             Function<Integer, String> currentGtid = x -> Vgtid.CURRENT_GTID;
             configGtidsPerShard = buildMap(shards, currentGtid);
         }

--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -242,18 +242,20 @@ public class VitessConnector extends RelationalBaseSourceConnector {
     }
 
     private Map<String, String> getConfigGtidsPerShard(List<String> shards) {
-        List<String> gtids = connectorConfig.getGtid();
+        String gtids = connectorConfig.getGtid();
         Map<String, String> configGtidsPerShard = null;
-        if (shards != null && gtids.equals(VitessConnectorConfig.EMPTY_GTID_LIST)) {
+        if (shards != null && gtids.equals(Vgtid.EMPTY_GTID)) {
             Function<Integer, String> emptyGtid = x -> Vgtid.EMPTY_GTID;
             configGtidsPerShard = buildMap(shards, emptyGtid);
         }
-        else if (shards != null && gtids.equals(VitessConnectorConfig.DEFAULT_GTID_LIST)) {
+        else if (shards != null && gtids.equals(VitessConnectorConfig.DEFAULT_GTID)) {
             Function<Integer, String> currentGtid = x -> Vgtid.CURRENT_GTID;
             configGtidsPerShard = buildMap(shards, currentGtid);
         }
         else if (shards != null) {
-            configGtidsPerShard = buildMap(shards, gtids::get);
+            List<Vgtid.ShardGtid> shardGtids = Vgtid.of(gtids).getShardGtids();
+            Function<Integer, String> shardGtid = (i -> shardGtids.get(i).getGtid());
+            configGtidsPerShard = buildMap(shards, shardGtid);
         }
         LOGGER.info("Found GTIDs per shard in config {}", configGtidsPerShard);
         return configGtidsPerShard;

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -234,7 +234,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withWidth(Width.LONG)
             .withDefault(Vgtid.CURRENT_GTID)
             .withImportance(ConfigDef.Importance.HIGH)
-            .withValidation(VitessConnectorConfig::validateGtids)
+            .withValidation(VitessConnectorConfig::validateVgtids)
             .withDescription(
                     "VGTID from where to start reading from for the given shard(s)."
                             + " It has to be set together with vitess.shard."
@@ -247,7 +247,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withWidth(Width.LONG)
             .withDefault(Vgtid.CURRENT_GTID)
             .withImportance(ConfigDef.Importance.HIGH)
-            .withValidation(VitessConnectorConfig::validateGtids)
+            .withValidation(VitessConnectorConfig::validateVgtids)
             .withDescription(
                     "This option is deprecated use vitess.vgtid instead."
                             + "VGTID from where to start reading from for the given shard(s)."
@@ -489,7 +489,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         return (value != null && !VGTID.defaultValueAsString().equals(value)) ? value : Vgtid.CURRENT_GTID;
     }
 
-    private static int validateGtids(Configuration config, Field field, ValidationOutput problems) {
+    private static int validateVgtids(Configuration config, Field field, ValidationOutput problems) {
         // Get the GTID as a string so that the default value is used if GTID is not set
         String vgtidString = config.getString(field);
         if (vgtidString.equals(Vgtid.CURRENT_GTID) || vgtidString.equals(Vgtid.EMPTY_GTID)) {

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -10,10 +10,10 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigDef;

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -141,7 +141,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
                                 String msg = "Received duplicate BEGIN events";
                                 // During a copy operation, we receive the duplicate event once when no record is copied.
                                 String eventTypes = bufferedEvents.stream().map(VEvent::getType).map(Objects::toString).collect(Collectors.joining(", "));
-                                if (eventTypes.equals("BEGIN, FIELD") || eventTypes.equals("BEGIN, FIELD, VGTID")) {
+                                if (eventTypes.equals("BEGIN, FIELD") || eventTypes.equals("BEGIN, FIELD, VGTID") || eventTypes.equals("COPY_COMPLETED, BEGIN, FIELD")) {
                                     msg += String.format(" during a copy operation. No harm to skip the buffered events. Buffered event types: %s",
                                             eventTypes);
                                     LOGGER.info(msg);
@@ -371,9 +371,9 @@ public class VitessReplicationConnection implements ReplicationConnection {
         else {
             if (config.getShard() == null || config.getShard().isEmpty()) {
                 // This case is not supported by the Vitess, so our workaround is to get all the shards from vtgate.
-                if (config.getGtid() == Vgtid.EMPTY_GTID) {
+                if (config.getVgtid() == Vgtid.EMPTY_GTID) {
                     List<String> shards = VitessConnector.getVitessShards(config);
-                    List<String> gtids = Collections.nCopies(shards.size(), config.getGtid());
+                    List<String> gtids = Collections.nCopies(shards.size(), config.getVgtid());
                     vgtid = buildVgtid(config.getKeyspace(), shards, gtids);
                 }
                 else {
@@ -384,9 +384,9 @@ public class VitessReplicationConnection implements ReplicationConnection {
             }
             else {
                 List<String> shards = config.getShard();
-                String vgtidString = config.getGtid();
+                String vgtidString = config.getVgtid();
                 List<String> gtids;
-                if (vgtidString == VitessConnectorConfig.DEFAULT_GTID ||
+                if (vgtidString == Vgtid.CURRENT_GTID ||
                         vgtidString == Vgtid.EMPTY_GTID) {
                     gtids = Collections.nCopies(shards.size(), vgtidString);
                     vgtid = buildVgtid(config.getKeyspace(), shards, gtids);

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -390,7 +390,8 @@ public class VitessReplicationConnection implements ReplicationConnection {
                         vgtidString == Vgtid.EMPTY_GTID) {
                     gtids = Collections.nCopies(shards.size(), vgtidString);
                     vgtid = buildVgtid(config.getKeyspace(), shards, gtids);
-                } else {
+                }
+                else {
                     vgtid = Vgtid.of(vgtidString);
                 }
                 LOGGER.info("VGTID '{}' is set to the GTID {} for keyspace: {} shard: {}",

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -429,7 +429,8 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
                     accept(r);
                     if (records.size() == expectedRecordsCount && extraRecordsTimeout == 0) {
                         break;
-                    } else if (records.size() == expectedRecordsCount) {
+                    }
+                    else if (records.size() == expectedRecordsCount) {
                         verifyNoExtraRecords(extraRecordsTimeout, unit);
                         break;
                     }

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -423,7 +423,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
 
         protected void await(long timeout, long extraRecordsTimeout, TimeUnit unit) throws InterruptedException {
             final ElapsedTimeStrategy timer = ElapsedTimeStrategy.constant(Clock.SYSTEM, unit.toMillis(timeout));
+            System.out.println(timer);
             while (!timer.hasElapsed()) {
+                System.out.println(timer);
                 final SourceRecord r = consumeRecord();
                 if (r != null) {
                     accept(r);

--- a/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/vitess/SourceInfoTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.vitess;
 
+import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
@@ -28,10 +29,7 @@ public class SourceInfoTest {
     private static final String TEST_SHARD2 = "80-";
     private static final String TEST_GTID2 = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000b:1-1513";
     private static final String VGTID_JSON = String.format(
-            "[" +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}," +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}" +
-                    "]",
+            VGTID_JSON_TEMPLATE,
             TEST_KEYSPACE,
             TEST_SHARD,
             TEST_GTID,

--- a/src/test/java/io/debezium/connector/vitess/TablePrimaryKeysTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TablePrimaryKeysTest.java
@@ -1,17 +1,19 @@
 package io.debezium.connector.vitess;
 
-import binlogdata.Binlogdata;
-import com.google.common.primitives.Ints;
-import com.google.protobuf.ByteString;
-import io.vitess.proto.Query;
-import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-
 import static org.assertj.core.api.Assertions.assertThat;
-
 
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import com.google.common.primitives.Ints;
+import com.google.protobuf.ByteString;
+
+import io.vitess.proto.Query;
+
+import binlogdata.Binlogdata;
 
 public class TablePrimaryKeysTest {
 
@@ -33,12 +35,14 @@ public class TablePrimaryKeysTest {
                             .addLengths(2)
                             .addLengths(1)
                             .setValues(ByteString.copyFrom("101", "UTF-8"))
-                            .build()).build();
+                            .build())
+                    .build();
             Binlogdata.TableLastPK tableLastPK = Binlogdata.TableLastPK.newBuilder()
                     .setTableName("comp_pk_table")
                     .setLastpk(queryResult).build();
             return tableLastPK;
-        } catch (UnsupportedEncodingException e) {
+        }
+        catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
     }
@@ -55,12 +59,14 @@ public class TablePrimaryKeysTest {
                     .addRows(Query.Row.newBuilder()
                             .addLengths(1)
                             .setValues(ByteString.copyFrom("5", "UTF-8"))
-                            .build()).build();
+                            .build())
+                    .build();
             Binlogdata.TableLastPK tableLastPK = Binlogdata.TableLastPK.newBuilder()
                     .setTableName("numeric_table")
                     .setLastpk(queryResult).build();
             return tableLastPK;
-        } catch (UnsupportedEncodingException e) {
+        }
+        catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
     }
@@ -165,8 +171,7 @@ public class TablePrimaryKeysTest {
         assertThat(tablePrimaryKeys.getRawTableLastPrimaryKeys()).isEqualTo(rawTableLastPK);
         TablePrimaryKeys.LastPrimaryKey lastPK = new TablePrimaryKeys.LastPrimaryKey(queryResult);
         assertThat(tablePrimaryKeys.getTableLastPrimaryKeys()).containsExactly(
-                new TablePrimaryKeys.TableLastPrimaryKey(tableName, lastPK)
-        );
+                new TablePrimaryKeys.TableLastPrimaryKey(tableName, lastPK));
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/TablePrimaryKeysTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TablePrimaryKeysTest.java
@@ -1,0 +1,187 @@
+package io.debezium.connector.vitess;
+
+import binlogdata.Binlogdata;
+import com.google.common.primitives.Ints;
+import com.google.protobuf.ByteString;
+import io.vitess.proto.Query;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+public class TablePrimaryKeysTest {
+
+    public static final Binlogdata.TableLastPK getCompPKRawTableLastPK() {
+        Query.QueryResult queryResult = null;
+        try {
+            queryResult = Query.QueryResult.newBuilder()
+                    .addFields(Query.Field.newBuilder()
+                            .setName("id")
+                            .setType(Query.Type.INT64)
+                            .setCharset(63)
+                            .setFlags(49667))
+                    .addFields(Query.Field.newBuilder()
+                            .setName("int_col")
+                            .setType(Query.Type.INT32)
+                            .setCharset(63)
+                            .setFlags(53251))
+                    .addRows(Query.Row.newBuilder()
+                            .addLengths(2)
+                            .addLengths(1)
+                            .setValues(ByteString.copyFrom("101", "UTF-8"))
+                            .build()).build();
+            Binlogdata.TableLastPK tableLastPK = Binlogdata.TableLastPK.newBuilder()
+                    .setTableName("comp_pk_table")
+                    .setLastpk(queryResult).build();
+            return tableLastPK;
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static final Binlogdata.TableLastPK getNumericRawTableLastPK() {
+        Query.QueryResult queryResult = null;
+        try {
+            queryResult = Query.QueryResult.newBuilder()
+                    .addFields(Query.Field.newBuilder()
+                            .setName("id")
+                            .setType(Query.Type.INT64)
+                            .setCharset(63)
+                            .setFlags(49667))
+                    .addRows(Query.Row.newBuilder()
+                            .addLengths(1)
+                            .setValues(ByteString.copyFrom("5", "UTF-8"))
+                            .build()).build();
+            Binlogdata.TableLastPK tableLastPK = Binlogdata.TableLastPK.newBuilder()
+                    .setTableName("numeric_table")
+                    .setLastpk(queryResult).build();
+            return tableLastPK;
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static final List<Binlogdata.TableLastPK> getTestRawTableLastPKList() {
+        return List.of(getCompPKRawTableLastPK());
+    }
+
+    public static List<TablePrimaryKeys.TableLastPrimaryKey> getTestTablePKs(List<Binlogdata.TableLastPK> tableLastPKs) {
+        TablePrimaryKeys tablePrimaryKeys = new TablePrimaryKeys(tableLastPKs);
+        return tablePrimaryKeys.getTableLastPrimaryKeys();
+    }
+
+    public static List<TablePrimaryKeys.TableLastPrimaryKey> getTestTablePKs() {
+        TablePrimaryKeys tablePrimaryKeys = new TablePrimaryKeys(getTestRawTableLastPKList());
+        return tablePrimaryKeys.getTableLastPrimaryKeys();
+    }
+
+    public static final String TEST_COMP_PK_LAST_PKS_JSON = "{\n" +
+            "      \"table_name\": \"comp_pk_table\",\n" +
+            "      \"lastpk\": {\n" +
+            "        \"fields\": [" +
+            "            {\n" +
+            "            \"name\": \"id\",\n" +
+            "            \"type\": \"INT64\",\n" +
+            "            \"charset\": 63,\n" +
+            "            \"flags\": 49667\n" +
+            "            }," +
+            "            {\n" +
+            "            \"name\": \"int_col\",\n" +
+            "            \"type\": \"INT32\",\n" +
+            "            \"charset\": 63,\n" +
+            "            \"flags\": 53251\n" +
+            "            }" +
+            "        ],\n" +
+            "        \"rows\": [" +
+            "          {\n" +
+            "          \"lengths\": [\"2\",\"1\"],\n" +
+            "          \"values\": \"101\"\n" +
+            "          }\n" +
+            "        ]" +
+            "      }" +
+            "}";
+
+    public static final String TEST_LAST_PKS_JSON = String.format(
+            "[%s]",
+            TEST_COMP_PK_LAST_PKS_JSON);
+
+    public static final String TEST_NUMERIC_TABLE_LAST_PK_JSON = "{" +
+            "      \"table_name\": \"numeric_table\",\n" +
+            "      \"lastpk\": {\n" +
+            "        \"fields\": [" +
+            "            {\n" +
+            "            \"name\": \"id\",\n" +
+            "            \"type\": \"INT64\",\n" +
+            "            \"charset\": 63,\n" +
+            "            \"flags\": 49667\n" +
+            "            }" +
+            "        ],\n" +
+            "        \"rows\": [" +
+            "          {\n" +
+            "          \"lengths\": [\"1\"],\n" +
+            "          \"values\": \"5\"\n" +
+            "          }\n" +
+            "        ]" +
+            "      }" +
+            "}";
+
+    public static final String TEST_MULTIPLE_TABLE_PKS_JSON = String.format(
+            "[%s, %s]",
+            TEST_COMP_PK_LAST_PKS_JSON,
+            TEST_NUMERIC_TABLE_LAST_PK_JSON);
+
+    @Test
+    public void shouldCreateTablePKsFromRawTablePKs() {
+        String tableName = "t1";
+        Query.QueryResult queryResult = Query.QueryResult.newBuilder()
+                .addFields(Query.Field.newBuilder()
+                        .setName("id")
+                        .setCharset(100)
+                        .setFlags(200)
+                        .setType(Query.Type.INT64))
+                .addFields(Query.Field.newBuilder()
+                        .setName("id2")
+                        .setCharset(100)
+                        .setFlags(200)
+                        .setType(Query.Type.INT64))
+                .addRows(Query.Row.newBuilder()
+                        .addLengths(2)
+                        .addLengths(4)
+                        .setValues(ByteString.copyFrom(Ints.toByteArray(10))))
+                .addRows(Query.Row.newBuilder()
+                        .addLengths(2)
+                        .setValues(ByteString.copyFrom(Ints.toByteArray(12))))
+                .build();
+        List<Binlogdata.TableLastPK> rawTableLastPK = List.of(Binlogdata.TableLastPK.newBuilder()
+                .setTableName(tableName)
+                .setLastpk(queryResult).build());
+
+        TablePrimaryKeys tablePrimaryKeys = TablePrimaryKeys.createFromRawTableLastPrimaryKey(rawTableLastPK);
+
+        assertThat(tablePrimaryKeys.getRawTableLastPrimaryKeys()).isEqualTo(rawTableLastPK);
+        TablePrimaryKeys.LastPrimaryKey lastPK = new TablePrimaryKeys.LastPrimaryKey(queryResult);
+        assertThat(tablePrimaryKeys.getTableLastPrimaryKeys()).containsExactly(
+                new TablePrimaryKeys.TableLastPrimaryKey(tableName, lastPK)
+        );
+    }
+
+    @Test
+    public void shouldCreateFromLastPKs() {
+        List<TablePrimaryKeys.TableLastPrimaryKey> tableLastPKs = getTestTablePKs();
+
+        TablePrimaryKeys tablePrimaryKeys = TablePrimaryKeys.createFromTableLastPrimaryKeys(tableLastPKs);
+
+        assertThat(tablePrimaryKeys.getRawTableLastPrimaryKeys()).isEqualTo(getTestRawTableLastPKList());
+        assertThat(tablePrimaryKeys.getTableLastPrimaryKeys()).isEqualTo(getTestTablePKs());
+    }
+
+    @Test
+    public void testTablePKsFromJson() {
+        TablePrimaryKeys tablePrimaryKeys = TablePrimaryKeys.of(TEST_LAST_PKS_JSON);
+        JSONAssert.assertEquals(tablePrimaryKeys.toString(), TEST_LAST_PKS_JSON, true);
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/TablePrimaryKeysTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TablePrimaryKeysTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.connector.vitess;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -54,6 +54,11 @@ public class TestHelper {
     private static final String USERNAME = "vitess";
     private static final String PASSWORD = "vitess_password";
 
+    protected static final String VGTID_JSON_TEMPLATE = "[" +
+                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}," +
+                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}" +
+                    "]";
+
     protected static final String INSERT_STMT = "INSERT INTO t1 (int_col) VALUES (1);";
     protected static final List<String> SETUP_TABLES_STMT = Arrays.asList(
             "DROP TABLE IF EXISTS t1;",

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -55,9 +55,9 @@ public class TestHelper {
     private static final String PASSWORD = "vitess_password";
 
     protected static final String VGTID_JSON_TEMPLATE = "[" +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}," +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}" +
-                    "]";
+            "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}," +
+            "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}" +
+            "]";
 
     protected static final String INSERT_STMT = "INSERT INTO t1 (int_col) VALUES (1);";
     protected static final List<String> SETUP_TABLES_STMT = Arrays.asList(

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -54,6 +54,11 @@ public class TestHelper {
     private static final String USERNAME = "vitess";
     private static final String PASSWORD = "vitess_password";
 
+    protected static final String VGTID_JSON_NO_PKS_TEMPLATE = "[" +
+            "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}," +
+            "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}" +
+            "]";
+
     protected static final String VGTID_JSON_TEMPLATE = "[" +
             "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}," +
             "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}" +

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.vitess;
 
+import static io.debezium.connector.vitess.TablePrimaryKeysTest.*;
+import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -14,24 +16,49 @@ import org.junit.Test;
 import io.debezium.util.Collect;
 
 import binlogdata.Binlogdata;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class VgtidTest {
-    private static final String TEST_KEYSPACE = "test_keyspace";
-    private static final String TEST_SHARD = "-80";
-    private static final String TEST_GTID = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000a:1-1513";
-    private static final String TEST_SHARD2 = "80-";
-    private static final String TEST_GTID2 = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000b:1-1513";
+    public static final String TEST_KEYSPACE = "test_keyspace";
+    public static final String TEST_SHARD = "-80";
+    public static final String TEST_GTID = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000a:1-1513";
+    public static final String TEST_SHARD2 = "80-";
+    public static final String TEST_GTID2 = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000b:1-1513";
+
     public static final String VGTID_JSON = String.format(
-            "[" +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}," +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}" +
-                    "]",
+            VGTID_JSON_TEMPLATE,
             TEST_KEYSPACE,
             TEST_SHARD,
             TEST_GTID,
             TEST_KEYSPACE,
             TEST_SHARD2,
             TEST_GTID2);
+
+    public static final String VGTID_JSON_WITH_LAST_PK_TEMPLATE = "[" +
+            "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":%s}," +
+            "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":%s}" +
+        "]";
+    public static final String VGTID_JSON_WITH_LAST_PK = String.format(
+            VGTID_JSON_WITH_LAST_PK_TEMPLATE,
+            TEST_KEYSPACE,
+            TEST_SHARD,
+            TEST_GTID,
+            TEST_LAST_PKS_JSON,
+            TEST_KEYSPACE,
+            TEST_SHARD2,
+            TEST_GTID2,
+            TEST_LAST_PKS_JSON);
+
+    public static final String VGTID_JSON_WITH_MULTIPLE_TABLE_LAST_PK = String.format(
+            VGTID_JSON_WITH_LAST_PK_TEMPLATE,
+            TEST_KEYSPACE,
+            TEST_SHARD,
+            TEST_GTID,
+            TEST_MULTIPLE_TABLE_PKS_JSON,
+            TEST_KEYSPACE,
+            TEST_SHARD2,
+            TEST_GTID2,
+            TEST_MULTIPLE_TABLE_PKS_JSON);
 
     @Test
     public void shouldCreateFromRawVgtid() {
@@ -58,6 +85,121 @@ public class VgtidTest {
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID),
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2));
         assertThat(vgtid.toString()).isEqualTo(VGTID_JSON);
+    }
+
+    @Test
+    public void shouldCreateFromRawVgtidWithLastPk() {
+        Binlogdata.VGtid rawVgtid = Binlogdata.VGtid.newBuilder()
+                .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                        .setKeyspace(TEST_KEYSPACE)
+                        .setShard(TEST_SHARD)
+                        .setGtid(TEST_GTID)
+                        .addAllTablePKs(getTestRawTableLastPKList())
+                        .build())
+                .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                        .setKeyspace(TEST_KEYSPACE)
+                        .setShard(TEST_SHARD2)
+                        .setGtid(TEST_GTID2)
+                        .addAllTablePKs(getTestRawTableLastPKList())
+                        .build())
+                .build();
+
+        Vgtid vgtid = Vgtid.of(rawVgtid);
+
+
+        assertThat(vgtid.getRawVgtid()).isEqualTo(rawVgtid);
+        assertThat(vgtid.getShardGtids()).containsExactly(
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID, getTestTablePKs()),
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2, getTestTablePKs()));
+        JSONAssert.assertEquals(vgtid.toString(), VGTID_JSON_WITH_LAST_PK, true);
+    }
+
+    @Test
+    public void shouldCreateFromRawVgtidWithMultipleLastPk() {
+        List<Binlogdata.TableLastPK> multipleTablePKs = List.of(getCompPKRawTableLastPK(), getNumericRawTableLastPK());
+        Binlogdata.VGtid rawVgtid = Binlogdata.VGtid.newBuilder()
+                .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                        .setKeyspace(TEST_KEYSPACE)
+                        .setShard(TEST_SHARD)
+                        .setGtid(TEST_GTID)
+                        .addAllTablePKs(multipleTablePKs)
+                        .build())
+                .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                        .setKeyspace(TEST_KEYSPACE)
+                        .setShard(TEST_SHARD2)
+                        .setGtid(TEST_GTID2)
+                        .addAllTablePKs(multipleTablePKs)
+                        .build())
+                .build();
+
+        Vgtid vgtid = Vgtid.of(rawVgtid);
+
+
+        assertThat(vgtid.getRawVgtid()).isEqualTo(rawVgtid);
+        assertThat(vgtid.getShardGtids()).containsExactly(
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID, getTestTablePKs(multipleTablePKs)),
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2, getTestTablePKs(multipleTablePKs)));
+        JSONAssert.assertEquals(vgtid.toString(), VGTID_JSON_WITH_MULTIPLE_TABLE_LAST_PK, true);
+    }
+
+    @Test
+    public void shouldCreateFromShardGtidsWithLastPk() {
+        List<Vgtid.ShardGtid> shardGtids = Collect.arrayListOf(
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID, getTestTablePKs()),
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2, getTestTablePKs()));
+
+        Vgtid vgtid = Vgtid.of(shardGtids);
+
+        assertThat(vgtid.getRawVgtid()).isEqualTo(
+                Binlogdata.VGtid.newBuilder()
+                        .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                                .setKeyspace(TEST_KEYSPACE)
+                                .setShard(TEST_SHARD)
+                                .setGtid(TEST_GTID)
+                                .addAllTablePKs(getTestRawTableLastPKList())
+                                .build())
+                        .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                                .setKeyspace(TEST_KEYSPACE)
+                                .setShard(TEST_SHARD2)
+                                .setGtid(TEST_GTID2)
+                                .addAllTablePKs(getTestRawTableLastPKList())
+                                .build())
+                        .build());
+
+        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID, getTestTablePKs()),
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2, getTestTablePKs())));
+
+        JSONAssert.assertEquals(vgtid.toString(), VGTID_JSON_WITH_LAST_PK, true);
+    }
+
+    @Test
+    public void shouldCreateFromShardGtidsWithLastPkInJson() {
+        // exercise SUT
+        Vgtid vgtid = Vgtid.of(VGTID_JSON_WITH_LAST_PK);
+
+        // verify outcome
+        assertThat(vgtid.getRawVgtid()).isEqualTo(
+                Binlogdata.VGtid.newBuilder()
+                        .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                                .setKeyspace(TEST_KEYSPACE)
+                                .setShard(TEST_SHARD)
+                                .setGtid(TEST_GTID)
+                                .addAllTablePKs(getTestRawTableLastPKList())
+                                .build())
+                        .addShardGtids(Binlogdata.ShardGtid.newBuilder()
+                                .setKeyspace(TEST_KEYSPACE)
+                                .setShard(TEST_SHARD2)
+                                .setGtid(TEST_GTID2)
+                                .addAllTablePKs(getTestRawTableLastPKList())
+                                .build())
+                        .build());
+
+        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID, getTestTablePKs()),
+                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2, getTestTablePKs())));
+
+        JSONAssert.assertEquals(vgtid.toString(), VGTID_JSON_WITH_LAST_PK, true);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -5,7 +5,12 @@
  */
 package io.debezium.connector.vitess;
 
-import static io.debezium.connector.vitess.TablePrimaryKeysTest.*;
+import static io.debezium.connector.vitess.TablePrimaryKeysTest.TEST_LAST_PKS_JSON;
+import static io.debezium.connector.vitess.TablePrimaryKeysTest.TEST_MULTIPLE_TABLE_PKS_JSON;
+import static io.debezium.connector.vitess.TablePrimaryKeysTest.getCompPKRawTableLastPK;
+import static io.debezium.connector.vitess.TablePrimaryKeysTest.getNumericRawTableLastPK;
+import static io.debezium.connector.vitess.TablePrimaryKeysTest.getTestRawTableLastPKList;
+import static io.debezium.connector.vitess.TablePrimaryKeysTest.getTestTablePKs;
 import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -12,11 +12,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import io.debezium.util.Collect;
 
 import binlogdata.Binlogdata;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class VgtidTest {
     public static final String TEST_KEYSPACE = "test_keyspace";
@@ -37,7 +37,7 @@ public class VgtidTest {
     public static final String VGTID_JSON_WITH_LAST_PK_TEMPLATE = "[" +
             "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":%s}," +
             "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":%s}" +
-        "]";
+            "]";
     public static final String VGTID_JSON_WITH_LAST_PK = String.format(
             VGTID_JSON_WITH_LAST_PK_TEMPLATE,
             TEST_KEYSPACE,
@@ -106,7 +106,6 @@ public class VgtidTest {
 
         Vgtid vgtid = Vgtid.of(rawVgtid);
 
-
         assertThat(vgtid.getRawVgtid()).isEqualTo(rawVgtid);
         assertThat(vgtid.getShardGtids()).containsExactly(
                 new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID, getTestTablePKs()),
@@ -133,7 +132,6 @@ public class VgtidTest {
                 .build();
 
         Vgtid vgtid = Vgtid.of(rawVgtid);
-
 
         assertThat(vgtid.getRawVgtid()).isEqualTo(rawVgtid);
         assertThat(vgtid.getShardGtids()).containsExactly(

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -11,6 +11,7 @@ import static io.debezium.connector.vitess.TablePrimaryKeysTest.getCompPKRawTabl
 import static io.debezium.connector.vitess.TablePrimaryKeysTest.getNumericRawTableLastPK;
 import static io.debezium.connector.vitess.TablePrimaryKeysTest.getTestRawTableLastPKList;
 import static io.debezium.connector.vitess.TablePrimaryKeysTest.getTestTablePKs;
+import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_NO_PKS_TEMPLATE;
 import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,6 +30,15 @@ public class VgtidTest {
     public static final String TEST_GTID = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000a:1-1513";
     public static final String TEST_SHARD2 = "80-";
     public static final String TEST_GTID2 = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000b:1-1513";
+
+    public static final String VGTID_JSON_NO_PKS = String.format(
+            VGTID_JSON_NO_PKS_TEMPLATE,
+            TEST_KEYSPACE,
+            TEST_SHARD,
+            TEST_GTID,
+            TEST_KEYSPACE,
+            TEST_SHARD2,
+            TEST_GTID2);
 
     public static final String VGTID_JSON = String.format(
             VGTID_JSON_TEMPLATE,

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -886,7 +886,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         String tableInclude = TEST_UNSHARDED_KEYSPACE + "." + "numeric_table";
         startConnector((builder) -> builder.with(
                 VitessConnectorConfig.VGTID,
-                        "[{\"keyspace\":\"test_unsharded_keyspace\",\"shard\":\"0\"," +
+                "[{\"keyspace\":\"test_unsharded_keyspace\",\"shard\":\"0\"," +
                         "\"gtid\":\"current\"," +
                         "\"table_p_ks\":[{\"table_name\":\"numeric_table\",\"lastpk\":{\"fields\":" +
                         "[{\"name\":\"id\",\"type\":\"INT64\",\"charset\":63,\"flags\":49667}]," +

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -915,7 +915,8 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         // Upper bound is the total size of the table so set that to prevent early termination
         consumer = testConsumer(expectedSnapshotRecordsCount, tableInclude);
         int recordCount = consumer.countRecords(5, TimeUnit.SECONDS);
-        // Assert snapshot is partially compelete
+        // Assert snapshot is partially complete
+        assertThat(recordCount).isPositive();
         assertThat(recordCount < expectedSnapshotRecordsCount).isTrue();
         // Assert the total snapshot records are sent after starting
         consumer = testConsumer(expectedSnapshotRecordsCount, tableInclude);
@@ -925,6 +926,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         for (int i = 1; i <= expectedSnapshotRecordsCount; i++) {
             assertRecordInserted(TEST_UNSHARDED_KEYSPACE + ".numeric_table", TestHelper.PK_FIELD, Long.valueOf(i));
         }
+        assertNoRecordsToConsume();
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -955,7 +955,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         TestHelper.executeDDL("vitess_create_tables.ddl");
         TestHelper.execute(INSERT_NUMERIC_TYPES_STMT, TEST_UNSHARDED_KEYSPACE);
 
-        String tableInclude = TEST_UNSHARDED_KEYSPACE + "." + ".*_table";
+        String tableInclude = TEST_UNSHARDED_KEYSPACE + "\\." + "numeric_table";
 
         // An exception due to duplicate BEGIN events (Buffered event type: BEGIN, FIELD) shouldn't occur
         startConnector(Function.identity(), false, false, 1, -1, -1, tableInclude, null, null);
@@ -970,7 +970,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         // Restart the connector.
         stopConnector();
-        startConnector(Function.identity(), false, false, 1, -1, -1, null, null, null);
+        startConnector(Function.identity(), false, false, 1, -1, -1, tableInclude, null, null);
 
         // We shouldn't receive a record written before restarting the connector.
         consumer = testConsumer(expectedRecordsCount);

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -909,7 +909,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         startConnector(Function.identity(), false, false, 1,
                 -1, -1, tableInclude, VitessConnectorConfig.SnapshotMode.INITIAL, TestHelper.TEST_SHARD);
 
-        consumer = testConsumer(1, tableInclude );
+        consumer = testConsumer(1, tableInclude);
         consumer.await(TestHelper.waitTimeForRecords(), 0, TimeUnit.SECONDS);
         stopConnector();
         // Upper bound is the total size of the table so set that to prevent early termination

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -14,7 +14,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/io/debezium/connector/vitess/VitessOffsetContextTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessOffsetContextTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.vitess;
 
+import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
@@ -22,10 +23,7 @@ public class VitessOffsetContextTest {
     private static final String TEST_SHARD2 = "80-";
     private static final String TEST_GTID2 = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000b:1-1513";
     private static final String VGTID_JSON = String.format(
-            "[" +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}," +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}" +
-                    "]",
+            VGTID_JSON_TEMPLATE,
             TEST_KEYSPACE,
             TEST_SHARD,
             TEST_GTID,

--- a/src/test/java/io/debezium/connector/vitess/VitessSourceInfoStructMakerTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessSourceInfoStructMakerTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.vitess;
 
+import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.kafka.connect.data.Schema;
@@ -21,10 +22,7 @@ public class VitessSourceInfoStructMakerTest {
     private static final String TEST_SHARD2 = "80-";
     private static final String TEST_GTID2 = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000b:1-1513";
     private static final String VGTID_JSON = String.format(
-            "[" +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}," +
-                    "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}" +
-                    "]",
+            VGTID_JSON_TEMPLATE,
             TEST_KEYSPACE,
             TEST_SHARD,
             TEST_GTID,
@@ -61,8 +59,8 @@ public class VitessSourceInfoStructMakerTest {
         sourceInfo.resetVgtid(
                 Vgtid.of(
                         Collect.arrayListOf(
-                                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID),
-                                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2))),
+                                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID, null),
+                                new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD2, TEST_GTID2, null))),
                 AnonymousValue.getInstant());
         sourceInfo.setTableId(new TableId(null, schemaName, tableName));
         sourceInfo.setShard(shard);

--- a/src/test/java/io/debezium/connector/vitess/VitessVerifyRecord.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessVerifyRecord.java
@@ -38,4 +38,10 @@ public class VitessVerifyRecord extends VerifyRecord {
         Struct key = (Struct) record.key();
         assertThat(key.get(pkField)).isNotNull();
     }
+
+    public static void isValidInsert(SourceRecord record, String pkField, Object pkValue) {
+        Struct key = (Struct) record.key();
+        assertThat(key.get(pkField)).isNotNull();
+        assertThat(key.get(pkField)).isEqualTo(pkValue);
+    }
 }

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -111,7 +111,7 @@ CREATE TABLE no_pk_multi_comp_unique_keys_table
 DROP TABLE IF EXISTS comp_pk_table;
 CREATE TABLE comp_pk_table
 (
-    id             BIGINT NOT NULL,
+    id             BIGINT NOT NULL AUTO_INCREMENT,
     int_col        INT,
     int_col2        INT,
     PRIMARY KEY (id, int_col)


### PR DESCRIPTION
Add automatic retry for snapshots.

### Automatic Retry
As detailed in the [table copy RFC ](https://github.com/vitessio/vitess/issues/6277) the last PK value in the VGTID is used for resuming partially complete snapshots. We utilize this for our automatic retries and parse this additional information now being sent by Vitess in the latest version (i.e., including fixes like [this](https://github.com/vitessio/vitess/pull/11103)).

One implementation decision I debated between was switching all of our VGTID parsing logic to instead use the [provided protobuf json converters](https://protobuf.dev/reference/java/api-docs/com/google/protobuf/util/JsonFormat). This would simplify our codebase but also mean the Debezium logic is more tightly coupled with Vitesss/protobuf, so for the latter reason I decided against this.

### GTID -> VGTID config
Previous configs had the option of `vitess.gtid` which was originally added when `vitess.shard` only allowed for a single shard. With the changes to support multiple shards back in https://github.com/debezium/debezium-connector-vitess/pull/135, we made GTID into a CSV as well. In order to easily test the automatic retry snapshot behavior, it would be useful to also specify the last PK values in the config. Additionally, GTID csv adds unnecessary complexity to support another format of specifying GTID(s). So to resolve both of these issues, I changed this to simply be a `vitess.vgtid` config which is a JSON parseable string that we can use to initialize our VGTID for a VStream. Since VGTID is an array of keyspace/shard/gtid/lastpks it has far more versatility for the user to be able to arbitrarily specify the GTID(s) for any shard(s) subset and even PKs to resume snapshots on. This is what is used to test the snapshot resume behavior in the integration tests.