### PR TITLE
DBZ-7910 Fix column exclude filter type, add itest

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -489,7 +489,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                 config,
                 null, x -> x.schema() + "." + x.table(),
                 -1,
-                ColumnFilterMode.CATALOG,
+                ColumnFilterMode.SCHEMA,
                 true);
     }
 

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -209,6 +209,22 @@ public abstract class AbstractVitessConnectorTest extends AbstractConnectorTest 
         return fields;
     }
 
+    protected List<SchemaAndValueField> schemasAndValuesForStringTypesExcludedColumn() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField("char_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "a"),
+                        new SchemaAndValueField("varchar_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "bc"),
+                        new SchemaAndValueField("varchar_ko_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "상품 명1"),
+                        new SchemaAndValueField("varchar_ja_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "リンゴ"),
+                        new SchemaAndValueField("tinytext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "gh"),
+                        new SchemaAndValueField("text_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "ij"),
+                        new SchemaAndValueField("longtext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "mn"),
+                        new SchemaAndValueField("json_col", Json.builder().optional().build(),
+                                "{\"key1\":\"value1\",\"key2\":{\"key21\":\"value21\",\"key22\":\"value22\"}}")));
+        return fields;
+    }
+
     protected List<SchemaAndValueField> schemasAndValuesForBytesTypesAsBytes() {
         final List<SchemaAndValueField> fields = new ArrayList<>();
         fields.addAll(


### PR DESCRIPTION
We were previously wrongly using catalog (which stores the shard as done in https://github.com/debezium/debezium-connector-vitess/pull/149) for doing column exclusion. Change to schema (keyspace) and add itest to reproduce issue.