### PR TITLE
DBZ-8053 Handle empty shards

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -41,12 +41,14 @@ public class VitessConnector extends RelationalBaseSourceConnector {
 
     private Map<String, String> properties;
     private VitessConnectorConfig connectorConfig;
+    private VitessMetadata vitessMetadata;
 
     @Override
     public void start(Map<String, String> props) {
         LOGGER.info("Starting Vitess Connector");
         this.properties = Collections.unmodifiableMap(props);
         this.connectorConfig = new VitessConnectorConfig(Configuration.from(properties));
+        this.vitessMetadata = new VitessMetadata(connectorConfig);
 
     }
 
@@ -113,7 +115,7 @@ public class VitessConnector extends RelationalBaseSourceConnector {
         if (connectorConfig.offsetStoragePerTask()) {
             shards = connectorConfig.getShard();
             if (shards == null) {
-                shards = VitessMetadata.getShards(connectorConfig);
+                shards = vitessMetadata.getShards();
             }
         }
         return taskConfigs(maxTasks, shards);
@@ -333,7 +335,7 @@ public class VitessConnector extends RelationalBaseSourceConnector {
     public List<TableId> getMatchingCollections(Configuration configuration) {
         VitessConnectorConfig vitessConnectorConfig = new VitessConnectorConfig(configuration);
         String keyspace = vitessConnectorConfig.getKeyspace();
-        List<String> allTables = VitessMetadata.getTables(vitessConnectorConfig);
+        List<String> allTables = vitessMetadata.getTables();
         List<String> includedTables = getIncludedTables(keyspace,
                 vitessConnectorConfig.tableIncludeList(), allTables);
         return includedTables.stream()

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -262,6 +262,14 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                             + " If not configured, the connector streams changes from the latest position for the given shard(s)."
                             + " If snapshot.mode is INITIAL (default), the connector starts copying the tables for the given shard(s) first regardless of gtid value.");
 
+    public static final Field EXCLUDE_EMPTY_SHARDS = Field.create(VITESS_CONFIG_GROUP_PREFIX + "exclude.empty.shards")
+            .withDisplayName("exclude.empty.shards")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withDefault(false)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("Auto-detects and excludes empty shards from queries & shard lists used for VStreams");
+
     public static final Field TABLET_TYPE = Field.create(VITESS_CONFIG_GROUP_PREFIX + "tablet.type")
             .withDisplayName("Tablet type to get data-changes")
             .withType(Type.STRING)
@@ -452,7 +460,8 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     SCHEMA_NAME_ADJUSTMENT_MODE,
                     OFFSET_STORAGE_PER_TASK,
                     OFFSET_STORAGE_TASK_KEY_GEN,
-                    PREV_NUM_TASKS)
+                    PREV_NUM_TASKS,
+                    EXCLUDE_EMPTY_SHARDS)
             .events(
                     INCLUDE_UNKNOWN_DATATYPES,
                     SOURCE_INFO_STRUCT_MAKER)
@@ -542,6 +551,10 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
         String value = getConfig().getString(VGTID);
         return (value != null && !VGTID.defaultValueAsString().equals(value)) ? value : Vgtid.CURRENT_GTID;
+    }
+
+    public boolean excludeEmptyShards() {
+        return getConfig().getBoolean(EXCLUDE_EMPTY_SHARDS);
     }
 
     private static int validateVgtids(Configuration config, Field field, ValidationOutput problems) {

--- a/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
@@ -79,7 +79,7 @@ public class VitessMetadata {
     }
 
     private static void logResponse(Vtgate.ExecuteResponse response, String query) {
-        LOGGER.info("Got response: {} for query: {}", response, query);
+        LOGGER.debug("Got response: {} for query: {}", response, query);
     }
 
     private List<String> getVitessShards() {

--- a/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import static java.lang.Math.toIntExact;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.ByteString;
+
+import io.debezium.annotation.VisibleForTesting;
+import io.debezium.connector.vitess.connection.VitessReplicationConnection;
+import io.vitess.proto.Query;
+import io.vitess.proto.Vtgate;
+
+/**
+ * Class for getting metadata on Vitess, e.g., tables, shards. Supports shard-specific queries.
+ */
+public class VitessMetadata {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VitessMetadata.class);
+
+    public static List<String> getShards(VitessConnectorConfig config) {
+        List<String> shards;
+        if (config.excludeEmptyShards()) {
+            LOGGER.info("Excluding empty shards from shard list");
+            shards = getVitessShardsFromTablets(config);
+        }
+        else {
+            shards = getVitessShards(config);
+        }
+        LOGGER.info("Shards: {}", shards);
+        return shards;
+    }
+
+    public static List<String> getTables(VitessConnectorConfig config) {
+        List<String> tables;
+        if (config.excludeEmptyShards()) {
+            String query = String.format("SHOW TABLES", config.getKeyspace());
+            List<String> shardsToQuery;
+            List<String> nonEmptyShards = getVitessShardsFromTablets(config);
+            // If there is a shard list specified, then query one of its non-empty shards
+            if (config.getShard() != null && !config.getShard().isEmpty()) {
+                List<String> shardList = config.getShard();
+                shardsToQuery = intersect(shardList, nonEmptyShards);
+            }
+            else {
+                shardsToQuery = nonEmptyShards;
+            }
+            String randomNonEmptyShard = shardsToQuery.get(new Random().nextInt(shardsToQuery.size()));
+            LOGGER.info("Get table list from non-empty shard: {}", randomNonEmptyShard);
+            tables = flattenAndConcat(getRowsFromQuery(config, query, randomNonEmptyShard));
+        }
+        else {
+            String query = String.format("SHOW TABLES FROM %s", config.getKeyspace());
+            tables = flattenAndConcat(getRowsFromQuery(config, query));
+        }
+        LOGGER.info("All tables from keyspace {} are: {}", config.getKeyspace(), tables);
+        return tables;
+    }
+
+    private static List<String> getVitessShards(VitessConnectorConfig config) {
+        String query = String.format("SHOW VITESS_SHARDS LIKE '%s/%%'", config.getKeyspace());
+        List<String> rows = flattenAndConcat(getRowsFromQuery(config, query));
+        List<String> shards = rows.stream().map(fieldValue -> {
+            String[] parts = fieldValue.split("/");
+            assert parts != null && parts.length == 2 : String.format("Wrong field format: %s", fieldValue);
+            return parts[1];
+        }).collect(Collectors.toList());
+        return shards;
+    }
+
+    private static List<String> getVitessShardsFromTablets(VitessConnectorConfig config) {
+        String query = "SHOW VITESS_TABLETS";
+        List<List<String>> rowValues = getRowsFromQuery(config, query);
+        List<String> shards = VitessMetadata.getNonEmptyShards(rowValues, config.getKeyspace());
+        return shards;
+    }
+
+    private static Vtgate.ExecuteResponse executeQuery(VitessConnectorConfig config, String query) {
+        return executeQuery(config, query, null);
+    }
+
+    @VisibleForTesting
+    protected static Vtgate.ExecuteResponse executeQuery(VitessConnectorConfig config, String query, String shard) {
+        // Some tests need to be issue a shard-specific query, so make this visible
+        try (VitessReplicationConnection connection = new VitessReplicationConnection(config, null)) {
+            Vtgate.ExecuteResponse response;
+            if (shard != null) {
+                response = connection.execute(query, shard);
+            }
+            else {
+                response = connection.execute(query);
+            }
+            LOGGER.info("Got response: {} for query: {}", response, query);
+            return response;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(String.format("Unexpected error while running query: %s", query), e);
+        }
+    }
+
+    private static List<List<String>> getRowsFromResponse(Vtgate.ExecuteResponse response) {
+        validateResponse(response);
+        Query.QueryResult result = response.getResult();
+        validateResult(result);
+        return parseRows(result.getRowsList());
+    }
+
+    private static List<List<String>> getRowsFromQuery(VitessConnectorConfig config, String query) {
+        Vtgate.ExecuteResponse response = executeQuery(config, query);
+        return getRowsFromResponse(response);
+    }
+
+    private static List<List<String>> getRowsFromQuery(VitessConnectorConfig config, String query, String shard) {
+        Vtgate.ExecuteResponse response = executeQuery(config, query, shard);
+        return getRowsFromResponse(response);
+    }
+
+    private static void validateResponse(Vtgate.ExecuteResponse response) {
+        assert response != null && !response.hasError() && response.hasResult()
+                : String.format("Error response: %s", response);
+    }
+
+    private static void validateResult(Query.QueryResult result) {
+        List<Query.Row> rows = result.getRowsList();
+        assert !rows.isEmpty() : String.format("Empty response: %s", result);
+    }
+
+    @VisibleForTesting
+    protected static List<List<String>> parseRows(List<Query.Row> rows) {
+        List<List<String>> allRowValues = new ArrayList<>();
+        for (Query.Row row : rows) {
+            List<String> currentRowValues = new ArrayList();
+            List<Integer> lengths = row.getLengthsList().stream().map(x -> toIntExact(x)).collect(Collectors.toList());
+            ByteString values = row.getValues();
+
+            int offset = 0;
+            for (int length : lengths) {
+                if (length == -1) {
+                    currentRowValues.add(null); // Handle NULL values
+                }
+                else {
+                    String value = values.substring(offset, offset + length).toStringUtf8();
+                    currentRowValues.add(value);
+                    offset += length;
+                }
+            }
+            allRowValues.add(currentRowValues);
+        }
+        return allRowValues;
+    }
+
+    @VisibleForTesting
+    protected static List<String> getNonEmptyShards(List<List<String>> vitessTabletRows, String keyspace) {
+        Set<String> shardSet = new HashSet<>();
+
+        for (List<String> row : vitessTabletRows) {
+            if (row.size() < 3) {
+                continue; // skip rows with insufficient data
+            }
+            String rowKeyspace = row.get(1);
+            if (rowKeyspace.equals(keyspace)) {
+                shardSet.add(row.get(2)); // add the shard value
+            }
+        }
+
+        return shardSet.stream().sorted().collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    protected static List<String> flattenAndConcat(List<List<String>> nestedList) {
+        return nestedList.stream()
+                .map(innerList -> String.join("", innerList))
+                .collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    protected static List<String> intersect(List<String> list1, List<String> list2) {
+        List<String> intersection = new ArrayList<>(list1);
+        intersection.retainAll(list2);
+        return intersection;
+    }
+
+}

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -66,7 +66,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
      * @throws StatusRuntimeException if the connection is not valid, or SQL statement can not be successfully exected
      */
     public Vtgate.ExecuteResponse execute(String sqlStatement) {
-        LOGGER.info("Executing sqlStament {}", sqlStatement);
+        LOGGER.debug("Executing sqlStament {}", sqlStatement);
         ManagedChannel channel = newChannel(config.getVtgateHost(), config.getVtgatePort(), config.getGrpcMaxInboundMessageSize());
         managedChannel.compareAndSet(null, channel);
 
@@ -83,7 +83,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
         String target = String.format("%s:%s@%s", config.getKeyspace(), shard, config.getTabletType());
         Vtgate.Session session = Vtgate.Session.newBuilder().setTargetString(target).setAutocommit(true).build();
-        LOGGER.info("Autocommit {}", session.getAutocommit());
+        LOGGER.debug("Autocommit {}", session.getAutocommit());
         Vtgate.ExecuteRequest request = Vtgate.ExecuteRequest.newBuilder()
                 .setQuery(Proto.bindQuery(sqlStatement, Collections.emptyMap()))
                 .setSession(session)

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -293,7 +293,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
         Binlogdata.Filter.Builder filterBuilder = Binlogdata.Filter.newBuilder();
         if (!Strings.isNullOrEmpty(config.tableIncludeList())) {
             final String keyspace = config.getKeyspace();
-            final List<String> allTables = VitessMetadata.getTables(config);
+            final List<String> allTables = new VitessMetadata(config).getTables();
             List<String> includedTables = VitessConnector.getIncludedTables(config.getKeyspace(),
                     config.tableIncludeList(), allTables);
             for (String table : includedTables) {
@@ -414,7 +414,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
             if (config.getShard() == null || config.getShard().isEmpty()) {
                 // This case is not supported by the Vitess, so our workaround is to get all the shards from vtgate.
                 if (config.getVgtid() == Vgtid.EMPTY_GTID) {
-                    List<String> shards = VitessMetadata.getShards(config);
+                    List<String> shards = new VitessMetadata(config).getShards();
                     List<String> gtids = Collections.nCopies(shards.size(), config.getVgtid());
                     vgtid = buildVgtid(config.getKeyspace(), shards, gtids);
                 }

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -213,7 +213,7 @@ public class TestHelper {
     public static void executeDDL(String ddlFile, VitessConnectorConfig config, String shard) throws IOException, URISyntaxException {
         String statements = readStringFromFile(ddlFile);
         for (String statement : Arrays.asList(statements.split(";"))) {
-            VitessMetadata.executeQuery(config, statement, shard);
+            new VitessMetadata(config).executeQuery(statement, shard);
         }
     }
 

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -40,6 +40,8 @@ public class TestHelper {
     protected static final String TEST_SERVER = "test_server";
     public static final String TEST_UNSHARDED_KEYSPACE = "test_unsharded_keyspace";
     public static final String TEST_SHARDED_KEYSPACE = "test_sharded_keyspace";
+    public static final String TEST_EMPTY_SHARD_KEYSPACE = "test_empty_shard_keyspace";
+    public static final String TEST_NON_EMPTY_SHARD = "-80";
     public static final String TEST_SHARD = "0";
     public static final String TEST_SHARD1 = "-80";
     public static final String TEST_SHARD2 = "80-";
@@ -206,6 +208,13 @@ public class TestHelper {
 
     protected static void executeDDL(String ddlFile) throws Exception {
         executeDDL(ddlFile, TEST_UNSHARDED_KEYSPACE);
+    }
+
+    public static void executeDDL(String ddlFile, VitessConnectorConfig config, String shard) throws IOException, URISyntaxException {
+        String statements = readStringFromFile(ddlFile);
+        for (String statement : Arrays.asList(statements.split(";"))) {
+            VitessMetadata.executeQuery(config, statement, shard);
+        }
     }
 
     protected static void executeDDL(String ddlFile, String database) throws Exception {

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -72,4 +72,12 @@ public class VitessConnectorConfigTest {
         assertThat(inputs.size()).isEqualTo(1);
     }
 
+    @Test
+    public void shouldExcludeEmptyShards() {
+        Configuration configuration = TestHelper.defaultConfig().with(
+                VitessConnectorConfig.EXCLUDE_EMPTY_SHARDS, true).build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.excludeEmptyShards()).isTrue();
+    }
+
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -1474,7 +1474,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     @Test
     public void testGetVitessShards() throws Exception {
         VitessConnectorConfig config = new VitessConnectorConfig(TestHelper.defaultConfig().build());
-        Set<String> shards = new HashSet<>(VitessMetadata.getShards(config));
+        Set<String> shards = new HashSet<>(new VitessMetadata(config).getShards());
         assertEquals(new HashSet<>(Arrays.asList("0")), shards);
     }
 
@@ -1482,7 +1482,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     public void testGetKeyspaceTables() throws Exception {
         TestHelper.executeDDL("vitess_create_tables.ddl");
         VitessConnectorConfig config = new VitessConnectorConfig(TestHelper.defaultConfig().build());
-        Set<String> tables = new HashSet<>(VitessMetadata.getTables(config));
+        Set<String> tables = new HashSet<>(new VitessMetadata(config).getTables());
         // Remove system tables starts with _
         tables = tables.stream().filter(t -> !t.startsWith("_")).collect(Collectors.toSet());
         List<String> expectedTables = Arrays.asList(
@@ -2001,7 +2001,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         try {
             TableId table = tableIdFromInsertStmt(statement, keyspace);
             if (config.excludeEmptyShards() && shardToQuery != null) {
-                VitessMetadata.executeQuery(config, statement, shardToQuery);
+                new VitessMetadata(config).executeQuery(statement, shardToQuery);
             }
             else {
                 executeAndWait(statement);

--- a/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
@@ -52,9 +52,4 @@ public class VitessMetadataTest {
         List<List<String>> input = List.of(List.of("foo"), List.of("bar"));
         assertThat(VitessMetadata.flattenAndConcat(input)).isEqualTo(expected);
     }
-
-    @Test
-    public void shouldIntersect() {
-        assertThat(VitessMetadata.intersect(List.of("foo", "baz"), List.of("foo", "bar"))).isEqualTo(List.of("foo"));
-    }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.protobuf.ByteString;
+
+import io.vitess.proto.Query;
+
+public class VitessMetadataTest {
+
+    @Test
+    public void shouldGetNonEmptyShards() {
+        List<List<String>> rowValues = List.of(
+                List.of("zone1", "keyspace", "-80", "PRIMARY", "SERVING", "zone1-001", "d55", "2024-07-11"),
+                List.of("zone1", "keyspace", "-80", "REPLICA", "SERVING", "zone1-001", "d55", "2024-07-11"),
+                List.of("zone1", "keyspace", "-80", "RDONLY", "SERVING", "zone1-001", "d55", "2024-07-11"),
+                List.of("zone1", "keyspace1", "-80", "PRIMARY", "SERVING", "zone1-001", "d55", "2024-07-11"),
+                List.of("zone1", "keyspace1", "-80", "REPLICA", "SERVING", "zone1-001", "d55", "2024-07-11"),
+                List.of("zone1", "keyspace1", "-80", "RDONLY", "SERVING", "zone1-001", "d55", "2024-07-11"),
+                List.of("zone1", "keyspace1", "80-", "PRIMARY", "SERVING", "zone1-001", "d55", "2024-07-11"),
+                List.of("zone1", "keyspace1", "80-", "REPLICA", "SERVING", "zone1-001", "d55", "2024-07-11"),
+                List.of("zone1", "keyspace1", "80-", "RDONLY", "SERVING", "zone1-001", "d55", "2024-07-11"));
+        List<String> shards = VitessMetadata.getNonEmptyShards(rowValues, "keyspace");
+        assertThat(shards).isEqualTo(List.of("-80"));
+    }
+
+    @Test
+    public void shouldParseRow() {
+        List<List<String>> expected = List.of(List.of("foo", "bars"));
+        List<Query.Row> rows = List.of(
+                Query.Row.newBuilder()
+                        .addLengths(3)
+                        .addLengths(4)
+                        .setValues(ByteString.copyFromUtf8("foobars"))
+                        .build());
+        assertThat(VitessMetadata.parseRows(rows)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldFlattenAndConcat() {
+        List<String> expected = List.of("foo", "bar");
+        List<List<String>> input = List.of(List.of("foo"), List.of("bar"));
+        assertThat(VitessMetadata.flattenAndConcat(input)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldIntersect() {
+        assertThat(VitessMetadata.intersect(List.of("foo", "baz"), List.of("foo", "bar"))).isEqualTo(List.of("foo"));
+    }
+}


### PR DESCRIPTION
[DBZ-8053](https://issues.redhat.com/browse/DBZ-8053)

In some cases, a Vitess keyspace can have empty shards (shards without tablets). Do the following to handle this:
1. Provide a config exclude.empty.shards (boolean) to enable this behavior
2. If enabled, and no shard list is specified, then auto detect the non-empty shards (shards with tablets)
3. If enabled, and a shard list is specified, then route metadata queries (e.g., get tables) only to those listed shards. Although we could filter this to find the non-empty shards, we want to stay true to what the user configured (and fail loudly if a user is expecting to have a vstream for a certain set of shards, and some of those are empty). However, we can still route the queries such that they use the configured shards and do not risk failing because there are empty shards not in the list.
4. For the detected non-empty shard list, use it for query routing and for setting up the vstreams.
5. Refactor our metadata queries (eg getting shards/tables) into one class and do this empty shard handling there.