### PR TITLE
DBZ-8087 Get previous vgtid from vgtid key in offsets

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessEpochProvider.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessEpochProvider.java
@@ -75,11 +75,11 @@ public class VitessEpochProvider {
     }
 
     public Long getEpoch(String shard, String previousVgtidString, String vgtidString) {
-        if (previousVgtidString == null && shardToEpoch.get(shard) != null) {
-            throw new DebeziumException("Previous VGTID is null but shardToEpoch map is not null: " + shardToEpoch.toString() +
-                    ", update VGTID in offsets to resume");
-        }
-        else if (previousVgtidString == null) {
+        if (previousVgtidString == null) {
+            if (shardToEpoch.get(shard) != null) {
+                throw new DebeziumException("Previous VGTID is null but shardToEpoch map is not null: " + shardToEpoch.toString() +
+                        ", update VGTID in offsets to resume");
+            }
             // When the connector is first created it has no previous VGTID in offsets (and there is no epoch stored)
             long epoch = 0L;
             storeEpoch(shard, epoch);

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionContext.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionContext.java
@@ -8,6 +8,7 @@ package io.debezium.connector.vitess.pipeline.txmetadata;
 import java.math.BigDecimal;
 import java.util.Map;
 
+import io.debezium.connector.vitess.SourceInfo;
 import io.debezium.connector.vitess.Vgtid;
 import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.pipeline.txmetadata.TransactionInfo;
@@ -73,7 +74,7 @@ public class VitessOrderedTransactionContext extends TransactionContext {
     public static VitessOrderedTransactionContext load(Map<String, ?> offsets) {
         TransactionContext transactionContext = TransactionContext.load(offsets);
         VitessOrderedTransactionContext vitessOrderedTransactionContext = new VitessOrderedTransactionContext(transactionContext);
-        vitessOrderedTransactionContext.previousVgtid = (String) offsets.get(TransactionContext.OFFSET_TRANSACTION_ID);
+        vitessOrderedTransactionContext.previousVgtid = (String) offsets.get(SourceInfo.VGTID_KEY);
         vitessOrderedTransactionContext.epochProvider.load(offsets);
         return vitessOrderedTransactionContext;
     }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -868,7 +868,6 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
                 Vgtid.CURRENT_GTID);
         Map<String, Long> shardToEpoch = Map.of(VgtidTest.TEST_SHARD, 2L, VgtidTest.TEST_SHARD2, 3L);
         Map<String, String> offsetId = Map.of(
-                VitessOrderedTransactionContext.OFFSET_TRANSACTION_ID, currentVgtid,
                 VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, mapper.writeValueAsString(shardToEpoch),
                 SourceInfo.VGTID_KEY, currentVgtid);
         Map<Map<String, ?>, Map<String, ?>> offsets = Map.of(srcPartition, offsetId);

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionContextTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionContextTest.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 
 import io.debezium.connector.vitess.SourceInfo;
 import io.debezium.connector.vitess.VgtidTest;
-import io.debezium.pipeline.txmetadata.TransactionContext;
 
 public class VitessOrderedTransactionContextTest {
 
@@ -35,7 +34,7 @@ public class VitessOrderedTransactionContextTest {
         String expectedEpoch = "{\"-80\": 5}";
         Map offsets = Map.of(
                 VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, expectedEpoch,
-                TransactionContext.OFFSET_TRANSACTION_ID, expectedId);
+                SourceInfo.VGTID_KEY, expectedId);
         VitessOrderedTransactionContext context = VitessOrderedTransactionContext.load(offsets);
         assertThat(context.previousVgtid).isEqualTo(expectedId);
         context.beginTransaction(new VitessTransactionInfo(VgtidTest.VGTID_JSON, "-80"));


### PR DESCRIPTION
It is non-deterministic/race condition whether or not the `OFFSET_TRANSACTION_ID` is present in the offsets (if we happen to store offsets during a transaction, [it is added since it's not null, otherwise it is not added](https://github.com/debezium/debezium/blob/main/debezium-core/src/main/java/io/debezium/pipeline/txmetadata/TransactionContext.java#L51)). For example if heartbeats are enabled, there is not transaction but we still commit offsets.

Epoch needs to be based on the vgtid we store as for the VGTID_KEY since that is always present in offsets regardless of whether we are in a transaction or not. This fixes an edge case where we saw epoch being set back down to zero because we were getting null for our previous VGTID string. Also fail loudly if we ever see this case again (null previous VGTID but there is state for the epoch, this is invalid state and should throw exception).