### PR TITLE
DBZ-6993 Fix VitessConnectorTaskTest failure

### DIFF
--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTaskTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTaskTest.java
@@ -77,7 +77,7 @@ public class VitessConnectorTaskTest {
         task.initialize(helper.getSourceTaskContext());
         ChangeEventSourceCoordinator coordinator = task.start(config);
         String expectedMessage = String.format(
-                "Found previous partition offset VitessPartition [sourcePartition={server=test_server}]: {transaction_id=null, vgtid=%s}",
+                "Found previous partition offset VitessPartition [sourcePartition={server=test_server}]: {vgtid=%s}",
                 VGTID_JSON);
         assertThat(logInterceptor.containsMessage(expectedMessage)).isTrue();
     }


### PR DESCRIPTION
While working on https://github.com/debezium/debezium/pull/4973 I have noticed the unrelated test failures, one of them being `VitessConnectorTaskTest#shouldReadOffsetsWhenTaskOffsetStorageDisabled`.

The failure was pointing to logs not including the correct error message. Upon closer logs inspection, I have noticed a _very similar_ message is being logged, but the test included an extra message component. I removed it to make the tests green again.

N.B.: I am not very familiar with this codebase, so feel free to discard this PR.