### PR TITLE
DBZ-7104 Fail the test always in the main thread

### DIFF
--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -62,7 +62,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
     private TestConsumer consumer;
     private VitessConnector connector;
-    private AtomicBoolean isConnecorRunning = new AtomicBoolean(false);
+    private AtomicBoolean isConnectorRunning = new AtomicBoolean(false);
 
     @Before
     public void before() {
@@ -670,11 +670,11 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         TestHelper.executeDDL("vitess_create_tables.ddl");
 
         EmbeddedEngine.CompletionCallback completionCallback = (success, message, error) -> {
-            isConnecorRunning.set(false);
+            isConnectorRunning.set(false);
         };
         start(VitessConnector.class, TestHelper.defaultConfig().build(), completionCallback);
         assertConnectorIsRunning();
-        isConnecorRunning.set(true);
+        isConnectorRunning.set(true);
         waitForStreamingRunning(null);
 
         // Connector receives a row whose column name is not valid, task should fail
@@ -682,9 +682,9 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         TestHelper.execute(INSERT_NUMERIC_TYPES_STMT);
         // Connector should still be running & retrying
         assertConnectorIsRunning();
-        assertTrue("The task is expected to keep retrying and not complete", isRunning.get());
+        assertTrue("The task is expected to keep retrying and not complete", isConnectorRunning.get());
         stopConnector();
-        assertFalse("The connector should be stopped now", isRunning.get());
+        assertFalse("The connector should be stopped now", isConnectorRunning.get());
         assertThat(logInterceptor.containsErrorMessage("Illegal prefix '@' for column: @1")).isTrue();
     }
 


### PR DESCRIPTION
Failing test in a different thread doesn't work reliably as JUnit may ignore exceptions (which is how failing test works) in other than main thread.

Do the assert and eventually fail the test in the main test thread.

https://issues.redhat.com/browse/DBZ-7104