### PR TITLE
DBZ-7792 Handle enum/set type conversions dynamically based on VStream copy state

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/Vgtid.java
+++ b/src/main/java/io/debezium/connector/vitess/Vgtid.java
@@ -89,6 +89,15 @@ public class Vgtid {
         return shardGtids;
     }
 
+    public boolean willTriggerVStreamCopy() {
+        for (ShardGtid shardGtid : shardGtids) {
+            if (shardGtid.getGtid().equals(EMPTY_GTID) || !shardGtid.getTableLastPrimaryKeys().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public ShardGtid getShardGtid(String shard) {
         for (ShardGtid shardGtid : shardGtids) {
             if (shardGtid.shard.equals(shard)) {

--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -86,8 +86,12 @@ public class VitessType {
         return Objects.hash(name, jdbcId, enumValues);
     }
 
-    // Resolve JDBC type from vstream FIELD event
     public static VitessType resolve(Query.Field field) {
+        return resolve(field, false);
+    }
+
+    // Resolve JDBC type from vstream FIELD event
+    public static VitessType resolve(Query.Field field, boolean isInVStreamCopy) {
         String type = field.getType().name();
         switch (type) {
             case "INT8":
@@ -101,9 +105,21 @@ public class VitessType {
             case "YEAR":
                 return new VitessType(type, Types.INTEGER);
             case "ENUM":
-                return new VitessType(type, Types.INTEGER, resolveEnumAndSetValues(field.getColumnType()));
+                // Use field.getEnumSetStrings once available in new Vitess versions
+                if (isInVStreamCopy) {
+                    return new VitessType(type, Types.VARCHAR, resolveEnumAndSetValues(field.getColumnType()));
+                }
+                else {
+                    return new VitessType(type, Types.INTEGER, resolveEnumAndSetValues(field.getColumnType()));
+                }
             case "SET":
-                return new VitessType(type, Types.BIGINT, resolveEnumAndSetValues(field.getColumnType()));
+                // Use field.getEnumSetStrings once available in new Vitess versions
+                if (isInVStreamCopy) {
+                    return new VitessType(type, Types.VARCHAR, resolveEnumAndSetValues(field.getColumnType()));
+                }
+                else {
+                    return new VitessType(type, Types.BIGINT, resolveEnumAndSetValues(field.getColumnType()));
+                }
             case "UINT32":
             case "INT64":
                 return new VitessType(type, Types.BIGINT);

--- a/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -281,7 +281,7 @@ public class VitessValueConverter extends JdbcValueConverters {
                 r.deliver(data);
             }
             else {
-                // The binlog will contain a long with the indexes of the options in the set value ...
+                // The binlog will contain a 64-bit bitmask with the indexes of the options in the set value ...
                 long indexes = ((Long) data).longValue();
                 r.deliver(convertSetValue(column, indexes, options));
             }
@@ -294,7 +294,7 @@ public class VitessValueConverter extends JdbcValueConverters {
         boolean first = true;
         int optionLen = options.size();
         while (indexes != 0L) {
-            if (indexes % 2L != 0) {
+            if ((indexes & 1) == 1) {
                 if (first) {
                     first = false;
                 }

--- a/src/main/java/io/debezium/connector/vitess/connection/MessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/MessageDecoder.java
@@ -14,7 +14,8 @@ import binlogdata.Binlogdata;
 /** Decode VStream gRPC VEvent and process it with the ReplicationMessageProcessor. */
 public interface MessageDecoder {
 
-    void processMessage(Binlogdata.VEvent event, ReplicationMessageProcessor processor, Vgtid newVgtid, boolean isLastRowEventOfTransaction)
+    void processMessage(Binlogdata.VEvent event, ReplicationMessageProcessor processor, Vgtid newVgtid, boolean isLastRowEventOfTransaction,
+                        boolean isInVStreamCopy)
             throws InterruptedException;
 
     void setCommitTimestamp(Instant commitTimestamp);

--- a/src/test/docker/Dockerfile
+++ b/src/test/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Use a temporary layer for the build stage.
-FROM vitess/base:v17.0.2 AS base
+FROM vitess/base:v19.0.3 AS base
 
-FROM vitess/lite:v17.0.2
+FROM vitess/lite:v19.0.3
 
 USER root
 

--- a/src/test/docker/Dockerfile
+++ b/src/test/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Use a temporary layer for the build stage.
-FROM vitess/base:v19.0.3 AS base
+FROM vitess/base:v19.0.4 AS base
 
-FROM vitess/lite:v19.0.3
+FROM vitess/lite:v19.0.4
 
 USER root
 

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -113,6 +113,8 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
             + "mediumblob_col)"
             + " VALUES ('d', 'ef', 'op', 'qs');";
     protected static final String INSERT_ENUM_TYPE_STMT = "INSERT INTO enum_table (enum_col)" + " VALUES ('large');";
+
+    protected static final String INSERT_ENUM_AMBIGUOUS_TYPE_STMT = "INSERT INTO enum_ambiguous_table (enum_col)" + " VALUES ('2');";
     protected static final String INSERT_SET_TYPE_STMT = "INSERT INTO set_table (set_col)" + " VALUES ('a,c');";
 
     protected static final String TIME = "01:02:03";
@@ -245,6 +247,14 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
         fields.addAll(
                 Arrays.asList(
                         new SchemaAndValueField("enum_col", io.debezium.data.Enum.builder("small,medium,large").build(), "large")));
+        return fields;
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForEnumTypeAmbiguous() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField("enum_col", io.debezium.data.Enum.builder("2,0,1").build(), "2")));
         return fields;
     }
 

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -41,6 +41,9 @@ public class TestHelper {
     public static final String TEST_UNSHARDED_KEYSPACE = "test_unsharded_keyspace";
     public static final String TEST_SHARDED_KEYSPACE = "test_sharded_keyspace";
     public static final String TEST_SHARD = "0";
+    public static final String TEST_SHARD1 = "-80";
+    public static final String TEST_SHARD2 = "80-";
+
     public static final String TEST_GTID = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000a:1-1513";
     public static final String TEST_TABLE = "test_table";
     private static final String TEST_VITESS_FULL_TABLE = TEST_UNSHARDED_KEYSPACE + "." + TEST_TABLE;
@@ -441,9 +444,14 @@ public class TestHelper {
 
         public ColumnValue(
                            String columnName, Query.Type queryType, int jdbcId, byte[] rawValue, Object javaValue) {
-            this.field = Field.newBuilder().setName(columnName).setType(queryType).build();
+            this(columnName, queryType, jdbcId, rawValue, javaValue, Collections.emptyList(), "");
+        }
+
+        public ColumnValue(
+                           String columnName, Query.Type queryType, int jdbcId, byte[] rawValue, Object javaValue, List<String> enumSetValues, String columnType) {
+            this.field = Field.newBuilder().setName(columnName).setType(queryType).setColumnType(columnType).build();
             this.replicationMessageColumn = new ReplicationMessageColumn(
-                    columnName, new VitessType(queryType.name(), jdbcId), true, rawValue);
+                    columnName, new VitessType(queryType.name(), jdbcId, enumSetValues), true, rawValue);
             this.javaValue = javaValue;
         }
 

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -77,6 +77,98 @@ public class VgtidTest {
             TEST_GTID2,
             TEST_MULTIPLE_TABLE_PKS_JSON);
 
+    public static final String VGTID_EMPTY_AND_GTID = String.format(
+            TestHelper.VGTID_JSON_TEMPLATE,
+            TestHelper.TEST_SHARDED_KEYSPACE,
+            TestHelper.TEST_SHARD1,
+            Vgtid.EMPTY_GTID,
+            TestHelper.TEST_SHARDED_KEYSPACE,
+            TestHelper.TEST_SHARD2,
+            TestHelper.TEST_GTID);
+
+    public static final String VGTID_BOTH_EMPTY = String.format(
+            TestHelper.VGTID_JSON_TEMPLATE,
+            TestHelper.TEST_SHARDED_KEYSPACE,
+            TestHelper.TEST_SHARD1,
+            Vgtid.EMPTY_GTID,
+            TestHelper.TEST_SHARDED_KEYSPACE,
+            TestHelper.TEST_SHARD2,
+            Vgtid.EMPTY_GTID);
+
+    public static final String VGTID_BOTH_CURRENT = String.format(
+            TestHelper.VGTID_JSON_TEMPLATE,
+            TestHelper.TEST_SHARDED_KEYSPACE,
+            TestHelper.TEST_SHARD1,
+            Vgtid.CURRENT_GTID,
+            TestHelper.TEST_SHARDED_KEYSPACE,
+            TestHelper.TEST_SHARD2,
+            Vgtid.CURRENT_GTID);
+
+    public static final String VGTID_EMPTY_AND_CURRENT = String.format(
+            TestHelper.VGTID_JSON_TEMPLATE,
+            TestHelper.TEST_SHARDED_KEYSPACE,
+            TestHelper.TEST_SHARD1,
+            Vgtid.EMPTY_GTID,
+            TestHelper.TEST_SHARDED_KEYSPACE,
+            TestHelper.TEST_SHARD2,
+            Vgtid.CURRENT_GTID);
+
+    @Test
+    public void isInCopyPhaseEmptyAndGtid() {
+        Vgtid vgtid = Vgtid.of(VGTID_EMPTY_AND_GTID);
+        boolean isInCopyPhase = vgtid.willTriggerVStreamCopy();
+        assertThat(isInCopyPhase).isTrue();
+    }
+
+    @Test
+    public void isInCopyPhaseBothEmpty() {
+        Vgtid vgtid = Vgtid.of(VGTID_BOTH_EMPTY);
+        boolean isInCopyPhase = vgtid.willTriggerVStreamCopy();
+        assertThat(isInCopyPhase).isTrue();
+    }
+
+    @Test
+    public void isInCopyPhaseEmptyAndCurrent() {
+        Vgtid vgtid = Vgtid.of(VGTID_EMPTY_AND_CURRENT);
+        boolean isInCopyPhase = vgtid.willTriggerVStreamCopy();
+        assertThat(isInCopyPhase).isTrue();
+    }
+
+    @Test
+    public void isInCopyPhaseBothCurrent() {
+        Vgtid vgtid = Vgtid.of(VGTID_BOTH_CURRENT);
+        boolean isInCopyPhase = vgtid.willTriggerVStreamCopy();
+        assertThat(isInCopyPhase).isFalse();
+    }
+
+    @Test
+    public void isInCopyPhaseGtidWithPks() {
+        Vgtid vgtid = Vgtid.of(VGTID_JSON_WITH_LAST_PK);
+        boolean isInCopyPhase = vgtid.willTriggerVStreamCopy();
+        assertThat(isInCopyPhase).isTrue();
+    }
+
+    @Test
+    public void isInCopyPhaseGtidWithMultiTablePks() {
+        Vgtid vgtid = Vgtid.of(VGTID_JSON_WITH_MULTIPLE_TABLE_LAST_PK);
+        boolean isInCopyPhase = vgtid.willTriggerVStreamCopy();
+        assertThat(isInCopyPhase).isTrue();
+    }
+
+    @Test
+    public void isInCopyPhaseGtidWithBothGtid() {
+        Vgtid vgtid = Vgtid.of(VGTID_JSON);
+        boolean isInCopyPhase = vgtid.willTriggerVStreamCopy();
+        assertThat(isInCopyPhase).isFalse();
+    }
+
+    @Test
+    public void isInCopyPhaseGtidWithBothGtidNoPks() {
+        Vgtid vgtid = Vgtid.of(VGTID_JSON_NO_PKS);
+        boolean isInCopyPhase = vgtid.willTriggerVStreamCopy();
+        assertThat(isInCopyPhase).isFalse();
+    }
+
     @Test
     public void shouldCreateFromRawVgtid() {
         // setup fixture

--- a/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
@@ -87,7 +87,7 @@ public class VitessBigIntUnsignedTest {
                 (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig));
         decoder = new VStreamOutputMessageDecoder(schema);
         // initialize schema by FIELD event
-        decoder.processMessage(TestHelper.newFieldEvent(defaultColumnValues(mode)), null, null, false);
+        decoder.processMessage(TestHelper.newFieldEvent(defaultColumnValues(mode)), null, null, false, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
         assertThat(table.columnWithName("bigint_unsigned_col").jdbcType() == Types.BIGINT);
 

--- a/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
@@ -38,7 +38,7 @@ public class VitessChangeRecordEmitterTest {
                 (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig));
         decoder = new VStreamOutputMessageDecoder(schema);
         // initialize schema by FIELD event
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
@@ -47,7 +47,7 @@ public class VitessTypeTest {
     }
 
     @Test
-    public void shouldResolveEnumToVitessType() {
+    public void shouldResolveEnumToVitessTypeWithIntMappingWhenNotInCopyPhase() {
         Query.Field enumField = Query.Field.newBuilder()
                 .setType(Query.Type.ENUM)
                 .setColumnType("enum('eu','us','asia')")
@@ -78,7 +78,38 @@ public class VitessTypeTest {
     }
 
     @Test
-    public void shouldResolveSetToVitessType() {
+    public void shouldResolveEnumToVitessTypeWithStringValueWhenInCopyPhase() {
+        Query.Field enumField = Query.Field.newBuilder()
+                .setType(Query.Type.ENUM)
+                .setColumnType("enum('eu','us','asia')")
+                .build();
+        assertThat(VitessType.resolve(enumField, true))
+                .isEqualTo(new VitessType(Query.Type.ENUM.name(), Types.VARCHAR, Arrays.asList("eu", "us", "asia")));
+
+        enumField = Query.Field.newBuilder()
+                .setType(Query.Type.ENUM)
+                .setColumnType("enum('e,u','us','asia')")
+                .build();
+        assertThat(VitessType.resolve(enumField, true))
+                .isEqualTo(new VitessType(Query.Type.ENUM.name(), Types.VARCHAR, Arrays.asList("e,u", "us", "asia")));
+
+        enumField = Query.Field.newBuilder()
+                .setType(Query.Type.ENUM)
+                .setColumnType("enum('e'',u','us','asia')")
+                .build();
+        assertThat(VitessType.resolve(enumField, true))
+                .isEqualTo(new VitessType(Query.Type.ENUM.name(), Types.VARCHAR, Arrays.asList("e',u", "us", "asia")));
+
+        enumField = Query.Field.newBuilder()
+                .setType(Query.Type.ENUM)
+                .setColumnType("enum('e'','',''u','us','asia')")
+                .build();
+        assertThat(VitessType.resolve(enumField, true))
+                .isEqualTo(new VitessType(Query.Type.ENUM.name(), Types.VARCHAR, Arrays.asList("e',','u", "us", "asia")));
+    }
+
+    @Test
+    public void shouldResolveSetToVitessTypeIntWhenNotInCopyPhase() {
         Query.Field setField = Query.Field.newBuilder()
                 .setType(Query.Type.SET)
                 .setColumnType("set('eu','us','asia')")
@@ -108,7 +139,42 @@ public class VitessTypeTest {
                 .isEqualTo(new VitessType(Query.Type.SET.name(), Types.BIGINT, Arrays.asList("e',','u", "us", "asia")));
     }
 
+    @Test
+    public void shouldResolveSetToVitessTypeStringWhenInCopyPhase() {
+        Query.Field setField = Query.Field.newBuilder()
+                .setType(Query.Type.SET)
+                .setColumnType("set('eu','us','asia')")
+                .build();
+        assertThat(VitessType.resolve(setField, true))
+                .isEqualTo(new VitessType(Query.Type.SET.name(), Types.VARCHAR, Arrays.asList("eu", "us", "asia")));
+
+        setField = Query.Field.newBuilder()
+                .setType(Query.Type.SET)
+                .setColumnType("set('e,u','us','asia')")
+                .build();
+        assertThat(VitessType.resolve(setField, true))
+                .isEqualTo(new VitessType(Query.Type.SET.name(), Types.VARCHAR, Arrays.asList("e,u", "us", "asia")));
+
+        setField = Query.Field.newBuilder()
+                .setType(Query.Type.SET)
+                .setColumnType("set('e'',u','us','asia')")
+                .build();
+        assertThat(VitessType.resolve(setField, true))
+                .isEqualTo(new VitessType(Query.Type.SET.name(), Types.VARCHAR, Arrays.asList("e',u", "us", "asia")));
+
+        setField = Query.Field.newBuilder()
+                .setType(Query.Type.SET)
+                .setColumnType("set('e'','',''u','us','asia')")
+                .build();
+        assertThat(VitessType.resolve(setField, true))
+                .isEqualTo(new VitessType(Query.Type.SET.name(), Types.VARCHAR, Arrays.asList("e',','u", "us", "asia")));
+    }
+
     private Query.Field asField(Query.Type type) {
         return Query.Field.newBuilder().setType(type).build();
+    }
+
+    private Query.Field asFieldWithColumnType(Query.Type type, String columnType) {
+        return Query.Field.newBuilder().setType(type).setColumnType(columnType).build();
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
@@ -74,6 +74,7 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 newVgtid,
+                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -99,6 +100,7 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
+                false,
                 false);
         assertThat(processed[0]).isFalse();
     }
@@ -130,6 +132,7 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 newVgtid,
+                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -155,6 +158,7 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
+                false,
                 false);
         assertThat(processed[0]).isFalse();
     }
@@ -180,6 +184,7 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
+                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -204,6 +209,7 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
+                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -211,7 +217,7 @@ public class VStreamOutputMessageDecoderTest {
     @Test
     public void shouldProcessFieldEvent() throws Exception {
         // exercise SUT
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         // verify outcome
@@ -229,8 +235,10 @@ public class VStreamOutputMessageDecoderTest {
         String shard1 = "-80";
         String shard2 = "80-";
         // exercise SUT
-        decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard1, TestHelper.TEST_SHARDED_KEYSPACE), null, null, false);
-        decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE), null, null, false);
+        decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard1, TestHelper.TEST_SHARDED_KEYSPACE),
+                null, null, false, false);
+        decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
+                null, null, false, false);
         Table table = schema.tableFor(new TableId(shard1, TestHelper.TEST_SHARDED_KEYSPACE, TestHelper.TEST_TABLE));
 
         // verify outcome
@@ -252,7 +260,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.columnSubsetNumOfColumns());
                 },
-                null, false);
+                null, false, false);
 
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
@@ -264,10 +272,11 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.columnSubsetNumOfColumns());
                 },
-                null, false);
+                null, false, false);
 
         // update schema for shard 2
-        decoder.processMessage(TestHelper.newFieldEvent(TestHelper.defaultColumnValues(), shard2, TestHelper.TEST_SHARDED_KEYSPACE), null, null, false);
+        decoder.processMessage(TestHelper.newFieldEvent(TestHelper.defaultColumnValues(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
+                null, null, false, false);
         Table tableAfterSchemaChange = schema.tableFor(new TableId(shard2, TestHelper.TEST_SHARDED_KEYSPACE, TestHelper.TEST_TABLE));
 
         // verify outcome
@@ -290,7 +299,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                 },
-                null, false);
+                null, false, false);
 
         // shard 1 has not been updated with new schema so it should still be able to handle values with the old schema
         decoder.processMessage(
@@ -303,7 +312,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.columnSubsetNumOfColumns());
                 },
-                null, false);
+                null, false, false);
     }
 
     @Test
@@ -311,8 +320,10 @@ public class VStreamOutputMessageDecoderTest {
         String shard1 = "-80";
         String shard2 = "80-";
         // exercise SUT
-        decoder.processMessage(TestHelper.defaultFieldEvent(shard1, TestHelper.TEST_SHARDED_KEYSPACE), null, null, false);
-        decoder.processMessage(TestHelper.defaultFieldEvent(shard2, TestHelper.TEST_SHARDED_KEYSPACE), null, null, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(shard1, TestHelper.TEST_SHARDED_KEYSPACE),
+                null, null, false, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(shard2, TestHelper.TEST_SHARDED_KEYSPACE),
+                null, null, false, false);
         Table table = schema.tableFor(new TableId(shard1, TestHelper.TEST_SHARDED_KEYSPACE, TestHelper.TEST_TABLE));
 
         // verify outcome
@@ -334,7 +345,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                 },
-                null, false);
+                null, false, false);
 
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.defaultColumnValues(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
@@ -346,10 +357,11 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                 },
-                null, false);
+                null, false, false);
 
         // update schema for shard 2
-        decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE), null, null, false);
+        decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
+                null, null, false, false);
         Table tableAfterSchemaChange = schema.tableFor(new TableId(shard2, TestHelper.TEST_SHARDED_KEYSPACE, TestHelper.TEST_TABLE));
 
         // verify outcome
@@ -372,7 +384,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.columnSubsetNumOfColumns());
                 },
-                null, false);
+                null, false, false);
 
         // shard 1 has not been updated with new schema so it should still be able to handle values with the old schema
         decoder.processMessage(
@@ -385,13 +397,13 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                 },
-                null, false);
+                null, false, false);
     }
 
     @Test
     public void shouldThrowExceptionWithDetailedMessageOnRowSchemaMismatch() throws Exception {
         // exercise SUT
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         // verify outcome
@@ -404,7 +416,8 @@ public class VStreamOutputMessageDecoderTest {
         }
 
         assertThatThrownBy(() -> {
-            decoder.processMessage(TestHelper.insertEvent(TestHelper.columnValuesSubset()), null, null, false);
+            decoder.processMessage(TestHelper.insertEvent(
+                    TestHelper.columnValuesSubset()), null, null, false, false);
         }).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("bool_col")
                 .hasMessageContaining("long_col");
@@ -413,7 +426,7 @@ public class VStreamOutputMessageDecoderTest {
     @Test
     public void shouldProcessInsertEvent() throws Exception {
         // setup fixture
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
         schema.tableFor(TestHelper.defaultTableId());
 
         // exercise SUT
@@ -430,14 +443,14 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                     processed[0] = true;
                 },
-                null, false);
+                null, false, false);
         assertThat(processed[0]).isTrue();
     }
 
     @Test
     public void shouldProcessDeleteEvent() throws Exception {
         // setup fixture
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
         schema.tableFor(TestHelper.defaultTableId());
 
         // exercise SUT
@@ -454,14 +467,14 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
-                false);
+                false, false);
         assertThat(processed[0]).isTrue();
     }
 
     @Test
     public void shouldProcessUpdateEvent() throws Exception {
         // setup fixture
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
         schema.tableFor(TestHelper.defaultTableId());
 
         // exercise SUT
@@ -478,7 +491,7 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
-                false);
+                false, false);
         assertThat(processed[0]).isTrue();
     }
 
@@ -496,7 +509,7 @@ public class VStreamOutputMessageDecoderTest {
                 .setTimestamp(expectedCommitTimestamp)
                 .build();
         decoder.setCommitTimestamp(Instant.ofEpochSecond(commitEvent.getTimestamp()));
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
         schema.tableFor(TestHelper.defaultTableId());
         schema.tableFor(TestHelper.defaultTableId());
         Vgtid newVgtid = Vgtid.of(VgtidTest.VGTID_JSON);
@@ -509,7 +522,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedBeginTimestamp);
                 },
                 newVgtid,
-                false);
+                false, false);
         decoder.processMessage(
                 TestHelper.defaultInsertEvent(),
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -517,7 +530,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 null,
-                false);
+                false, false);
         decoder.processMessage(
                 TestHelper.defaultUpdateEvent(),
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -525,7 +538,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 null,
-                false);
+                false, false);
         decoder.processMessage(
                 TestHelper.defaultDeleteEvent(),
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -533,7 +546,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 null,
-                false);
+                false, false);
         decoder.processMessage(
                 commitEvent,
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -541,7 +554,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 newVgtid,
-                false);
+                false, false);
     }
 
     @Test
@@ -570,7 +583,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedEventTimestamp);
                 },
                 newVgtid,
-                false);
+                false, false);
         decoder.processMessage(
                 ddlEvent,
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -578,7 +591,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedEventTimestamp);
                 },
                 null,
-                false);
+                false, false);
         decoder.processMessage(
                 commitEvent,
                 (message, vgtid, isLastRowEventOfTransaction) -> {
@@ -586,6 +599,6 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 null,
-                false);
+                false, false);
     }
 }

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -48,6 +48,14 @@ CREATE TABLE enum_table
     PRIMARY KEY (id)
 );
 
+DROP TABLE IF EXISTS enum_ambiguous_table;
+CREATE TABLE enum_ambiguous_table
+(
+    id       BIGINT                            NOT NULL AUTO_INCREMENT,
+    enum_col ENUM ('2', '0', '1') NOT NULL DEFAULT '2',
+    PRIMARY KEY (id)
+);
+
 DROP TABLE IF EXISTS set_table;
 CREATE TABLE set_table
 (


### PR DESCRIPTION
Enums/Sets are sent as strings during VStream copy, and during stream are sent as int indexes.

Dynamically handle these two cases.

Soon, there will be a field in newer vitess versions specifying whether it is the actual value or an index. We will add that once it's available in v20 (only v19 released so far)

Fix a brittle itest testing if we increment offset after DDL.

Upgrade to v19 to prep for eventual upgrade to v20.

Note commented where on v20 we will read the enumSetStrings field (allows for smooth upgrades to v20+ for debezium users)

See [zulip](https://debezium.zulipchat.com/#narrow/stream/348255-community-vitess/topic/VStream.20ENUM.20.2F.20SET.20Changes) for more info.