### PR TITLE
DBZ-8069 Add override.data.change.topic.prefix property to TableTopicNamingStrategy

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/TableTopicNamingStrategy.java
+++ b/src/main/java/io/debezium/connector/vitess/TableTopicNamingStrategy.java
@@ -12,6 +12,7 @@ import io.debezium.config.Configuration;
 import io.debezium.relational.TableId;
 import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Collect;
+import io.debezium.util.Strings;
 
 /**
  * Topic naming strategy where only the table name is added. This is used to avoid including
@@ -35,7 +36,7 @@ public class TableTopicNamingStrategy extends AbstractTopicNamingStrategy<TableI
     @Override
     public String dataChangeTopic(TableId id) {
         String topicName;
-        if (overrideDataChangeTopicPrefix != null) {
+        if (!Strings.isNullOrBlank(overrideDataChangeTopicPrefix)) {
             topicName = mkString(Collect.arrayListOf(overrideDataChangeTopicPrefix, id.table()), delimiter);
         }
         else {

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -330,6 +330,14 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                             + "'false' (the default) offsets are stored as a single unit under the database name. "
                             + "'true' stores the offsets per task id");
 
+    public static final Field OVERRIDE_DATA_CHANGE_TOPIC_PREFIX = Field.create("override.data.change.topic.prefix")
+            .withDisplayName("Override Data Topic prefix")
+            .withType(Type.STRING)
+            .withWidth(Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withValidation(CommonConnectorConfig::validateTopicName)
+            .withDescription("Overrides the topic.prefix used for the data change topic.");
+
     public static final Field OFFSET_STORAGE_TASK_KEY_GEN = Field.create(VITESS_CONFIG_GROUP_PREFIX + "offset.storage.task.key.gen")
             .withDisplayName("Offset storage task key generation number")
             .withType(Type.INT)
@@ -440,6 +448,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     GRPC_HEADERS,
                     GRPC_MAX_INBOUND_MESSAGE_SIZE,
                     BINARY_HANDLING_MODE,
+                    OVERRIDE_DATA_CHANGE_TOPIC_PREFIX,
                     SCHEMA_NAME_ADJUSTMENT_MODE,
                     OFFSET_STORAGE_PER_TASK,
                     OFFSET_STORAGE_TASK_KEY_GEN,

--- a/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
@@ -28,4 +28,16 @@ public class TableTopicNamingStrategyTest {
         assertThat(topicName).isEqualTo("prefix.table");
     }
 
+    @Test
+    public void shouldGetOverrideDataChangeTopic() {
+        TableId tableId = new TableId("shard", "keyspace", "table");
+        final Properties props = new Properties();
+        props.put("topic.delimiter", ".");
+        props.put("topic.prefix", "prefix");
+        props.put(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX.name(), "override-prefix");
+        TopicNamingStrategy strategy = new TableTopicNamingStrategy(props);
+        String topicName = strategy.dataChangeTopic(tableId);
+        assertThat(topicName).isEqualTo("override-prefix.table");
+    }
+
 }

--- a/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
@@ -40,4 +40,16 @@ public class TableTopicNamingStrategyTest {
         assertThat(topicName).isEqualTo("override-prefix.table");
     }
 
+    @Test
+    public void shouldUseTopicPrefixIfOverrideIsBlank() {
+        TableId tableId = new TableId("shard", "keyspace", "table");
+        final Properties props = new Properties();
+        props.put("topic.delimiter", ".");
+        props.put("topic.prefix", "prefix");
+        props.put(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX.name(), "");
+        TopicNamingStrategy strategy = new TableTopicNamingStrategy(props);
+        String topicName = strategy.dataChangeTopic(tableId);
+        assertThat(topicName).isEqualTo("prefix.table");
+    }
+
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -8,6 +8,10 @@ package io.debezium.connector.vitess;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
@@ -42,6 +46,30 @@ public class VitessConnectorConfigTest {
                 null);
         assertThat(heartbeat).isNotNull();
         assertThat(heartbeat).isEqualTo(Heartbeat.DEFAULT_NOOP_HEARTBEAT);
+    }
+
+    @Test
+    public void shouldImproperOverrideTopicPrefixFailValidation() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX, "hello@world").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX), printConsumer);
+        assertThat(inputs.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldBlankOverrideTopicPrefixFailValidation() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX, "").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX), printConsumer);
+        assertThat(inputs.size()).isEqualTo(1);
     }
 
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/DBZ-8069 for more context on why this needed

See also this Zulip chat on why we went this route https://debezium.zulipchat.com/#narrow/stream/302529-community-general/topic/Separate.20logs.2Fmetrics.20for.20identical.20topic.2Eprefix.20connectors 

Expand our current custom vitess topic naming strategy to support this additional config.