### PR TITLE
DBZ-7773 Implement time.precision.mode for adaptive_time_microseconds and connect

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -31,6 +31,7 @@ import io.debezium.config.Field.ValidationOutput;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.vitess.connection.VitessTabletType;
 import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
@@ -389,6 +390,29 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     + "'precise' represents values as precise (Java's 'BigDecimal') values;"
                     + "'long' represents values using Java's 'long', which may not offer the precision but will be far easier to use in consumers.");
 
+    public static final Field TIME_PRECISION_MODE = RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE
+            .withEnum(TemporalPrecisionMode.class, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 26))
+            .withValidation(VitessConnectorConfig::validateTimePrecisionMode)
+            .withDescription("Time, date and timestamps can be represented with different kinds of precisions, including: "
+                    + "'adaptive_time_microseconds': the precision of date and timestamp values is based the database column's precision; but time fields always use microseconds precision; "
+                    + "'connect': always represents time, date and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, "
+                    + "which uses millisecond precision regardless of the database columns' precision.");
+
+    private static int validateTimePrecisionMode(Configuration config, Field field, ValidationOutput problems) {
+        if (config.hasKey(TIME_PRECISION_MODE.name())) {
+            final String timePrecisionMode = config.getString(TIME_PRECISION_MODE.name());
+            if (TemporalPrecisionMode.ADAPTIVE.getValue().equals(timePrecisionMode)) {
+                // this is a problem
+                problems.accept(TIME_PRECISION_MODE, timePrecisionMode, "The 'adaptive' time.precision.mode is no longer supported");
+                return 1;
+            }
+        }
+
+        // Everything checks out ok.
+        return 0;
+    }
+
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
             .withDefault(VitessSourceInfoStructMaker.class.getName());
 
@@ -417,8 +441,14 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .events(
                     INCLUDE_UNKNOWN_DATATYPES,
                     SOURCE_INFO_STRUCT_MAKER)
-            .connector(SNAPSHOT_MODE, BIGINT_UNSIGNED_HANDLING_MODE)
-            .excluding(SCHEMA_EXCLUDE_LIST, SCHEMA_INCLUDE_LIST)
+            .connector(
+                    SNAPSHOT_MODE,
+                    BIGINT_UNSIGNED_HANDLING_MODE,
+                    TIME_PRECISION_MODE)
+            .excluding(
+                    SCHEMA_EXCLUDE_LIST,
+                    SCHEMA_INCLUDE_LIST,
+                    RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE)
             .create();
 
     // tasks.max is defined in org.apache.kafka.connect.runtime.ConnectorConfig
@@ -470,6 +500,11 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
     @Override
     public String getConnectorName() {
         return Module.name();
+    }
+
+    @Override
+    public TemporalPrecisionMode getTemporalPrecisionMode() {
+        return TemporalPrecisionMode.parse(getConfig().getString(TIME_PRECISION_MODE));
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
@@ -8,6 +8,7 @@ package io.debezium.connector.vitess.connection;
 import java.sql.Types;
 
 import io.debezium.connector.vitess.VitessType;
+import io.debezium.connector.vitess.VitessValueConverter;
 
 /** Resolve raw column value to Java value */
 public class ReplicationMessageColumnValueResolver {
@@ -28,12 +29,19 @@ public class ReplicationMessageColumnValueResolver {
             case Types.BLOB:
             case Types.BINARY:
                 return value.asBytes();
+            case Types.TIMESTAMP_WITH_TIMEZONE: // This is the case for TIMESTAMP which is simply treated as string
             case Types.VARCHAR:
                 return value.asString();
             case Types.FLOAT:
                 return value.asFloat();
             case Types.DOUBLE:
                 return value.asDouble();
+            case Types.TIME:
+                return VitessValueConverter.stringToDuration(value.asString());
+            case Types.TIMESTAMP: // This is a misnomer and is the case for DATETIME
+                return VitessValueConverter.stringToTimestamp(value.asString());
+            case Types.DATE:
+                return VitessValueConverter.stringToLocalDate(value.asString());
             default:
                 break;
         }

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -5,8 +5,6 @@
  */
 package io.debezium.connector.vitess.connection;
 
-import static io.debezium.connector.vitess.connection.ReplicationMessage.Column;
-
 import java.sql.Types;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -387,8 +385,12 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                     .type(columnMetaData.getVitessType().getName())
                     .jdbcType(columnMetaData.getVitessType().getJdbcId())
                     .optional(columnMetaData.isOptional());
-            if (columnMetaData.getVitessType().isEnum()) {
-                editor = editor.enumValues(columnMetaData.getVitessType().getEnumValues());
+            VitessType vitessType = columnMetaData.getVitessType();
+            if (vitessType.getPrecision().isPresent()) {
+                editor = editor.length(vitessType.getPrecision().get());
+            }
+            if (vitessType.isEnum()) {
+                editor = editor.enumValues(vitessType.getEnumValues());
             }
             cols.add(editor.create());
 

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -52,6 +52,7 @@ import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.TableId;
 import io.debezium.util.Collect;
@@ -141,9 +142,62 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         consumer.expects(expectedRecordsCount);
         assertInsert(INSERT_SET_TYPE_STMT, schemasAndValuesForSetType(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveChangesForInsertsWithTimestampTypes() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector();
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
 
         consumer.expects(expectedRecordsCount);
         assertInsert(INSERT_TIME_TYPES_STMT, schemasAndValuesForTimeType(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveChangesForInsertsWithTimestampTypesConnect() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(
+                VitessConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.CONNECT),
+                false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_TIME_TYPES_STMT, schemasAndValuesForTimeTypeConnect(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveChangesForInsertsWithTimestampTypesPrecision() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector();
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_PRECISION_TIME_TYPES_STMT, schemasAndValuesForTimeTypePrecision(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveChangesForInsertsWithTimestampTypesPrecisionConnect() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(
+                VitessConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.CONNECT),
+                false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_PRECISION_TIME_TYPES_STMT, schemasAndValuesForTimeTypePrecisionConnect(), TestHelper.PK_FIELD);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
@@ -36,11 +36,11 @@ public class VitessTypeTest {
         assertThat(VitessType.resolve(asField(Query.Type.TEXT)).getJdbcId()).isEqualTo(Types.VARCHAR);
         assertThat(VitessType.resolve(asField(Query.Type.JSON)).getJdbcId()).isEqualTo(Types.VARCHAR);
         assertThat(VitessType.resolve(asField(Query.Type.DECIMAL)).getJdbcId()).isEqualTo(Types.VARCHAR);
-        assertThat(VitessType.resolve(asField(Query.Type.TIME)).getJdbcId()).isEqualTo(Types.VARCHAR);
-        assertThat(VitessType.resolve(asField(Query.Type.DATE)).getJdbcId()).isEqualTo(Types.VARCHAR);
-        assertThat(VitessType.resolve(asField(Query.Type.DATETIME)).getJdbcId()).isEqualTo(Types.VARCHAR);
+        assertThat(VitessType.resolve(asField(Query.Type.TIME)).getJdbcId()).isEqualTo(Types.TIME);
+        assertThat(VitessType.resolve(asField(Query.Type.DATE)).getJdbcId()).isEqualTo(Types.DATE);
+        assertThat(VitessType.resolve(asField(Query.Type.DATETIME)).getJdbcId()).isEqualTo(Types.TIMESTAMP);
         assertThat(VitessType.resolve(asField(Query.Type.TIMESTAMP)).getJdbcId())
-                .isEqualTo(Types.VARCHAR);
+                .isEqualTo(Types.TIMESTAMP_WITH_TIMEZONE);
         assertThat(VitessType.resolve(asField(Query.Type.ENUM)).getJdbcId()).isEqualTo(Types.INTEGER);
         assertThat(VitessType.resolve(asField(Query.Type.SET)).getJdbcId()).isEqualTo(Types.BIGINT);
         assertThat(VitessType.resolve(asField(Query.Type.GEOMETRY)).getJdbcId()).isEqualTo(Types.OTHER);

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.ValueConverter;
+import io.debezium.schema.DefaultTopicNamingStrategy;
+import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.spi.topic.TopicNamingStrategy;
+import io.debezium.time.MicroTime;
+import io.debezium.time.Year;
+import io.vitess.proto.Query;
+
+import binlogdata.Binlogdata;
+
+public class VitessValueConverterTest {
+
+    private VitessDatabaseSchema schema;
+    private VitessConnectorConfig config;
+    private VitessValueConverter converter;
+    private VStreamOutputMessageDecoder decoder;
+
+    @Before
+    public void before() {
+        config = new VitessConnectorConfig(TestHelper.defaultConfig().build());
+        converter = new VitessValueConverter(
+                config.getDecimalMode(),
+                config.getTemporalPrecisionMode(),
+                ZoneOffset.UTC,
+                config.binaryHandlingMode(),
+                config.includeUnknownDatatypes(),
+                config.getBigIntUnsgnedHandlingMode());
+        schema = new VitessDatabaseSchema(
+                config,
+                SchemaNameAdjuster.create(),
+                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(config));
+        decoder = new VStreamOutputMessageDecoder(schema);
+    }
+
+    public static List<TestHelper.ColumnValue> temporalColumnValues() {
+        return Arrays.asList(
+                new TestHelper.ColumnValue("time_col", Query.Type.TIME, Types.TIME, "01:02:03".getBytes(), 3600),
+                new TestHelper.ColumnValue("year_col", Query.Type.YEAR, Types.INTEGER, "2020".getBytes(), 2020),
+                new TestHelper.ColumnValue("datetime_col", Query.Type.DATETIME, Types.TIMESTAMP, "2020-01-01 01:02:03".getBytes(), 3600));
+    }
+
+    public static Binlogdata.VEvent temporalFieldEvent() {
+        return TestHelper.newFieldEvent(temporalColumnValues());
+    }
+
+    public static List<Query.Field> temporalFields() {
+        return TestHelper.newFields(temporalColumnValues());
+    }
+
+    @Test
+    public void shouldGetInt64SchemaBuilderForTime() throws InterruptedException {
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        Column column = table.columnWithName("time_col");
+        SchemaBuilder schemaBuilder = converter.schemaBuilder(column);
+        assertThat(schemaBuilder.schema()).isEqualTo(MicroTime.builder().build());
+        assertThat(schemaBuilder.schema().type()).isEqualTo(SchemaBuilder.INT64_SCHEMA.type());
+    }
+
+    @Test
+    public void shouldGetYearSchemaBuilderForYear() throws InterruptedException {
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        Column column = table.columnWithName("year_col");
+        SchemaBuilder schemaBuilder = converter.schemaBuilder(column);
+        assertThat(schemaBuilder.schema()).isEqualTo(Year.builder().build());
+        assertThat(schemaBuilder.schema().type()).isEqualTo(SchemaBuilder.INT32_SCHEMA.type());
+    }
+
+    @Test
+    public void shouldConverterWorkForTimeColumn() throws InterruptedException {
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        Column column = table.columnWithName("time_col");
+        Field field = new Field("foo", 0, Schema.INT64_SCHEMA);
+        ValueConverter valueConverter = converter.converter(column, field);
+        Duration expectedDuration = Duration.ofSeconds(3 + 2 * 60 + 1 * 60 * 60);
+        assertThat(valueConverter.convert(expectedDuration)).isInstanceOf(Long.class);
+        assertThat(valueConverter.convert(expectedDuration)).isEqualTo(expectedDuration.toNanos() / 1000);
+    }
+
+    @Test
+    public void shouldConverterWorkForDatetimeColumn() throws InterruptedException {
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        Column column = table.columnWithName("datetime_col");
+        Field field = new Field("foo", 0, Schema.INT64_SCHEMA);
+        ValueConverter valueConverter = converter.converter(column, field);
+        String timestampString = "2020-01-01 01:01:01";
+        Timestamp timestamp = Timestamp.valueOf(timestampString);
+        Object actual = valueConverter.convert(timestamp);
+        assertThat(actual).isInstanceOf(Long.class);
+        assertThat(actual).isEqualTo(timestamp.toLocalDateTime().toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void shouldConvertStringToDuration() {
+        assertThat(VitessValueConverter.stringToDuration("01:02:03")).isEqualTo(Duration.ofSeconds(1 * 60 * 60 + 2 * 60 + 3));
+        assertThat(VitessValueConverter.stringToDuration("01:02:03.1")).isEqualTo(Duration.ofMillis((1 * 60 * 60 + 2 * 60 + 3) * 1000 + 100));
+        assertThat(VitessValueConverter.stringToDuration("01:02:03.12")).isEqualTo(Duration.ofMillis((1 * 60 * 60 + 2 * 60 + 3) * 1000 + 120));
+        assertThat(VitessValueConverter.stringToDuration("01:02:03.123")).isEqualTo(Duration.ofMillis((1 * 60 * 60 + 2 * 60 + 3) * 1000 + 123));
+        assertThat(VitessValueConverter.stringToDuration("01:02:03.1234")).isEqualTo(Duration.ofNanos(
+                ((1 * 60 * 60 + 2 * 60 + 3) * 1000L * 1000 + 1234 * 100) * 1000));
+        assertThat(VitessValueConverter.stringToDuration("01:02:03.12345")).isEqualTo(Duration.ofNanos(
+                ((1 * 60 * 60 + 2 * 60 + 3) * 1000L * 1000 + 12345 * 10) * 1000));
+        assertThat(VitessValueConverter.stringToDuration("01:02:03.123456")).isEqualTo(Duration.ofNanos(
+                ((1 * 60 * 60 + 2 * 60 + 3) * 1000L * 1000 + 123456) * 1000));
+    }
+
+    @Test
+    public void shouldConvertStringToLocalDate() {
+        assertThat(VitessValueConverter.stringToLocalDate("2020-02-12")).isEqualTo(LocalDate.of(2020, 2, 12));
+        assertThat(VitessValueConverter.stringToLocalDate("9999-12-31")).isEqualTo(LocalDate.of(9999, 12, 31));
+    }
+
+    @Test
+    public void shouldConvertStringToTimestamp() {
+        assertThat(VitessValueConverter.stringToTimestamp("2000-01-01 00:00:00")).isEqualTo(
+                Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay()));
+        assertThat(VitessValueConverter.stringToTimestamp("2000-01-01 00:00:00.1")).isEqualTo(
+                Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(1 * 1000 * 1000 * 100)));
+        assertThat(VitessValueConverter.stringToTimestamp("2000-01-01 00:00:00.12")).isEqualTo(
+                Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(12 * 1000 * 1000 * 10)));
+        assertThat(VitessValueConverter.stringToTimestamp("2000-01-01 00:00:00.123")).isEqualTo(
+                Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(123 * 1000 * 1000)));
+        assertThat(VitessValueConverter.stringToTimestamp("2000-01-01 00:00:00.1234")).isEqualTo(
+                Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(1234 * 1000 * 100)));
+        assertThat(VitessValueConverter.stringToTimestamp("2000-01-01 00:00:00.12345")).isEqualTo(
+                Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(12345 * 1000 * 10)));
+        assertThat(VitessValueConverter.stringToTimestamp("2000-01-01 00:00:00.123456")).isEqualTo(
+                Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(123456 * 1000)));
+    }
+}

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -68,6 +68,21 @@ CREATE TABLE time_table
     PRIMARY KEY (id)
 );
 
+DROP TABLE IF EXISTS time_table_precision;
+CREATE TABLE time_table_precision
+(
+    id            BIGINT    NOT NULL AUTO_INCREMENT,
+    time_col1      TIME(1)      NOT NULL DEFAULT '00:00:00.0',
+    time_col4      TIME(4)      NOT NULL DEFAULT '00:00:00.0000',
+    datetime_col2  DATETIME(2)  NOT NULL DEFAULT '2020-02-12 00:00:00.00',
+    datetime_col5  DATETIME(5)  NOT NULL DEFAULT '2020-02-12 00:00:00.00000',
+    timestamp_col3 TIMESTAMP(3) NOT NULL DEFAULT '2020-02-12 00:00:00.000',
+    timestamp_col6 TIMESTAMP(6) NOT NULL DEFAULT '2020-02-12 00:00:00.000000',
+    PRIMARY KEY (id)
+);
+
+DROP TABLE IF EXISTS time_table_default;
+
 DROP TABLE IF EXISTS no_pk_table;
 CREATE TABLE no_pk_table
 (


### PR DESCRIPTION
### Changes

Match what the [MySQL](https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-temporal-types) connector does for handling temporal types with the time.precision.mode setting. Previously was converting everything to strings.

### Verificaiton
Add unit tests for the custom logic for conversion we added. Also add integration test for a table with varying precision levels to test how the behavior changes (e.g., micros or millis based on precision).