### PR TITLE
DBZ-7962 Add heartbeats

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -31,10 +31,15 @@ import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.vitess.connection.VitessTabletType;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.heartbeat.HeartbeatConnectionProvider;
+import io.debezium.heartbeat.HeartbeatErrorHandler;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.spi.topic.TopicNamingStrategy;
 
 /**
  * Vitess connector configuration, including its specific configurations and the common
@@ -652,6 +657,15 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
     @Override
     public Optional<EnumeratedValue> getSnapshotLockingMode() {
         return Optional.empty();
+    }
+
+    @Override
+    public Heartbeat createHeartbeat(TopicNamingStrategy topicNamingStrategy, SchemaNameAdjuster schemaNameAdjuster,
+                                     HeartbeatConnectionProvider connectionProvider, HeartbeatErrorHandler errorHandler) {
+        if (getHeartbeatInterval().isZero()) {
+            return Heartbeat.DEFAULT_NOOP_HEARTBEAT;
+        }
+        return new VitessHeartbeatImpl(getHeartbeatInterval(), topicNamingStrategy.heartbeatTopic(), getLogicalName(), schemaNameAdjuster);
     }
 
     public BigIntUnsignedHandlingMode getBigIntUnsgnedHandlingMode() {

--- a/src/main/java/io/debezium/connector/vitess/VitessHeartbeatImpl.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessHeartbeatImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.heartbeat.HeartbeatImpl;
+import io.debezium.schema.SchemaNameAdjuster;
+
+public class VitessHeartbeatImpl extends HeartbeatImpl implements Heartbeat {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VitessHeartbeatImpl.class);
+
+    private final String topicName;
+    private final String key;
+
+    private final Schema keySchema;
+    private final Schema valueSchema;
+
+    public VitessHeartbeatImpl(Duration heartbeatInterval, String topicName, String key, SchemaNameAdjuster schemaNameAdjuster) {
+        super(heartbeatInterval, topicName, key, schemaNameAdjuster);
+        this.topicName = topicName;
+        this.key = key;
+        keySchema = VitessSchemaFactory.get().heartbeatKeySchema(schemaNameAdjuster);
+        valueSchema = VitessSchemaFactory.get().heartbeatValueSchema(schemaNameAdjuster);
+    }
+
+    @Override
+    public void forcedBeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer)
+            throws InterruptedException {
+        LOGGER.debug("Generating heartbeat event");
+        if (offset == null || offset.isEmpty()) {
+            // Do not send heartbeat message if no offset is available yet
+            return;
+        }
+        consumer.accept(heartbeatRecord(partition, offset));
+    }
+
+    private SourceRecord heartbeatRecord(Map<String, ?> sourcePartition, Map<String, ?> sourceOffset) {
+        final Integer partition = 0;
+
+        return new SourceRecord(sourcePartition, sourceOffset,
+                topicName, partition, keySchema, serverNameKey(key), valueSchema, messageValue(sourceOffset));
+    }
+
+    private Struct serverNameKey(String serverName) {
+        Struct result = new Struct(keySchema);
+        result.put(SERVER_NAME_KEY, serverName);
+        return result;
+    }
+
+    private Struct messageValue(Map<String, ?> sourceOffset) {
+        String vgtid = (String) sourceOffset.get(SourceInfo.VGTID_KEY);
+        if (vgtid == null) {
+            vgtid = "";
+        }
+        Struct result = new Struct(valueSchema);
+        result.put(SourceInfo.VGTID_KEY, vgtid);
+        result.put(AbstractSourceInfo.TIMESTAMP_KEY, Instant.now().toEpochMilli());
+        return result;
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/VitessSchemaFactory.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessSchemaFactory.java
@@ -9,11 +9,16 @@ import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
+import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionContext;
 import io.debezium.pipeline.txmetadata.TransactionStructMaker;
 import io.debezium.schema.SchemaFactory;
+import io.debezium.schema.SchemaNameAdjuster;
 
 public class VitessSchemaFactory extends SchemaFactory {
+
+    private static final String VITESS_HEARTBEAT_VALUE_SCHEMA_NAME = "io.debezium.connector.vitess.Heartbeat";
+    private static final int VITESS_HEARTBEAT_VALUE_SCHEMA_VERSION = 1;
 
     public VitessSchemaFactory() {
         super();
@@ -36,5 +41,16 @@ public class VitessSchemaFactory extends SchemaFactory {
                 .field(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, Schema.INT64_SCHEMA)
                 .field(VitessOrderedTransactionContext.OFFSET_TRANSACTION_RANK, rankSchema)
                 .build();
+    }
+
+    @Override
+    public Schema heartbeatValueSchema(SchemaNameAdjuster adjuster) {
+        return SchemaBuilder.struct()
+                .name(adjuster.adjust(VITESS_HEARTBEAT_VALUE_SCHEMA_NAME))
+                .version(VITESS_HEARTBEAT_VALUE_SCHEMA_VERSION)
+                .field(SourceInfo.VGTID_KEY, Schema.STRING_SCHEMA)
+                .field(AbstractSourceInfo.TIMESTAMP_KEY, Schema.INT64_SCHEMA)
+                .build();
+
     }
 }

--- a/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
@@ -103,6 +103,8 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
                 else if (message.getOperation() == ReplicationMessage.Operation.COMMIT) {
                     // send to transaction topic
                     dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext, message.getCommitTime());
+                    // Send a heartbeat event if time has elapsed
+                    dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
                 }
                 return;
             }

--- a/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
@@ -110,6 +110,9 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
                 // DDL event or OTHER event
                 offsetContext.rotateVgtid(newVgtid, message.getCommitTime());
             }
+            else if (message.getOperation().equals(ReplicationMessage.Operation.HEARTBEAT)) {
+                dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
+            }
             else {
                 // DML event
                 TableId tableId = VitessDatabaseSchema.parse(message.getTable());

--- a/src/main/java/io/debezium/connector/vitess/connection/HeartbeatMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/HeartbeatMessage.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.connection;
+
+import java.time.Instant;
+import java.util.List;
+
+public class HeartbeatMessage implements ReplicationMessage {
+
+    private final Instant commitTime;
+    private final Operation operation;
+
+    public HeartbeatMessage(Instant commitTime) {
+        this.commitTime = commitTime;
+        this.operation = Operation.HEARTBEAT;
+    }
+
+    @Override
+    public Operation getOperation() {
+        return Operation.HEARTBEAT;
+    }
+
+    @Override
+    public Instant getCommitTime() {
+        return commitTime;
+    }
+
+    @Override
+    public String getTransactionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getShard() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Column> getOldTupleList() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Column> getNewTupleList() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        return "HeartbeatMessage{"
+                + "commitTime="
+                + commitTime
+                + ", operation="
+                + operation
+                + '}';
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
@@ -24,7 +24,8 @@ public interface ReplicationMessage {
         BEGIN,
         COMMIT,
         DDL,
-        OTHER
+        OTHER,
+        HEARTBEAT
     }
 
     /** A representation of column value delivered as a part of replication message */

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -83,6 +83,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                 break;
             case HEARTBEAT:
                 handleHeartbeat(vEvent, processor, newVgtid);
+                break;
             case VGTID:
             case VERSION:
                 break;

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -81,6 +81,8 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
             case OTHER:
                 handleOther(vEvent, processor, newVgtid);
                 break;
+            case HEARTBEAT:
+                handleHeartbeat(vEvent, processor, newVgtid);
             case VGTID:
             case VERSION:
                 break;
@@ -109,6 +111,11 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
         }
         processor.process(
                 new OtherMessage(transactionId, eventTimestamp), newVgtid, false);
+    }
+
+    private void handleHeartbeat(Binlogdata.VEvent vEvent, ReplicationMessageProcessor processor, Vgtid newVgtid) throws InterruptedException {
+        Instant eventTimestamp = Instant.ofEpochSecond(vEvent.getTimestamp());
+        processor.process(new HeartbeatMessage(eventTimestamp), newVgtid, false);
     }
 
     private void handleBeginMessage(Binlogdata.VEvent vEvent, ReplicationMessageProcessor processor, Vgtid newVgtid)

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.schema.DefaultTopicNamingStrategy;
+import io.debezium.schema.SchemaNameAdjuster;
+
+public class VitessConnectorConfigTest {
+
+    @Test
+    public void shouldGetVitessHeartbeatImplWhenIntervalSet() {
+        Configuration configuration = TestHelper.defaultConfig().with(
+                Heartbeat.HEARTBEAT_INTERVAL, 1000).build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        Heartbeat heartbeat = connectorConfig.createHeartbeat(
+                DefaultTopicNamingStrategy.create(connectorConfig),
+                SchemaNameAdjuster.NO_OP,
+                null,
+                null);
+        assertThat(heartbeat).isNotNull();
+        assertThat(heartbeat instanceof VitessHeartbeatImpl).isTrue();
+    }
+
+    @Test
+    public void shouldGetVitessHeartbeatNoOp() {
+        Configuration configuration = TestHelper.defaultConfig().build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        Heartbeat heartbeat = connectorConfig.createHeartbeat(
+                DefaultTopicNamingStrategy.create(connectorConfig),
+                SchemaNameAdjuster.NO_OP,
+                null,
+                null);
+        assertThat(heartbeat).isNotNull();
+        assertThat(heartbeat).isEqualTo(Heartbeat.DEFAULT_NOOP_HEARTBEAT);
+    }
+
+}

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -161,8 +161,11 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         String topic = Heartbeat.HEARTBEAT_TOPICS_PREFIX.defaultValueAsString() + "." + TEST_SERVER;
         int expectedHeartbeatRecords = 1;
-        // Sleep for 3 seconds, heartbeat sent every 1 second
-        Thread.sleep(3 * 1000);
+        Awaitility
+                .await()
+                .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
+                .pollInterval(Duration.ofSeconds(1))
+                .until(() -> consumeRecordsByTopic(expectedHeartbeatRecords).allRecordsInOrder().size() >= expectedHeartbeatRecords);
 
         AbstractConnectorTest.SourceRecords records = consumeRecordsByTopic(expectedHeartbeatRecords, 1);
         assertThat(records.recordsForTopic(topic).size()).isEqualTo(expectedHeartbeatRecords);
@@ -181,8 +184,11 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         String topic = Heartbeat.HEARTBEAT_TOPICS_PREFIX.defaultValueAsString() + "." + TEST_SERVER;
         int expectedHeartbeatRecords = 1;
-        // Sleep for 3 seconds, heartbeat sent every 1 second
-        Thread.sleep(3 * 1000);
+        Awaitility
+                .await()
+                .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
+                .pollInterval(Duration.ofSeconds(1))
+                .until(() -> consumeRecordsByTopic(expectedHeartbeatRecords).allRecordsInOrder().size() >= expectedHeartbeatRecords);
 
         AbstractConnectorTest.SourceRecords records = consumeRecordsByTopic(expectedHeartbeatRecords, 1);
         List<SourceRecord> recordsForTopic = records.recordsForTopic(topic);

--- a/src/test/java/io/debezium/connector/vitess/VitessHeartbeatImplTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessHeartbeatImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.function.BlockingConsumer;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.schema.SchemaNameAdjuster;
+
+public class VitessHeartbeatImplTest {
+
+    class CapturingBlockingConsumer implements BlockingConsumer<SourceRecord> {
+
+        private final List<SourceRecord> records = new ArrayList<>();
+
+        @Override
+        public void accept(SourceRecord record) throws InterruptedException {
+            this.records.add(record);
+        }
+
+        public List<SourceRecord> getRecords() {
+            return records;
+        }
+    }
+
+    @Test
+    public void shouldNotSendRecordIfNoOffset() throws InterruptedException {
+        Heartbeat heartbeat = new VitessHeartbeatImpl(Duration.ofMillis(1), "topicName", "key", SchemaNameAdjuster.NO_OP);
+        CapturingBlockingConsumer blockingConsumer = new CapturingBlockingConsumer();
+        heartbeat.forcedBeat(null, null, blockingConsumer);
+        assertThat(blockingConsumer.getRecords()).isEmpty();
+    }
+
+    @Test
+    public void shouldSendRecordIfOffsetPresent() throws InterruptedException {
+        Heartbeat heartbeat = new VitessHeartbeatImpl(Duration.ofMillis(1), "topicName", "key", SchemaNameAdjuster.NO_OP);
+        CapturingBlockingConsumer blockingConsumer = new CapturingBlockingConsumer();
+        Map<String, ?> offset = Map.of("foo", "bar");
+        heartbeat.forcedBeat(null, offset, blockingConsumer);
+        assertThat(blockingConsumer.getRecords()).isNotEmpty();
+    }
+
+    @Test
+    public void shouldSendRecordWithVgtid() throws InterruptedException {
+        Heartbeat heartbeat = new VitessHeartbeatImpl(Duration.ofMillis(1), "topicName", "key", SchemaNameAdjuster.NO_OP);
+        CapturingBlockingConsumer blockingConsumer = new CapturingBlockingConsumer();
+        String expectedVgtid = "bar";
+        Map<String, ?> offset = Map.of("vgtid", expectedVgtid);
+        heartbeat.forcedBeat(null, offset, blockingConsumer);
+        SourceRecord record = blockingConsumer.getRecords().get(0);
+        assertThat(record).isNotNull();
+        Struct value = (Struct) record.value();
+        assertThat(value.get(SourceInfo.VGTID_KEY)).isEqualTo(expectedVgtid);
+    }
+
+}

--- a/src/test/java/io/debezium/connector/vitess/VitessSchemaFactoryTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessSchemaFactoryTest.java
@@ -14,8 +14,10 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Test;
 
+import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionContext;
 import io.debezium.pipeline.txmetadata.TransactionStructMaker;
+import io.debezium.schema.SchemaNameAdjuster;
 
 public class VitessSchemaFactoryTest {
 
@@ -33,6 +35,14 @@ public class VitessSchemaFactoryTest {
         assertThat(fields).contains(new Field(TransactionStructMaker.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY, 2, Schema.INT64_SCHEMA));
         assertThat(fields).contains(new Field(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, 3, Schema.INT64_SCHEMA));
         assertThat(fields).contains(new Field(VitessOrderedTransactionContext.OFFSET_TRANSACTION_RANK, 4, Decimal.schema(0)));
+    }
+
+    @Test
+    public void getHeartbeatValueSchema() {
+        Schema heartbeatValueSchema = VitessSchemaFactory.get().heartbeatValueSchema(SchemaNameAdjuster.NO_OP);
+        List<Field> fields = heartbeatValueSchema.fields();
+        assertThat(fields).contains(new Field(SourceInfo.VGTID_KEY, 0, Schema.STRING_SCHEMA));
+        assertThat(fields).contains(new Field(AbstractSourceInfo.TIMESTAMP_KEY, 1, Schema.INT64_SCHEMA));
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/connection/HeartbeatMessageTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/HeartbeatMessageTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+public class HeartbeatMessageTest {
+
+    @Test
+    public void getOperation() {
+        ReplicationMessage message = new HeartbeatMessage(Instant.EPOCH);
+        assertThat(message.getOperation()).isEqualTo(ReplicationMessage.Operation.HEARTBEAT);
+    }
+
+    @Test
+    public void getCommitTime() {
+        ReplicationMessage message = new HeartbeatMessage(Instant.EPOCH);
+        assertThat(message.getCommitTime()).isEqualTo(Instant.EPOCH);
+    }
+
+    @Test
+    public void getTransactionId() {
+        ReplicationMessage message = new HeartbeatMessage(Instant.EPOCH);
+        assertThatThrownBy(() -> message.getTransactionId())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void getTable() {
+        ReplicationMessage message = new HeartbeatMessage(Instant.EPOCH);
+        assertThatThrownBy(() -> message.getTable())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void getShard() {
+        ReplicationMessage message = new HeartbeatMessage(Instant.EPOCH);
+        assertThatThrownBy(() -> message.getShard())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void getOldTupleList() {
+        ReplicationMessage message = new HeartbeatMessage(Instant.EPOCH);
+        assertThatThrownBy(() -> message.getOldTupleList())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void getNewTupleList() {
+        ReplicationMessage message = new HeartbeatMessage(Instant.EPOCH);
+        assertThatThrownBy(() -> message.getNewTupleList())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void testToString() {
+        ReplicationMessage message = new HeartbeatMessage(Instant.EPOCH);
+        assertThat(message.toString()).isEqualTo("HeartbeatMessage{commitTime=1970-01-01T00:00:00Z, operation=HEARTBEAT}");
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
@@ -80,6 +80,34 @@ public class VStreamOutputMessageDecoderTest {
     }
 
     @Test
+    public void shouldProcessHeartbeatEvent() throws Exception {
+        // setup fixture
+        String expectedShard = "shard";
+        Binlogdata.VEvent event = Binlogdata.VEvent.newBuilder()
+                .setType(Binlogdata.VEventType.HEARTBEAT)
+                .setShard(expectedShard)
+                .setTimestamp(AnonymousValue.getLong())
+                .build();
+        Vgtid newVgtid = Vgtid.of(VgtidTest.VGTID_JSON);
+
+        // exercise SUT
+        final boolean[] processed = { false };
+        decoder.processMessage(
+                event,
+                (message, vgtid, isLastRowEventOfTransaction) -> {
+                    // verify outcome
+                    assertThat(message).isNotNull();
+                    assertThat(message).isInstanceOf(HeartbeatMessage.class);
+                    assertThat(message.getOperation()).isEqualTo(ReplicationMessage.Operation.HEARTBEAT);
+                    processed[0] = true;
+                },
+                newVgtid,
+                false,
+                false);
+        assertThat(processed[0]).isTrue();
+    }
+
+    @Test
     @FixFor("DBZ-4667")
     public void shouldNotProcessBeginEventIfNoVgtid() throws Exception {
         // setup fixture


### PR DESCRIPTION
### Summary

In the case of low volume write tables, we need to be able to emit heartbeat events.

### Design

Other connectors do this with a heartbeat query that is run regularly in the upstream database. We don't need to do this since Vitess/VStream provides a helpful flag called [HeartbeatInterval](https://vitess.io/docs/17.0/reference/vreplication/vstream/#heartbeatinterval). We can use the HeartbeatInterval config already present in Debezium core to get this value, parse as seconds, and pass to the VStream API. With this set up, the vstream channel will receive regular heartbeat events from the vtgate indicating liveness. We can dispatch downstream heartbeat events for each we receive.

In order for the heartbeat to be useful, we must know which vitess shards it pertains to (e.g., 8 shards, 2 tasks, each streaming data for 4 shards, if one task is down, how do we detect it from the heartbeats?). So we include the vgtid in each heartbeat's payload, this vgtid forms the collections of shards for this task and will allow us to determine which shards this heartbeat is indicating liveness for.

### Implementation
Various changes to support another data type Heartbeat. Handling it correctly in the replication connection (ie send the event even if we didn't receive a complete transaction, ie between transactions). Decode and read the timestamp properly. Call dispatch heartbeat event for each heartbeat event we receive. We call it roughly as frequently as its own heartbeat expiration logic (assuming no events to send, if there are events it will be longer, which is fine since heartbeats are needed when there are no events, and we want to keep up with realtime rather than be processing heartbeat events if there are data events to process).

Note: there is an edge case where there can be many events sent (commit/begin) but no data changes for the filtered tables. In this case, no data change records are published to the data change topic & Vitess VStream will not send a heartbeat event because there is plenty of events being sent over the vstream, so no records are sent to the heartbeat topic. This would wrongfully mean no heartbeat events are emitted or a live/healthy connector. To counteract this, also dispatch heartbeat events on COMMIT events. If there is a surplus of data not for this table, it means that there are other tables receiving many transactions so these events will be received frequently enough. HeartbeatImpl superclass uses its own rate limiting so its fine if we call more often than necessary.

### Testing 
Set up some itests to verify we get heartbeat events when no other writes are happening. Other tests to verify handling of heartbeat events.