### PR TITLE
DBZ-6721 & DBZ-6722 Add transforms: local vgtid, remove field, and filter transaction topic

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/Vgtid.java
+++ b/src/main/java/io/debezium/connector/vitess/Vgtid.java
@@ -105,6 +105,7 @@ public class Vgtid {
         }
         return false;
     }
+
     public Vgtid getLocalVgtid(String shard) {
         return Vgtid.of(List.of(getShardGtid(shard)));
     }

--- a/src/main/java/io/debezium/connector/vitess/transforms/FilterTransactionTopicRecords.java
+++ b/src/main/java/io/debezium/connector/vitess/transforms/FilterTransactionTopicRecords.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.transforms;
+
+import static io.debezium.config.CommonConnectorConfig.SCHEMA_NAME_ADJUSTMENT_MODE;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.components.Versioned;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import io.debezium.Module;
+import io.debezium.config.Configuration;
+import io.debezium.connector.vitess.VitessConnectorConfig;
+import io.debezium.schema.SchemaFactory;
+import io.debezium.schema.SchemaNameAdjuster;
+
+public class FilterTransactionTopicRecords<R extends ConnectRecord<R>> implements Transformation<R>, Versioned {
+
+    private SchemaNameAdjuster schemaNameAdjuster;
+
+    @Override
+    public String version() {
+        return Module.version();
+    }
+
+    @Override
+    public R apply(R record) {
+        if (isTransactionTopicMessage(record)) {
+            return null;
+        }
+        return record;
+    }
+
+    private boolean isTransactionTopicMessage(R record) {
+        if (record.keySchema().equals(SchemaFactory.get().transactionKeySchema(schemaNameAdjuster)) &&
+                record.valueSchema().equals(SchemaFactory.get().transactionValueSchema(schemaNameAdjuster))) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final Configuration config = Configuration.from(props);
+        schemaNameAdjuster = VitessConnectorConfig.SchemaNameAdjustmentMode.parse(config.getString(SCHEMA_NAME_ADJUSTMENT_MODE))
+                .createAdjuster();
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/transforms/RemoveField.java
+++ b/src/main/java/io/debezium/connector/vitess/transforms/RemoveField.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.transforms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.components.Versioned;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import io.debezium.Module;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.transforms.SmtManager;
+
+public class RemoveField<R extends ConnectRecord<R>> implements Transformation<R>, Versioned {
+    private static final String FIELD_DELIMITER = ",";
+
+    public static final String FIELD_NAMES_CONF = "field_names";
+
+    public static final Field FIELD_NAMES_FIELD = Field.create(FIELD_NAMES_CONF)
+            .withDisplayName("List of field names to remove, full path eg source.database or transaction.id")
+            .withType(ConfigDef.Type.LIST)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withValidation(RemoveField::validateRemoveFieldNames)
+            .withDescription(
+                    "The comma-separated list of fields to remove, e.g., 'source.id', 'transaction.data_collection_order'");
+
+    protected List<String> fieldNames;
+
+    private static int validateRemoveFieldNames(Configuration configuration, Field field, Field.ValidationOutput problems) {
+        // ensure not empty and doesn't start with periods and doesn't end with periods
+        String fieldNames = configuration.getString(field);
+        if (fieldNames == null || fieldNames.isEmpty()) {
+            problems.accept(field, fieldNames, "Field names cannot be empty or null, must specify field names to drop");
+            return 1;
+        }
+        for (String fieldName : fieldNames.split(FIELD_DELIMITER)) {
+            if (fieldName.startsWith(".") || fieldName.endsWith(".")) {
+                problems.accept(field, fieldNames, "Field names cannot start or end with '.', must specify correct field name");
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public R apply(R record) {
+        Struct value = (Struct) record.value();
+        Schema schema = record.valueSchema();
+        Schema updatedSchema = updateSchema("", schema);
+        Struct newValue = updateStruct("", updatedSchema, value);
+        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
+                updatedSchema, newValue, record.timestamp());
+    }
+
+    private Schema updateSchema(String fullName, Schema schema) {
+        // Create a schema builder
+        SchemaBuilder schemaBuilder = SchemaBuilder.struct().version(schema.version()).name(schema.name());
+        if (schema.isOptional()) {
+            schemaBuilder = schemaBuilder.optional();
+        }
+
+        // Iterate over fields in the original schema and add to the schema builder dynamically
+        for (org.apache.kafka.connect.data.Field field : schema.fields()) {
+            String currentFullName = !fullName.isEmpty() ? fullName + "." + field.name() : field.name();
+
+            if (field.schema().type() == Schema.Type.STRUCT) {
+                // If the field is a nested struct, recursively modify it and add its schema
+                Schema updatedNestedSchema = updateSchema(currentFullName, field.schema());
+                schemaBuilder.field(field.name(), updatedNestedSchema);
+            }
+            else {
+                if (!shouldExcludeField(currentFullName)) {
+                    schemaBuilder.field(field.name(), field.schema());
+                }
+            }
+        }
+        return schemaBuilder.build();
+    }
+
+    private boolean shouldExcludeField(String fullFieldName) {
+        for (String fieldName : fieldNames) {
+            if (fullFieldName.equals(fieldName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Struct updateStruct(String fullName, Schema updatedSchema, Struct struct) {
+        // Create an updated struct
+        Struct updatedStruct = new Struct(updatedSchema);
+        for (org.apache.kafka.connect.data.Field field : updatedSchema.fields()) {
+            String currentFullName = fullName != "" ? fullName + "." + field.name() : field.name();
+            Object fieldValue = struct.get(field.name());
+            if (fieldValue instanceof Struct) {
+                // If a field is a struct recursively create its nested structs
+                Struct nestedStruct = (Struct) fieldValue;
+                Struct updatedNestedStruct = updateStruct(currentFullName, field.schema(), nestedStruct);
+                updatedStruct.put(field, updatedNestedStruct);
+            }
+            else {
+                if (!shouldExcludeField(currentFullName)) {
+                    updatedStruct.put(field, fieldValue);
+                }
+            }
+        }
+        return updatedStruct;
+    }
+
+    @Override
+    public String version() {
+        return Module.version();
+    }
+
+    @Override
+    public ConfigDef config() {
+        final ConfigDef config = new ConfigDef();
+        Field.group(config, null, FIELD_NAMES_FIELD);
+        return config;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final Configuration config = Configuration.from(props);
+        SmtManager<R> smtManager = new SmtManager<>(config);
+        smtManager.validate(config, Field.setOf(FIELD_NAMES_FIELD));
+        fieldNames = determineRemoveFields(config);
+    }
+
+    private static List<String> determineRemoveFields(Configuration config) {
+        String fieldNamesString = config.getString(FIELD_NAMES_FIELD);
+        List<String> fieldNames = new ArrayList<>();
+        for (String fieldName : fieldNamesString.split(FIELD_DELIMITER)) {
+            fieldNames.add(fieldName);
+        }
+        return fieldNames;
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/transforms/UseLocalVgtid.java
+++ b/src/main/java/io/debezium/connector/vitess/transforms/UseLocalVgtid.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.transforms;
+
+import static io.debezium.connector.vitess.SourceInfo.SHARD_KEY;
+import static io.debezium.connector.vitess.SourceInfo.VGTID_KEY;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.components.Versioned;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.vitess.Module;
+import io.debezium.connector.vitess.Vgtid;
+import io.debezium.transforms.SmtManager;
+
+public class UseLocalVgtid<R extends ConnectRecord<R>> implements Transformation<R>, Versioned {
+
+    private SmtManager<R> smtManager;
+
+    @Override
+    public R apply(R record) {
+        if (record.value() instanceof Struct) {
+            Struct value = (Struct) record.value();
+            Schema schema = record.valueSchema();
+
+            String localVgtid = getLocalVgtid(value);
+
+            if (localVgtid != null) {
+                Struct updatedValue = modifyStruct("", value, schema, localVgtid);
+                return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
+                        schema, updatedValue, record.timestamp());
+            }
+
+        }
+        return record;
+    }
+
+    private String getLocalVgtid(Struct value) {
+        if (value.schema().field("source") != null) {
+            Struct sourceStruct = (Struct) value.get("source");
+            String shard = sourceStruct.getString(SHARD_KEY);
+            String vgtid = sourceStruct.getString(VGTID_KEY);
+            return Vgtid.of(vgtid).getLocalVgtid(shard).toString();
+        }
+        else {
+            return null;
+        }
+    }
+
+    private Struct modifyStruct(String previousPath, Struct struct, Schema schema, String localVgtid) {
+        // change to work only with exact path match
+        Struct updatedStruct = new Struct(schema);
+        for (Field field : schema.fields()) {
+            String fullName = previousPath.isEmpty() ? field.name() : previousPath + "." + field.name();
+            Object fieldValue = struct.get(field);
+            if (fieldValue instanceof Struct) {
+                Struct nestedStruct = (Struct) fieldValue;
+                Struct updatedNestedStruct = modifyStruct(fullName, nestedStruct, field.schema(), localVgtid);
+                updatedStruct.put(field, updatedNestedStruct);
+            }
+            else {
+                if (fullName.equals("source." + VGTID_KEY)) {
+                    updatedStruct.put(field, localVgtid);
+                }
+                else {
+                    updatedStruct.put(field, fieldValue);
+                }
+            }
+        }
+        return updatedStruct;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final Configuration config = Configuration.from(props);
+        smtManager = new SmtManager<>(config);
+    }
+
+    @Override
+    public String version() {
+        return Module.version();
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -406,6 +406,13 @@ public class VgtidTest {
     }
 
     @Test
+    public void shouldGetLocalVgtid() {
+        Vgtid vgtid = Vgtid.of(VGTID_JSON);
+        Vgtid shardGtid = vgtid.getLocalVgtid(TEST_SHARD);
+        assertThat(shardGtid).isEqualTo(Vgtid.of(List.of(new Vgtid.ShardGtid(TEST_KEYSPACE, TEST_SHARD, TEST_GTID))));
+    }
+
+    @Test
     public void shouldGetMissingShardGtidThrowsDebeziumException() {
         Vgtid vgtid1 = Vgtid.of(VGTID_JSON);
         assertThatThrownBy(() -> {

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -52,6 +52,7 @@ import io.debezium.connector.vitess.connection.VitessReplicationConnection;
 import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionContext;
 import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionMetadataFactory;
 import io.debezium.connector.vitess.pipeline.txmetadata.VitessRankProvider;
+import io.debezium.connector.vitess.transforms.RemoveField;
 import io.debezium.converters.CloudEventsConverterTest;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.data.Envelope;
@@ -642,6 +643,138 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
             assertThat(sourceVgtid.getShardGtids().get(0).getShard()).isEqualTo(source.getString("shard"));
         }
         assertRecordEnd(expectedTxId1, expectedRecordsCount);
+    }
+
+    @Test
+    public void shouldProvideTransactionMetadataWithoutIdOrTransactionTopic() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl", TEST_SHARDED_KEYSPACE);
+        TestHelper.applyVSchema("vitess_vschema.json");
+        startConnector(config -> config
+                .with(CommonConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                .with("transforms", "filterTransactionTopicRecords,removeField")
+                .with("transforms.filterTransactionTopicRecords.type",
+                        "io.debezium.connector.vitess.transforms.FilterTransactionTopicRecords")
+                .with("transforms.removeField.type", "io.debezium.connector.vitess.transforms.RemoveField")
+                .with("transforms.removeField." + RemoveField.FIELD_NAMES_CONF, "transaction.id")
+                .with(CommonConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class)
+                .with(CommonConnectorConfig.PROVIDE_TRANSACTION_METADATA, true),
+                true,
+                "-80,80-");
+        assertConnectorIsRunning();
+
+        Vgtid baseVgtid = TestHelper.getCurrentVgtid();
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        String rowValue = "(1, 1, 12, 12, 123, 123, 1234, 1234, 12345, 12345, 18446744073709551615, 1.5, 2.5, 12.34, true)";
+        String insertQuery = "INSERT INTO numeric_table ("
+                + "tinyint_col,"
+                + "tinyint_unsigned_col,"
+                + "smallint_col,"
+                + "smallint_unsigned_col,"
+                + "mediumint_col,"
+                + "mediumint_unsigned_col,"
+                + "int_col,"
+                + "int_unsigned_col,"
+                + "bigint_col,"
+                + "bigint_unsigned_col,"
+                + "bigint_unsigned_overflow_col,"
+                + "float_col,"
+                + "double_col,"
+                + "decimal_col,"
+                + "boolean_col)"
+                + " VALUES " + rowValue;
+        StringBuilder insertRows = new StringBuilder().append(insertQuery);
+        for (int i = 1; i < expectedRecordsCount; i++) {
+            insertRows.append(", ").append(rowValue);
+        }
+
+        String insertRowsStatement = insertRows.toString();
+
+        // exercise SUT
+        executeAndWait(insertRowsStatement, TEST_SHARDED_KEYSPACE);
+        // First transaction.
+        Long expectedEpoch = 0L;
+        for (int i = 1; i <= expectedRecordsCount; i++) {
+            SourceRecord record = assertRecordInserted(TEST_SHARDED_KEYSPACE + ".numeric_table", TestHelper.PK_FIELD);
+            Struct source = (Struct) ((Struct) record.value()).get("source");
+            String shard = source.getString("shard");
+            String vgtid = source.getString("vgtid");
+            Vgtid actualVgtid = Vgtid.of(vgtid);
+            final Struct txn = ((Struct) record.value()).getStruct("transaction");
+            assertThat(txn.schema().field("id")).isNull();
+            assertThat(txn.get("transaction_epoch")).isEqualTo(expectedEpoch);
+            BigDecimal expectedRank = VitessRankProvider.getRank(actualVgtid.getShardGtid(shard).getGtid());
+            assertThat(txn.get("transaction_rank")).isEqualTo(expectedRank);
+        }
+    }
+
+    @Test
+    public void shouldProvideTransactionMetadataWithoutIdOrTransactionTopicAndUseLocalVgtid() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl", TEST_SHARDED_KEYSPACE);
+        TestHelper.applyVSchema("vitess_vschema.json");
+        startConnector(config -> config
+                .with(CommonConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                .with("transforms", "filterTransactionTopicRecords,removeField,useLocalVgtid")
+                .with("transforms.filterTransactionTopicRecords.type",
+                        "io.debezium.connector.vitess.transforms.FilterTransactionTopicRecords")
+                .with("transforms.removeField.type", "io.debezium.connector.vitess.transforms.RemoveField")
+                .with("transforms.removeField." + RemoveField.FIELD_NAMES_CONF, "transaction.id")
+                .with("transforms.useLocalVgtid.type", "io.debezium.connector.vitess.transforms.UseLocalVgtid")
+                .with(CommonConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class)
+                .with(CommonConnectorConfig.PROVIDE_TRANSACTION_METADATA, true),
+                true,
+                "-80,80-");
+        assertConnectorIsRunning();
+
+        Vgtid baseVgtid = TestHelper.getCurrentVgtid();
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        String rowValue = "(1, 1, 12, 12, 123, 123, 1234, 1234, 12345, 12345, 18446744073709551615, 1.5, 2.5, 12.34, true)";
+        String insertQuery = "INSERT INTO numeric_table ("
+                + "tinyint_col,"
+                + "tinyint_unsigned_col,"
+                + "smallint_col,"
+                + "smallint_unsigned_col,"
+                + "mediumint_col,"
+                + "mediumint_unsigned_col,"
+                + "int_col,"
+                + "int_unsigned_col,"
+                + "bigint_col,"
+                + "bigint_unsigned_col,"
+                + "bigint_unsigned_overflow_col,"
+                + "float_col,"
+                + "double_col,"
+                + "decimal_col,"
+                + "boolean_col)"
+                + " VALUES " + rowValue;
+        StringBuilder insertRows = new StringBuilder().append(insertQuery);
+        for (int i = 1; i < expectedRecordsCount; i++) {
+            insertRows.append(", ").append(rowValue);
+        }
+
+        String insertRowsStatement = insertRows.toString();
+
+        // exercise SUT
+        executeAndWait(insertRowsStatement, TEST_SHARDED_KEYSPACE);
+        // First transaction.
+        Long expectedEpoch = 0L;
+        for (int i = 1; i <= expectedRecordsCount; i++) {
+            SourceRecord record = assertRecordInserted(TEST_SHARDED_KEYSPACE + ".numeric_table", TestHelper.PK_FIELD);
+            Struct source = (Struct) ((Struct) record.value()).get("source");
+            String shard = source.getString("shard");
+            Vgtid sourceVgtid = Vgtid.of(source.getString("vgtid"));
+            final Struct txn = ((Struct) record.value()).getStruct("transaction");
+            assertThat(txn.schema().field("id")).isNull();
+            assertThat(txn.get("transaction_epoch")).isEqualTo(expectedEpoch);
+            BigDecimal expectedRank = VitessRankProvider.getRank(sourceVgtid.getShardGtid(shard).getGtid());
+            assertThat(txn.get("transaction_rank")).isEqualTo(expectedRank);
+            assertThat(txn.get("total_order")).isEqualTo(1L);
+            // We have two shards for multi-shard keyspace, a local vgtid should only have one shard
+            assertThat(sourceVgtid.getShardGtids().size()).isEqualTo(1);
+            assertThat(sourceVgtid.getShardGtids().get(0).getShard()).isEqualTo(source.getString("shard"));
+        }
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -61,7 +61,6 @@ import io.debezium.embedded.EmbeddedEngine;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.TableId;
-import io.debezium.transforms.ExcludeTransactionComponents;
 import io.debezium.util.Collect;
 import io.debezium.util.Testing;
 

--- a/src/test/java/io/debezium/connector/vitess/transforms/FilterTransactionTopicRecordsTest.java
+++ b/src/test/java/io/debezium/connector/vitess/transforms/FilterTransactionTopicRecordsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.schema.SchemaFactory;
+import io.debezium.schema.SchemaNameAdjuster;
+
+public class FilterTransactionTopicRecordsTest {
+
+    @Test
+    public void shouldExcludeTransactionTopicMessageWhenEnabled() {
+        Schema keySchema = SchemaFactory.get().transactionKeySchema(SchemaNameAdjuster.NO_OP);
+        Struct keyStruct = new Struct(keySchema);
+        Schema valueSchema = SchemaFactory.get().transactionValueSchema(SchemaNameAdjuster.NO_OP);
+        Struct valueStruct = new Struct(valueSchema);
+        SourceRecord sourceRecord = new SourceRecord(
+                null,
+                null,
+                "topic",
+                0,
+                keySchema,
+                keyStruct,
+                valueSchema,
+                valueStruct,
+                null);
+        FilterTransactionTopicRecords<SourceRecord> exclude = new FilterTransactionTopicRecords<>();
+        exclude.configure(Collections.emptyMap());
+        SourceRecord resultRecord = exclude.apply(sourceRecord);
+        assertThat(resultRecord).isNull();
+    }
+
+    @Test
+    public void shouldNotExcludeNonTransactionTopicMessages() {
+        FilterTransactionTopicRecords<SourceRecord> exclude = new FilterTransactionTopicRecords<>();
+        exclude.configure(Collections.emptyMap());
+        SourceRecord resultRecord = exclude.apply(TransformsTestHelper.SOURCE_RECORD);
+        assertThat(resultRecord).isEqualTo(TransformsTestHelper.SOURCE_RECORD);
+    }
+
+}

--- a/src/test/java/io/debezium/connector/vitess/transforms/RemoveFieldTest.java
+++ b/src/test/java/io/debezium/connector/vitess/transforms/RemoveFieldTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.data.Envelope;
+import io.debezium.pipeline.txmetadata.TransactionStructMaker;
+import io.debezium.schema.SchemaFactory;
+
+public class RemoveFieldTest {
+
+    private static final String TRANSACTION_BLOCK_SCHEMA_NAME = "event.block";
+    public static final int TRANSACTION_BLOCK_SCHEMA_VERSION = 1;
+
+    @Test
+    public void shouldExcludeTxIdWhenEnabled() {
+        RemoveField<SourceRecord> removeFields = new RemoveField();
+        Map<String, ?> config = Map.of(RemoveField.FIELD_NAMES_FIELD.name(), "transaction.id");
+        removeFields.configure(config);
+        SourceRecord record = removeFields.apply(TransformsTestHelper.SOURCE_RECORD);
+
+        Schema expectedTransactionSchema = SchemaBuilder.struct().optional()
+                .name(TRANSACTION_BLOCK_SCHEMA_NAME)
+                .version(TRANSACTION_BLOCK_SCHEMA_VERSION)
+                .field(TransactionStructMaker.DEBEZIUM_TRANSACTION_TOTAL_ORDER_KEY, SchemaBuilder.int64().build())
+                .field(TransactionStructMaker.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY, SchemaBuilder.int64().build())
+                .build();
+        Envelope expectedEnvelope = SchemaFactory.get().datatypeEnvelopeSchema()
+                .withRecord(TransformsTestHelper.RECORD_SCHEMA)
+                .withSource(TransformsTestHelper.SOURCE_SCHEMA)
+                .withTransaction(expectedTransactionSchema)
+                .build();
+        Schema expectedValueSchema = expectedEnvelope.schema();
+        Struct expectedValueStruct = new Struct(expectedValueSchema)
+                .put("before", new Struct(TransformsTestHelper.RECORD_SCHEMA).put("id", "foo"))
+                .put("after", new Struct(TransformsTestHelper.RECORD_SCHEMA).put("id", "foo"))
+                .put("op", "c")
+                .put("source", new Struct(TransformsTestHelper.SOURCE_SCHEMA).put("db", "bar"))
+                .put("transaction", new Struct(expectedTransactionSchema)
+                        .put("data_collection_order", 1L)
+                        .put("total_order", 2L));
+
+        Struct actualStruct = (Struct) record.value();
+        Schema actualValueSchema = record.valueSchema();
+
+        assertThat(actualStruct).isEqualTo(expectedValueStruct);
+        assertThat(actualValueSchema).isEqualTo(expectedValueSchema);
+    }
+
+    @Test
+    public void shouldExcludeTotalOrderWhenEnabled() {
+        RemoveField<SourceRecord> removeFields = new RemoveField();
+        Map<String, ?> config = Map.of(RemoveField.FIELD_NAMES_FIELD.name(), "transaction.total_order");
+        removeFields.configure(config);
+        SourceRecord record = removeFields.apply(TransformsTestHelper.SOURCE_RECORD);
+
+        Schema expectedTransactionSchema = SchemaBuilder.struct().optional()
+                .name(TRANSACTION_BLOCK_SCHEMA_NAME)
+                .version(TRANSACTION_BLOCK_SCHEMA_VERSION)
+                .field(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY, SchemaBuilder.string().build())
+                .field(TransactionStructMaker.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY, SchemaBuilder.int64().build())
+                .build();
+        Envelope expectedEnvelope = SchemaFactory.get().datatypeEnvelopeSchema()
+                .withRecord(TransformsTestHelper.RECORD_SCHEMA)
+                .withSource(TransformsTestHelper.SOURCE_SCHEMA)
+                .withTransaction(expectedTransactionSchema)
+                .build();
+        Schema expectedValueSchema = expectedEnvelope.schema();
+        Struct expectedValueStruct = new Struct(expectedValueSchema)
+                .put("before", new Struct(TransformsTestHelper.RECORD_SCHEMA).put("id", "foo"))
+                .put("after", new Struct(TransformsTestHelper.RECORD_SCHEMA).put("id", "foo"))
+                .put("op", "c")
+                .put("source", new Struct(TransformsTestHelper.SOURCE_SCHEMA).put("db", "bar"))
+                .put("transaction", new Struct(expectedTransactionSchema)
+                        .put("id", "foo")
+                        .put("data_collection_order", 1L));
+
+        Struct actualStruct = (Struct) record.value();
+        Schema actualValueSchema = record.valueSchema();
+
+        assertThat(actualStruct).isEqualTo(expectedValueStruct);
+        assertThat(actualValueSchema).isEqualTo(expectedValueSchema);
+    }
+
+    @Test
+    public void shouldExcludeDataCollectionOrderWhenEnabled() {
+
+        RemoveField<SourceRecord> removeFields = new RemoveField();
+        Map<String, ?> config = Map.of(RemoveField.FIELD_NAMES_FIELD.name(), "transaction.data_collection_order");
+        removeFields.configure(config);
+        SourceRecord record = removeFields.apply(TransformsTestHelper.SOURCE_RECORD);
+
+        Schema expectedTransactionSchema = SchemaBuilder.struct().optional()
+                .name(TRANSACTION_BLOCK_SCHEMA_NAME)
+                .version(TRANSACTION_BLOCK_SCHEMA_VERSION)
+                .field(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY, SchemaBuilder.string().build())
+                .field(TransactionStructMaker.DEBEZIUM_TRANSACTION_TOTAL_ORDER_KEY, SchemaBuilder.int64().build())
+                .build();
+        Envelope expectedEnvelope = SchemaFactory.get().datatypeEnvelopeSchema()
+                .withRecord(TransformsTestHelper.RECORD_SCHEMA)
+                .withSource(TransformsTestHelper.SOURCE_SCHEMA)
+                .withTransaction(expectedTransactionSchema)
+                .build();
+        Schema expectedValueSchema = expectedEnvelope.schema();
+        Struct expectedValueStruct = new Struct(expectedValueSchema)
+                .put("before", new Struct(TransformsTestHelper.RECORD_SCHEMA).put("id", "foo"))
+                .put("after", new Struct(TransformsTestHelper.RECORD_SCHEMA).put("id", "foo"))
+                .put("op", "c")
+                .put("source", new Struct(TransformsTestHelper.SOURCE_SCHEMA).put("db", "bar"))
+                .put("transaction", new Struct(expectedTransactionSchema)
+                        .put("id", "foo")
+                        .put("total_order", 2L));
+
+        Struct actualStruct = (Struct) record.value();
+        Schema actualValueSchema = record.valueSchema();
+
+        assertThat(actualStruct).isEqualTo(expectedValueStruct);
+        assertThat(actualValueSchema).isEqualTo(expectedValueSchema);
+    }
+
+    @Test
+    public void shouldValidateConfigImproperFormat() {
+        RemoveField<SourceRecord> exclude = new RemoveField();
+        Map<String, ?> config = Map.of(RemoveField.FIELD_NAMES_FIELD.name(), ".invalid_option");
+        assertThatThrownBy(() -> {
+            exclude.configure(config);
+        }).isInstanceOf(ConfigException.class);
+        Map<String, ?> config2 = Map.of(RemoveField.FIELD_NAMES_FIELD.name(), "valid,invalid_option.");
+        assertThatThrownBy(() -> {
+            exclude.configure(config);
+        }).isInstanceOf(ConfigException.class);
+    }
+
+    @Test
+    public void shouldValidateConfigNoFieldNames() {
+        RemoveField<SourceRecord> exclude = new RemoveField();
+        Map<String, ?> config = Map.of(RemoveField.FIELD_NAMES_FIELD.name(), "");
+        assertThatThrownBy(() -> {
+            exclude.configure(config);
+        }).isInstanceOf(ConfigException.class);
+    }
+
+    @Test
+    public void shouldValidateConfigNullFieldNames() {
+        RemoveField<SourceRecord> exclude = new RemoveField();
+        Map<String, String> config = new HashMap<>();
+        config.put(RemoveField.FIELD_NAMES_FIELD.name(), null);
+        assertThatThrownBy(() -> {
+            exclude.configure(config);
+        }).isInstanceOf(ConfigException.class);
+    }
+
+    @Test
+    public void shouldValidateConfigMultipleFieldNames() {
+        RemoveField<SourceRecord> removeField = new RemoveField();
+        Map<String, ?> config = Map.of(RemoveField.FIELD_NAMES_FIELD.name(), "foo.bar,foo1");
+        removeField.configure(config);
+        // assert the list created correctly
+        assertThat(removeField.fieldNames).isEqualTo(List.of("foo.bar", "foo1"));
+    }
+
+}

--- a/src/test/java/io/debezium/connector/vitess/transforms/TransformsTestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/transforms/TransformsTestHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.transforms;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.data.Envelope;
+import io.debezium.schema.SchemaFactory;
+
+public class TransformsTestHelper {
+    public static Schema RECORD_SCHEMA = SchemaBuilder.struct()
+            .field("id", Schema.STRING_SCHEMA)
+            .build();
+    public static Schema TRANSACTION_SCHEMA = SchemaFactory.get().transactionBlockSchema();
+    public static Schema SOURCE_SCHEMA = SchemaBuilder.struct()
+            .field("db", Schema.STRING_SCHEMA).build();
+    public static Envelope ENVELOPE = SchemaFactory.get().datatypeEnvelopeSchema()
+            .withRecord(RECORD_SCHEMA)
+            .withSource(SOURCE_SCHEMA)
+            .withTransaction(TRANSACTION_SCHEMA)
+            .build();
+    public static Schema KEY_SCHEMA = SchemaBuilder.struct().field("key", SchemaBuilder.STRING_SCHEMA).build();
+    public static Struct KEY_STRUCT = new Struct(KEY_SCHEMA).put("key", "k1");
+    public static Schema VALUE_SCHEMA = ENVELOPE.schema();
+    public static Struct VALUE_STRUCT = new Struct(VALUE_SCHEMA)
+            .put("before", new Struct(RECORD_SCHEMA).put("id", "foo"))
+            .put("after", new Struct(RECORD_SCHEMA).put("id", "foo"))
+            .put("op", "c")
+            .put("source", new Struct(SOURCE_SCHEMA).put("db", "bar"))
+            .put("transaction", new Struct(TRANSACTION_SCHEMA)
+                    .put("id", "foo")
+                    .put("data_collection_order", 1L)
+                    .put("total_order", 2L));
+    public static SourceRecord SOURCE_RECORD = new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            KEY_SCHEMA,
+            KEY_STRUCT,
+            VALUE_SCHEMA,
+            VALUE_STRUCT,
+            null);
+}

--- a/src/test/java/io/debezium/connector/vitess/transforms/UseLocalVgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/transforms/UseLocalVgtidTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.transforms;
+
+import static io.debezium.connector.vitess.SourceInfo.SHARD_KEY;
+import static io.debezium.connector.vitess.SourceInfo.VGTID_KEY;
+import static io.debezium.connector.vitess.VgtidTest.TEST_GTID;
+import static io.debezium.connector.vitess.VgtidTest.TEST_KEYSPACE;
+import static io.debezium.connector.vitess.VgtidTest.TEST_SHARD;
+import static io.debezium.connector.vitess.VgtidTest.VGTID_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.data.Envelope;
+import io.debezium.schema.SchemaFactory;
+
+public class UseLocalVgtidTest {
+
+    public static final String LOCAL_VGTID_JSON_WITH_LAST_PK_TEMPLATE = "[" +
+            "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}" +
+            "]";
+
+    public static final String LOCAL_VGTID_JSON_WITH_LAST_PK = String.format(
+            LOCAL_VGTID_JSON_WITH_LAST_PK_TEMPLATE,
+            TEST_KEYSPACE,
+            TEST_SHARD,
+            TEST_GTID);
+
+    @Test
+    public void shouldNotReplaceATableWithVgtidColumn() {
+        Schema recordSchema = SchemaBuilder.struct()
+                .field(VGTID_KEY, Schema.STRING_SCHEMA)
+                .build();
+        Schema sourceSchema = SchemaBuilder.struct()
+                .field(VGTID_KEY, Schema.STRING_SCHEMA)
+                .field(SHARD_KEY, Schema.STRING_SCHEMA).build();
+        Envelope envelope = SchemaFactory.get().datatypeEnvelopeSchema()
+                .withRecord(recordSchema)
+                .withSource(sourceSchema)
+                .build();
+        Schema valueSchema = envelope.schema();
+        Struct valueStruct = new Struct(valueSchema)
+                .put("before", new Struct(recordSchema).put(VGTID_KEY, "foo"))
+                .put("after", new Struct(recordSchema).put(VGTID_KEY, "foo"))
+                .put("op", "c")
+                .put("source", new Struct(sourceSchema)
+                        .put(VGTID_KEY, VGTID_JSON)
+                        .put(SHARD_KEY, TEST_SHARD));
+
+        SourceRecord sourceRecord = new SourceRecord(
+                null,
+                null,
+                "topic",
+                0,
+                null,
+                null,
+                valueSchema,
+                valueStruct,
+                null);
+
+        UseLocalVgtid<SourceRecord> useLocalVgtid = new UseLocalVgtid();
+        SourceRecord result = useLocalVgtid.apply(sourceRecord);
+
+        Envelope expectedEnvelope = SchemaFactory.get().datatypeEnvelopeSchema()
+                .withRecord(recordSchema)
+                .withSource(sourceSchema)
+                .build();
+        Schema expectedValueSchema = expectedEnvelope.schema();
+        Struct expectedValueStruct = new Struct(expectedValueSchema)
+                .put("before", new Struct(recordSchema).put(VGTID_KEY, "foo"))
+                .put("after", new Struct(recordSchema).put(VGTID_KEY, "foo"))
+                .put("op", "c")
+                .put("source", new Struct(sourceSchema)
+                        .put(VGTID_KEY, LOCAL_VGTID_JSON_WITH_LAST_PK)
+                        .put(SHARD_KEY, TEST_SHARD));
+
+        assertThat(result.value()).isEqualTo(expectedValueStruct);
+    }
+
+    @Test
+    public void shouldReplaceWithLocalVgtid() {
+        Schema recordSchema = SchemaBuilder.struct()
+                .field("id", Schema.STRING_SCHEMA)
+                .build();
+        Schema sourceSchema = SchemaBuilder.struct()
+                .field(VGTID_KEY, Schema.STRING_SCHEMA)
+                .field(SHARD_KEY, Schema.STRING_SCHEMA).build();
+        Envelope envelope = SchemaFactory.get().datatypeEnvelopeSchema()
+                .withRecord(recordSchema)
+                .withSource(sourceSchema)
+                .build();
+        Schema valueSchema = envelope.schema();
+        Struct valueStruct = new Struct(valueSchema)
+                .put("before", new Struct(recordSchema).put("id", "foo"))
+                .put("after", new Struct(recordSchema).put("id", "foo"))
+                .put("op", "c")
+                .put("source", new Struct(sourceSchema)
+                        .put(VGTID_KEY, VGTID_JSON)
+                        .put(SHARD_KEY, TEST_SHARD));
+
+        SourceRecord sourceRecord = new SourceRecord(
+                null,
+                null,
+                "topic",
+                0,
+                null,
+                null,
+                valueSchema,
+                valueStruct,
+                null);
+
+        UseLocalVgtid<SourceRecord> useLocalVgtid = new UseLocalVgtid();
+        SourceRecord result = useLocalVgtid.apply(sourceRecord);
+
+        Envelope expectedEnvelope = SchemaFactory.get().datatypeEnvelopeSchema()
+                .withRecord(recordSchema)
+                .withSource(sourceSchema)
+                .build();
+        Schema expectedValueSchema = expectedEnvelope.schema();
+        Struct expectedValueStruct = new Struct(expectedValueSchema)
+                .put("before", new Struct(recordSchema).put("id", "foo"))
+                .put("after", new Struct(recordSchema).put("id", "foo"))
+                .put("op", "c")
+                .put("source", new Struct(sourceSchema)
+                        .put(VGTID_KEY, LOCAL_VGTID_JSON_WITH_LAST_PK)
+                        .put(SHARD_KEY, TEST_SHARD));
+
+        assertThat(result.value()).isEqualTo(expectedValueStruct);
+    }
+}


### PR DESCRIPTION
[DBZ-6721](https://issues.redhat.com/browse/DBZ-6721)
[DBZ-6722](https://issues.redhat.com/browse/DBZ-6722)

Add three new transforms

### Filter Transaction Topic
For connectors where the volume is high (transaction topic is massive), we can drop all messages matching the schema

### Remove Field
Generic config for specifying field names (separated by dot '.' for nesting) to remove fields. Can be used to drop any field, in this case we use for transaction.id which can be very large in vitess (contains all shards gtid).

### Local VGTID
Update VGTID field to only contain vgtid for the shard that the change happened in.

We add this local vgtid transformation (add a hashmap so we don't have to iterate over all shards to do this).

We need to keep the vgtid global for proper offset/state storage so therefore it must be done only at the end as SMT before publishing the message (and does not affect source offset of the message).

### Itests
Also add itests for all these functionalities together for how they can be used to receive transaction order metadata without massively increasing data volume produced.