### PR TITLE
DBZ-7905 Handle single position with host in gtid

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -230,6 +230,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
             @Override
             public void onError(Throwable t) {
                 LOGGER.error("VStream streaming onError. Status: {}", Status.fromThrowable(t), t);
+                LOGGER.error("Error caused by", t.getCause());
                 // Only propagate the first error
                 error.compareAndSet(null, t);
                 reset();

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -230,7 +230,6 @@ public class VitessReplicationConnection implements ReplicationConnection {
             @Override
             public void onError(Throwable t) {
                 LOGGER.error("VStream streaming onError. Status: {}", Status.fromThrowable(t), t);
-                LOGGER.error("Error caused by", t.getCause());
                 // Only propagate the first error
                 error.compareAndSet(null, t);
                 reset();

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/GtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/GtidTest.java
@@ -6,11 +6,14 @@
 package io.debezium.connector.vitess.pipeline.txmetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Set;
 
 import org.junit.Test;
+
+import io.debezium.DebeziumException;
 
 public class GtidTest {
 
@@ -21,6 +24,38 @@ public class GtidTest {
         assertThat(gtid.getVersion()).isEqualTo(expectedVersion);
         assertThat(gtid.getSequenceValues()).isEqualTo(List.of("4", "10"));
         assertThat(gtid.getHosts()).isEqualTo(Set.of("host1", "host2"));
+    }
+
+    @Test
+    public void shouldHandleSingleValue() {
+        String expectedVersion = "MySQL56";
+        Gtid gtid = new Gtid(expectedVersion + "/host1:1,host2:2-10");
+        assertThat(gtid.getVersion()).isEqualTo(expectedVersion);
+        assertThat(gtid.getSequenceValues()).isEqualTo(List.of("1", "10"));
+        assertThat(gtid.getHosts()).isEqualTo(Set.of("host1", "host2"));
+    }
+
+    @Test
+    public void shouldThrowExceptionOnEmptyStringWithPrefix() {
+        String expectedVersion = "MySQL56";
+        assertThatThrownBy(() -> {
+            Gtid gtid = new Gtid(expectedVersion + "/");
+        }).isInstanceOf(DebeziumException.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionOnVersionOnly() {
+        String expectedVersion = "MySQL56";
+        assertThatThrownBy(() -> {
+            Gtid gtid = new Gtid(expectedVersion);
+        }).isInstanceOf(DebeziumException.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionOnVersionOnEmptyString() {
+        assertThatThrownBy(() -> {
+            Gtid gtid = new Gtid("");
+        }).isInstanceOf(DebeziumException.class);
     }
 
 }


### PR DESCRIPTION
We can have an edge case where a mysql/vitess host is only used for a single binlog position so it's not a range format host1:1-5 instead just host1:5 so we adapt parsing logic to handle this and reproduce with a test.