### PR TITLE
DBZ-7628 Use COMMIT time for events, not BEGIN time

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/MessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/MessageDecoder.java
@@ -9,9 +9,13 @@ import io.debezium.connector.vitess.Vgtid;
 
 import binlogdata.Binlogdata;
 
+import java.time.Instant;
+
 /** Decode VStream gRPC VEvent and process it with the ReplicationMessageProcessor. */
 public interface MessageDecoder {
 
     void processMessage(Binlogdata.VEvent event, ReplicationMessageProcessor processor, Vgtid newVgtid, boolean isLastRowEventOfTransaction)
             throws InterruptedException;
+
+    void setCommitTimestamp(Instant commitTimestamp);
 }

--- a/src/main/java/io/debezium/connector/vitess/connection/MessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/MessageDecoder.java
@@ -5,11 +5,11 @@
  */
 package io.debezium.connector.vitess.connection;
 
+import java.time.Instant;
+
 import io.debezium.connector.vitess.Vgtid;
 
 import binlogdata.Binlogdata;
-
-import java.time.Instant;
 
 /** Decode VStream gRPC VEvent and process it with the ReplicationMessageProcessor. */
 public interface MessageDecoder {

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.vitess.connection;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -167,6 +168,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
                                 return;
                             }
                             commitEventSeen = true;
+                            messageDecoder.setCommitTimestamp(Instant.ofEpochSecond(event.getTimestamp()));
                             break;
                         case DDL:
                         case OTHER:

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -10,7 +10,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-import java.sql.Connection;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -10,7 +10,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+import java.sql.Connection;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -285,6 +287,113 @@ public class VitessReplicationConnectionIT {
             assertThat(messages.get(0).getMessage().getOperation().name()).isEqualTo("BEGIN");
             assertThat(messages.get(1).getMessage().getOperation().name()).isEqualTo("INSERT");
             assertThat(messages.get(2).getMessage().getOperation().name()).isEqualTo("COMMIT");
+        }
+        finally {
+            if (error.get() != null) {
+                LOGGER.error("Error during streaming", error.get());
+            }
+        }
+    }
+
+    @Test
+    public void shouldSendCommitTimestamp() throws Exception {
+        // setup fixture
+        final VitessConnectorConfig conf = new VitessConnectorConfig(TestHelper.defaultConfig().build());
+        final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        try (VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema)) {
+            Vgtid startingVgtid = Vgtid.of(
+                    Binlogdata.VGtid.newBuilder()
+                            .addShardGtids(
+                                    Binlogdata.ShardGtid.newBuilder()
+                                            .setKeyspace(conf.getKeyspace())
+                                            .setShard(conf.getShard().get(0))
+                                            .setGtid(Vgtid.CURRENT_GTID)
+                                            .build())
+                            .build());
+
+            BlockingQueue<MessageAndVgtid> consumedMessages = new ArrayBlockingQueue<>(100);
+            AtomicBoolean started = new AtomicBoolean(false);
+            connection.startStreaming(
+                    startingVgtid,
+                    (message, vgtid, isLastRowEventOfTransaction) -> {
+                        if (!started.get()) {
+                            started.set(true);
+                        }
+                        consumedMessages.add(new MessageAndVgtid(message, vgtid));
+                    },
+                    error);
+            // Since we are using the "current" as the starting position, there is a race here
+            // if we execute INSERT_STMT before the vstream starts we will never receive the update
+            // therefore, we wait until the stream is setup and then do the insertion
+            Awaitility
+                    .await()
+                    .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
+                    .until(started::get);
+            consumedMessages.clear();
+            int expectedNumOfMessages = 3;
+            MySQLConnection testConnection = MySQLConnection.forTestDatabase(TEST_UNSHARDED_KEYSPACE);
+            testConnection.setAutoCommit(false);
+            testConnection.executeWithoutCommitting("BEGIN");
+            Thread.sleep(1000);
+            testConnection.executeWithoutCommitting(TestHelper.INSERT_STMT);
+            Thread.sleep(1000);
+            testConnection.executeWithoutCommitting("COMMIT");
+            List<MessageAndVgtid> messages = awaitMessages(
+                    TestHelper.waitTimeForRecords(),
+                    SECONDS,
+                    expectedNumOfMessages,
+                    () -> {
+                        try {
+                            return consumedMessages.poll(pollTimeoutInMs, TimeUnit.MILLISECONDS);
+                        }
+                        catch (InterruptedException e) {
+                            return null;
+                        }
+                    });
+
+            messages.forEach(m -> assertValidVgtid(m.getVgtid(), conf.getKeyspace(), conf.getShard().get(0)));
+            assertThat(messages.get(0).getMessage().getOperation().name()).isEqualTo("BEGIN");
+            Instant beginTime = messages.get(0).getMessage().getCommitTime();
+            assertThat(messages.get(1).getMessage().getOperation().name()).isEqualTo("INSERT");
+            Instant insertTime = messages.get(1).getMessage().getCommitTime();
+            assertThat(messages.get(2).getMessage().getOperation().name()).isEqualTo("COMMIT");
+            Instant commitTime = messages.get(2).getMessage().getCommitTime();
+            assertThat(beginTime).isNotEqualTo(commitTime);
+            assertThat(insertTime).isEqualTo(commitTime);
+
+            testConnection.executeWithoutCommitting("BEGIN");
+            Thread.sleep(1000);
+            testConnection.executeWithoutCommitting(TestHelper.INSERT_STMT);
+            Thread.sleep(1000);
+            testConnection.executeWithoutCommitting("COMMIT");
+            List<MessageAndVgtid> messages2 = awaitMessages(
+                    TestHelper.waitTimeForRecords(),
+                    SECONDS,
+                    expectedNumOfMessages,
+                    () -> {
+                        try {
+                            return consumedMessages.poll(pollTimeoutInMs, TimeUnit.MILLISECONDS);
+                        }
+                        catch (InterruptedException e) {
+                            return null;
+                        }
+                    });
+
+            messages2.forEach(m -> assertValidVgtid(m.getVgtid(), conf.getKeyspace(), conf.getShard().get(0)));
+            assertThat(messages2.get(0).getMessage().getOperation().name()).isEqualTo("BEGIN");
+            Instant beginTime2 = messages2.get(0).getMessage().getCommitTime();
+            assertThat(messages2.get(1).getMessage().getOperation().name()).isEqualTo("INSERT");
+            Instant insertTime2 = messages2.get(1).getMessage().getCommitTime();
+            assertThat(messages2.get(2).getMessage().getOperation().name()).isEqualTo("COMMIT");
+            Instant commitTime2 = messages2.get(2).getMessage().getCommitTime();
+            assertThat(beginTime2).isNotEqualTo(commitTime2);
+            assertThat(insertTime2).isEqualTo(commitTime2);
+
+            // Verify we use the commit time of the second transaction
+            assertThat(commitTime).isNotEqualTo(commitTime2);
         }
         finally {
             if (error.get() != null) {

--- a/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
@@ -8,6 +8,8 @@ package io.debezium.connector.vitess.connection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -28,8 +30,6 @@ import io.debezium.spi.topic.TopicNamingStrategy;
 import io.vitess.proto.Query;
 
 import binlogdata.Binlogdata;
-
-import java.time.Instant;
 
 public class VStreamOutputMessageDecoderTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(VStreamOutputMessageDecoderTest.class);
@@ -496,7 +496,6 @@ public class VStreamOutputMessageDecoderTest {
         Vgtid newVgtid = Vgtid.of(VgtidTest.VGTID_JSON);
 
         // exercise SUT
-//        final boolean[] processed = { false };
         decoder.processMessage(
                 beginEvent,
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -541,7 +540,6 @@ public class VStreamOutputMessageDecoderTest {
 
     @Test
     public void shouldSetOtherEventsToEventTimestamp() throws Exception {
-        // setup fixture
         Long expectedEventTimestamp = 1L;
         Long expectedCommitTimestamp = 2L;
         Binlogdata.VEvent otherEvent = Binlogdata.VEvent.newBuilder()


### PR DESCRIPTION
We were using BEGIN timestamp for events. This does not match the [docs](DBZ-7628) which state that ts_ms is the time that the change is _applied_ to the database. This is also inconsistent with other connectors.

We add tests to reproduce the issue of using BEGIN timestamp. Then adjust the functionality to support using COMMIT timestamp instead.

One key part of the correctness of this code is that a the response.getEventsList() will only ever contain 1 transaction or a partial transaction. It will never contain two transactions (this is why we do not need to buffer/store multiple commit timestamps). We know this is the case by the [commit validation in the codebase](https://github.com/debezium/debezium-connector-vitess/blob/main/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java#L165-L167), ie that if another commit is ever received in a response.getEventsList() then we throw an exception. 