### PR TITLE
DBZ-8154 Make order metadata epoch handle changes to task parallelism & shard set

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/OffsetValueType.java
+++ b/src/main/java/io/debezium/connector/vitess/OffsetValueType.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import io.debezium.connector.vitess.pipeline.txmetadata.ShardEpochMap;
+import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionContext;
+
+public enum OffsetValueType {
+
+    GTID(SourceInfo.VGTID_KEY, OffsetValueType::parseGtid,
+            OffsetValueType::getVgtid, OffsetValueType::getConfigGtidsPerShard),
+    EPOCH(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, OffsetValueType::parseEpoch,
+            OffsetValueType::getShardEpochMap, OffsetValueType::getConfigShardEpochMapPerShard);
+
+    public final String name;
+    public final Function<String, Map<String, Object>> parserFunction;
+    public final BiFunction<Map<String, Object>, String, Object> conversionFunction;
+    public final BiFunction<VitessConnectorConfig, List<String>, Map<String, Object>> configValuesFunction;
+
+    OffsetValueType(String typeName, Function<String, Map<String, Object>> parserFunction,
+                    BiFunction<Map<String, Object>, String, Object> conversionFunction,
+                    BiFunction<VitessConnectorConfig, List<String>, Map<String, Object>> configValuesFunction) {
+        this.name = typeName;
+        this.parserFunction = parserFunction;
+        this.conversionFunction = conversionFunction;
+        this.configValuesFunction = configValuesFunction;
+    }
+
+    private static Map<String, Object> parseGtid(String vgtidStr) {
+        Map<String, Object> shardToGtid = new HashMap<>();
+        List<Vgtid.ShardGtid> shardGtids = Vgtid.of(vgtidStr).getShardGtids();
+        for (Vgtid.ShardGtid shardGtid : shardGtids) {
+            shardToGtid.put(shardGtid.getShard(), shardGtid.getGtid());
+        }
+        return shardToGtid;
+    }
+
+    private static Map<String, Object> parseEpoch(String epochString) {
+        ShardEpochMap shardToEpoch = ShardEpochMap.of(epochString);
+        return (Map) shardToEpoch.getMap();
+    }
+
+    /**
+     * Get the {@link ShardEpochMap} from this map of shards to epochs.
+     *
+     * @param epochMap Map of shards to epoch values
+     * @param keyspace Needed to match the function signature of getVgtid, ignored
+     * @return The {@link ShardEpochMap}
+     */
+    static ShardEpochMap getShardEpochMap(Map<String, ?> epochMap, String keyspace) {
+        return new ShardEpochMap((Map<String, Long>) epochMap);
+    }
+
+    static Vgtid getVgtid(Map<String, ?> gtidsPerShard, String keyspace) {
+        List<Vgtid.ShardGtid> shardGtids = new ArrayList();
+        for (Map.Entry<String, ?> entry : gtidsPerShard.entrySet()) {
+            shardGtids.add(new Vgtid.ShardGtid(keyspace, entry.getKey(), (String) entry.getValue()));
+        }
+        return Vgtid.of(shardGtids);
+    }
+
+    static Map<String, Object> getConfigShardEpochMapPerShard(VitessConnectorConfig connectorConfig, List<String> shards) {
+        String shardEpochMapString = connectorConfig.getShardEpochMap();
+        Function<Integer, Long> initEpoch = x -> 0L;
+        Map<String, Long> shardEpochMap;
+        if (shardEpochMapString.isEmpty()) {
+            shardEpochMap = buildMap(shards, initEpoch);
+        }
+        else {
+            shardEpochMap = ShardEpochMap.of(shardEpochMapString).getMap();
+        }
+        return (Map) shardEpochMap;
+    }
+
+    static Map<String, Object> getConfigGtidsPerShard(VitessConnectorConfig connectorConfig, List<String> shards) {
+        String gtids = connectorConfig.getVgtid();
+        Map<String, String> configGtidsPerShard = null;
+        if (shards != null && gtids.equals(Vgtid.EMPTY_GTID)) {
+            Function<Integer, String> emptyGtid = x -> Vgtid.EMPTY_GTID;
+            configGtidsPerShard = buildMap(shards, emptyGtid);
+        }
+        else if (shards != null && gtids.equals(Vgtid.CURRENT_GTID)) {
+            Function<Integer, String> currentGtid = x -> Vgtid.CURRENT_GTID;
+            configGtidsPerShard = buildMap(shards, currentGtid);
+        }
+        else if (shards != null) {
+            List<Vgtid.ShardGtid> shardGtids = Vgtid.of(gtids).getShardGtids();
+            Map<String, String> shardsToGtid = new HashMap<>();
+            for (Vgtid.ShardGtid shardGtid : shardGtids) {
+                shardsToGtid.put(shardGtid.getShard(), shardGtid.getGtid());
+            }
+            Function<Integer, String> shardGtid = (i -> shardsToGtid.get(shards.get(i)));
+            configGtidsPerShard = buildMap(shards, shardGtid);
+        }
+        return (Map) configGtidsPerShard;
+    }
+
+    private static <T> Map<String, T> buildMap(List<String> keys, Function<Integer, T> function) {
+        return IntStream.range(0, keys.size())
+                .boxed()
+                .collect(Collectors.toMap(keys::get, function));
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/Vgtid.java
+++ b/src/main/java/io/debezium/connector/vitess/Vgtid.java
@@ -18,8 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.debezium.DebeziumException;
-
 import binlogdata.Binlogdata;
 
 /** Vitess source position coordinates. */
@@ -112,9 +110,6 @@ public class Vgtid {
 
     public ShardGtid getShardGtid(String shard) {
         ShardGtid shardGtid = shardNameToShardGtid.get(shard);
-        if (shardGtid == null) {
-            throw new DebeziumException("Gtid for shard missing, shard: " + shard + "vgtid: " + this.rawVgtid.toString());
-        }
         return shardGtid;
     }
 

--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -106,14 +106,14 @@ public class VitessConnector extends RelationalBaseSourceConnector {
                     connectorConfig, tasks, gen, false, context().offsetStorageReader());
 
             Map<String, String> gtidsPerShard = currentGen.getGtidPerShard();
-            validateCurrentGen(currentGen, gtidsPerShard, currentShards, VitessOffsetRetriever.ValueType.GTID);
+            validateCurrentGen(currentGen, gtidsPerShard, currentShards, OffsetValueType.GTID);
             List<String> shards = determineShards(prevGtidsPerShard, gtidsPerShard, currentShards);
 
             if (VitessOffsetRetriever.isShardEpochMapEnabled(connectorConfig)) {
                 Map<String, Long> prevEpochsPerShard = previousGen.getEpochPerShard();
                 validateNoLostShardData(prevEpochsPerShard, currentShards, "epochs");
                 Map<String, Long> epochsPerShard = currentGen.getEpochPerShard();
-                validateCurrentGen(currentGen, epochsPerShard, currentShards, VitessOffsetRetriever.ValueType.EPOCH);
+                validateCurrentGen(currentGen, epochsPerShard, currentShards, OffsetValueType.EPOCH);
                 List<String> shardsFromEpoch = determineShards(prevEpochsPerShard, epochsPerShard, currentShards);
                 if (!shardsFromEpoch.equals(shards)) {
                     throw new IllegalArgumentException(String.format(
@@ -180,7 +180,7 @@ public class VitessConnector extends RelationalBaseSourceConnector {
     }
 
     private Map<String, ?> validateCurrentGen(VitessOffsetRetriever retriever, Map<String, ?> valuePerShard, List<String> currentShards,
-                                              VitessOffsetRetriever.ValueType valueType) {
+                                              OffsetValueType valueType) {
         if (valuePerShard != null && !hasSameShards(valuePerShard.keySet(), currentShards)) {
             LOGGER.warn("Some shards {} for the current generation {} are not persisted.  Expected shards: {}",
                     valueType.name(), valuePerShard.keySet(), currentShards);

--- a/src/main/java/io/debezium/connector/vitess/VitessOffsetContext.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessOffsetContext.java
@@ -45,7 +45,15 @@ public class VitessOffsetContext extends CommonOffsetContext<SourceInfo> {
         this.transactionContext = transactionContext;
     }
 
-    /** Initialize VitessOffsetContext if no previous offset exists */
+    /**
+     * Initialize VitessOffsetContext if no previous offset exists. This happens if either
+     * 1. This is a new connector
+     * 2. The generation has changed
+     *
+     * @param connectorConfig
+     * @param clock
+     * @return
+     */
     public static VitessOffsetContext initialContext(
                                                      VitessConnectorConfig connectorConfig, Clock clock) {
         LOGGER.info("No previous offset exists. Use default VGTID.");
@@ -144,6 +152,14 @@ public class VitessOffsetContext extends CommonOffsetContext<SourceInfo> {
             this.connectorConfig = connectorConfig;
         }
 
+        /**
+         * Loads the previously stored offsets for vgtid & transaction context (e.g., epoch).
+         * If offset storage per task mode is enabled, this is called only if there is no generation change.
+         * If offset storage per task mode is disabled, this is called only if previous offsets exist.
+         *
+         * @param offset
+         * @return
+         */
         @Override
         public VitessOffsetContext load(Map<String, ?> offset) {
             LOGGER.info("Previous offset exists, load from {}", offset);

--- a/src/main/java/io/debezium/connector/vitess/VitessOffsetRetriever.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessOffsetRetriever.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.vitess.pipeline.txmetadata.ShardEpochMap;
+import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionContext;
+import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionMetadataFactory;
+
+/**
+ * Retrieves values from offsets, specifically for retrieving the previous VGTID and shard epoch
+ * values.
+ */
+public class VitessOffsetRetriever {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VitessConnector.class);
+
+    private final int numTasks;
+    private final int gen;
+    private boolean expectsOffset;
+    private final VitessConnectorConfig config;
+    private final OffsetStorageReader reader;
+
+    public VitessOffsetRetriever(VitessConnectorConfig config, int numTasks, int gen, boolean expectsOffset, OffsetStorageReader reader) {
+        this.config = config;
+        this.numTasks = numTasks;
+        this.gen = gen;
+        this.expectsOffset = expectsOffset;
+        this.reader = reader;
+    }
+
+    public static boolean isShardEpochMapEnabled(VitessConnectorConfig config) {
+        return config.getTransactionMetadataFactory() instanceof VitessOrderedTransactionMetadataFactory;
+    }
+
+    public void setExpectsOffset(boolean expectsOffset) {
+        this.expectsOffset = expectsOffset;
+    }
+
+    public enum ValueType {
+        GTID(SourceInfo.VGTID_KEY, ValueType::parseGtid),
+        EPOCH(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, ValueType::parseEpoch);
+
+        private final String typeName;
+        private final Function<String, Map<String, Object>> parserFunction;
+
+        ValueType(String typeName, Function<String, Map<String, Object>> parserFunction) {
+            this.typeName = typeName;
+            this.parserFunction = parserFunction;
+        }
+
+        private static Map<String, Object> parseGtid(String vgtidStr) {
+            Map<String, Object> shardToGtid = new HashMap<>();
+            List<Vgtid.ShardGtid> shardGtids = Vgtid.of(vgtidStr).getShardGtids();
+            for (Vgtid.ShardGtid shardGtid : shardGtids) {
+                shardToGtid.put(shardGtid.getShard(), shardGtid.getGtid());
+            }
+            return shardToGtid;
+        }
+
+        private static Map<String, Object> parseEpoch(String epochString) {
+            ShardEpochMap shardToEpoch = ShardEpochMap.of(epochString);
+            return (Map) shardToEpoch.getMap();
+        }
+    }
+
+    public Map<String, String> getGtidPerShard() {
+        return (Map) getValuePerShardFromStorage(ValueType.GTID);
+    }
+
+    public Map<String, Long> getEpochPerShard() {
+        return (Map) getValuePerShardFromStorage(ValueType.EPOCH);
+    }
+
+    public Map<String, ?> getValuePerShardFromStorage(ValueType valueType) {
+        String key = valueType.typeName;
+        Function<String, Map<String, Object>> valueReader = valueType.parserFunction;
+        return getValuePerShardFromStorage(
+                key,
+                valueReader);
+    }
+
+    public Map<String, Object> getValuePerShardFromStorage(String key, Function<String, Map<String, Object>> valueReader) {
+        if (gen < 0) {
+            return null;
+        }
+        final Map<String, Object> valuesPerShard = new HashMap<>();
+        for (int i = 0; i < numTasks; i++) {
+            String taskKey = VitessConnector.getTaskKeyName(i, numTasks, gen);
+            VitessPartition par = new VitessPartition(config.getLogicalName(), taskKey);
+            Map<String, Object> offset = reader.offset(par.getSourcePartition());
+            if (offset == null && gen == 0) {
+                LOGGER.info("No previous offset for partition: {}, fall back to only server key", par);
+                par = new VitessPartition(config.getLogicalName(), null);
+                offset = reader.offset(par.getSourcePartition());
+            }
+            if (offset == null) {
+                if (expectsOffset) {
+                    throw new IllegalArgumentException(String.format("No offset found for %s", par));
+                }
+                else {
+                    LOGGER.warn("No offset found for task key: {}", taskKey);
+                    continue;
+                }
+            }
+            final String stringValue = (String) offset.get(key);
+            Objects.requireNonNull(stringValue, String.format("Missing %s from %s", key, offset));
+            Map<String, Object> shardToValue = valueReader.apply(stringValue);
+            valuesPerShard.putAll(shardToValue);
+
+        }
+        return valuesPerShard;
+    }
+
+}

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardEpochMap.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardEpochMap.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.pipeline.txmetadata;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tracks the mapping of shards to epoch values. Used for serializing/deserializing to JSON and to update
+ * epochs per shard.
+ */
+public class ShardEpochMap {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final Map<String, Long> shardEpochMap;
+
+    public ShardEpochMap() {
+        this.shardEpochMap = new TreeMap<>();
+    }
+
+    public ShardEpochMap(Map<String, Long> shardToEpoch) {
+        this.shardEpochMap = new TreeMap<>(shardToEpoch);
+    }
+
+    public static ShardEpochMap init(List<String> shards) {
+        Map<String, Long> map = shards.stream().collect(Collectors.toMap(s -> s, s -> 0L));
+        return new ShardEpochMap(map);
+    }
+
+    public static ShardEpochMap of(String shardToEpochJson) {
+        try {
+            return new ShardEpochMap(MAPPER.readValue(shardToEpochJson, new TypeReference<>() {
+            }));
+        }
+        catch (JsonProcessingException e) {
+            throw new IllegalStateException("Cannot read shard epoch map", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return MAPPER.writeValueAsString(shardEpochMap);
+        }
+        catch (JsonProcessingException e) {
+            throw new IllegalStateException("Cannot convert shard epoch map to string", e);
+        }
+    }
+
+    public Long get(String shard) {
+        return shardEpochMap.get(shard);
+    }
+
+    public Long put(String shard, Long epoch) {
+        return shardEpochMap.put(shard, epoch);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ShardEpochMap shardToEpoch = (ShardEpochMap) o;
+        return Objects.equals(this.shardEpochMap, shardToEpoch.shardEpochMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shardEpochMap);
+    }
+
+    public Map<String, Long> getMap() {
+        return new TreeMap<>(shardEpochMap);
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessEpochProvider.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessEpochProvider.java
@@ -5,32 +5,42 @@
  */
 package io.debezium.connector.vitess.pipeline.txmetadata;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.debezium.DebeziumException;
 import io.debezium.connector.vitess.Vgtid;
+import io.debezium.connector.vitess.VitessConnectorConfig;
+import io.debezium.connector.vitess.VitessConnectorTask;
+import io.debezium.connector.vitess.connection.VitessReplicationConnection;
+import io.debezium.util.Strings;
 
 public class VitessEpochProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VitessEpochProvider.class);
-    private Map<String, Long> shardToEpoch = new HashMap<>();
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private ShardEpochMap shardEpochMap;
+    private boolean isFirstTransaction = true;
+
+    public VitessEpochProvider() {
+        shardEpochMap = new ShardEpochMap();
+    }
+
+    public VitessEpochProvider(ShardEpochMap shardToEpoch) {
+        this.shardEpochMap = shardToEpoch;
+    }
 
     private static boolean isInvalidGtid(String gtid) {
         return gtid.equals(Vgtid.CURRENT_GTID) || gtid.equals(Vgtid.EMPTY_GTID);
     }
 
-    public static Long getEpochForGtid(Long previousEpoch, String previousGtidString, String gtidString) {
-        if (isInvalidGtid(previousGtidString)) {
+    public static Long getEpochForGtid(Long previousEpoch, String previousGtidString, String gtidString, boolean isFirstTransaction) {
+        if (isFirstTransaction && isInvalidGtid(previousGtidString)) {
             return previousEpoch + 1;
+        }
+        else if (isInvalidGtid(previousGtidString)) {
+            throw new DebeziumException("Invalid GTID: The previous GTID cannot be one of current or empty after the first transaction " + gtidString);
         }
         if (isInvalidGtid(gtidString)) {
             throw new DebeziumException("Invalid GTID: The current GTID cannot be one of current or empty " + gtidString);
@@ -51,52 +61,81 @@ public class VitessEpochProvider {
         }
     }
 
-    public Map<String, Object> store(Map<String, Object> offset) {
-        try {
-            offset.put(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, MAPPER.writeValueAsString(shardToEpoch));
-            return offset;
-        }
-        catch (JsonProcessingException e) {
-            throw new RuntimeException("Cannot store epoch: " + shardToEpoch.toString());
-        }
+    public ShardEpochMap getShardEpochMap() {
+        return shardEpochMap;
     }
 
+    /**
+     * Initialize the VitessEpochProvider. Called if either:
+     * 1. Change in offset storage generation (task number change or vitess shard set change): Read from the config that is set to be the
+     * shard epoch map derived from previous generation and other info in {@link VitessConnectorTask}
+     * 2. Newly created connector: Set all shards equal to 0 to initialize shardToEpoch map
+     *
+     * @param config VitessConnectorConfig to use for initialization
+     * @return VitessEpochProvider
+     */
+    public static VitessEpochProvider initialize(VitessConnectorConfig config) {
+        ShardEpochMap shardEpochMap = VitessReplicationConnection.defaultShardEpochMap(config);
+        return new VitessEpochProvider(shardEpochMap);
+    }
+
+    public Map<String, Object> store(Map<String, Object> offset) {
+        offset.put(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, shardEpochMap.toString());
+        return offset;
+    }
+
+    /**
+     * Load the shard epoch map from offsets. If we enabled ordered transaction metadata for the first time,
+     * then there will be no offsets so use default empty map
+     *
+     * @param offsets Offsets to load
+     */
     public void load(Map<String, ?> offsets) {
-        try {
-            String shardToEpochString = (String) offsets.get(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH);
-            if (shardToEpochString != null) {
-                shardToEpoch = MAPPER.readValue(shardToEpochString, new TypeReference<Map<String, Long>>() {
-                });
-            }
-        }
-        catch (JsonProcessingException e) {
-            throw new RuntimeException("Cannot read shardToEpoch from offsets: " + offsets);
+        String shardToEpochString = (String) offsets.get(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH);
+        if (!Strings.isNullOrEmpty(shardToEpochString)) {
+            shardEpochMap = ShardEpochMap.of(shardToEpochString);
         }
     }
 
     public Long getEpoch(String shard, String previousVgtidString, String vgtidString) {
         if (previousVgtidString == null) {
-            if (shardToEpoch.get(shard) != null) {
-                throw new DebeziumException("Previous VGTID is null but shardToEpoch map is not null: " + shardToEpoch.toString() +
-                        ", update VGTID in offsets to resume");
-            }
-            // When the connector is first created it has no previous VGTID in offsets (and there is no epoch stored)
-            long epoch = 0L;
-            storeEpoch(shard, epoch);
-            return epoch;
+            throw new DebeziumException(String.format("Previous vgtid string cannot be null shard %s current %s", shard, vgtidString));
         }
-
         Vgtid vgtid = Vgtid.of(vgtidString);
         Vgtid previousVgtid = Vgtid.of(previousVgtidString);
-        String previousGtid = previousVgtid.getShardGtid(shard).getGtid();
-        String gtid = vgtid.getShardGtid(shard).getGtid();
-        long previousEpoch = shardToEpoch.getOrDefault(shard, 0L);
-        long currentEpoch = getEpochForGtid(previousEpoch, previousGtid, gtid);
-        storeEpoch(shard, currentEpoch);
-        return currentEpoch;
+        processVgtid(previousVgtid, vgtid);
+        if (isFirstTransaction) {
+            isFirstTransaction = false;
+        }
+        return shardEpochMap.get(shard);
     }
 
-    private void storeEpoch(String shard, long epoch) {
-        shardToEpoch.put(shard, epoch);
+    private void processVgtid(Vgtid previousVgtid, Vgtid vgtid) {
+        for (Vgtid.ShardGtid shardGtid : vgtid.getShardGtids()) {
+            String shard = shardGtid.getShard();
+            String gtid = shardGtid.getGtid();
+            Vgtid.ShardGtid previousShardGtid = previousVgtid.getShardGtid(shard);
+            if (previousShardGtid != null) {
+                String previousGtid = previousShardGtid.getGtid();
+                // If there is a previous GTID, then we should have initialized shardEpochMap with the shard
+                Long previousEpoch = shardEpochMap.get(shard);
+                if (previousEpoch == null) {
+                    throw new DebeziumException(String.format(
+                            "Previous epoch cannot be null for shard %s when shard present in previous vgtid %s",
+                            shard, previousVgtid));
+                }
+                Long epoch = getEpochForGtid(previousEpoch, previousGtid, gtid, isFirstTransaction);
+                shardEpochMap.put(shard, epoch);
+            }
+            else {
+                // A re-shard happened while we are streaming set the new value to zero
+                // TODO: Add support to inherit epoch from ancestor shard
+                shardEpochMap.put(shard, 0L);
+            }
+        }
+        // Note: we could purge all shards from the shard epoch map that are not present in the current vgtid.
+        // However, this poses some risk of losing epoch values, so we leave them as is. There may be dormant shards
+        // that we still have epoch values for, but that should be fine. Once we allow for epochs to be inherited from other shards
+        // we could reconsider purging them to ensure the epoch shard map does not grow too large.
     }
 }

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionMetadataFactory.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionMetadataFactory.java
@@ -7,25 +7,28 @@
 package io.debezium.connector.vitess.pipeline.txmetadata;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.vitess.VitessConnectorConfig;
 import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.pipeline.txmetadata.TransactionStructMaker;
 import io.debezium.pipeline.txmetadata.spi.TransactionMetadataFactory;
 
 public class VitessOrderedTransactionMetadataFactory implements TransactionMetadataFactory {
 
-    private final Configuration configuraiton;
+    private final Configuration configuration;
 
     public VitessOrderedTransactionMetadataFactory(Configuration configuration) {
-        this.configuraiton = configuration;
+        this.configuration = configuration;
     }
 
     @Override
     public TransactionContext getTransactionContext() {
-        return new VitessOrderedTransactionContext();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        VitessOrderedTransactionContext context = VitessOrderedTransactionContext.initialize(connectorConfig);
+        return context;
     }
 
     @Override
     public TransactionStructMaker getTransactionStructMaker() {
-        return new VitessOrderedTransactionStructMaker(configuraiton);
+        return new VitessOrderedTransactionStructMaker(configuration);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -17,6 +17,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.vitess.connection.ReplicationMessage;
 import io.debezium.connector.vitess.connection.ReplicationMessageColumn;
 import io.debezium.connector.vitess.connection.VitessTabletType;
+import io.debezium.connector.vitess.pipeline.txmetadata.ShardEpochMap;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.vitess.proto.Query;
@@ -45,6 +47,9 @@ public class TestHelper {
     public static final String TEST_SHARD = "0";
     public static final String TEST_SHARD1 = "-80";
     public static final String TEST_SHARD2 = "80-";
+    public static final Long TEST_SHARD1_EPOCH = 2L;
+    public static final Long TEST_SHARD2_EPOCH = 3L;
+    public static final ShardEpochMap TEST_SHARD_TO_EPOCH = new ShardEpochMap(Map.of(TEST_SHARD1, TEST_SHARD1_EPOCH, TEST_SHARD2, TEST_SHARD2_EPOCH));
 
     public static final String TEST_GTID = "MySQL56/a790d864-9ba1-11ea-99f6-0242ac11000a:1-1513";
     public static final String TEST_TABLE = "test_table";

--- a/src/test/java/io/debezium/connector/vitess/VgtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VgtidTest.java
@@ -14,14 +14,12 @@ import static io.debezium.connector.vitess.TablePrimaryKeysTest.getTestTablePKs;
 import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_NO_PKS_TEMPLATE;
 import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import io.debezium.DebeziumException;
 import io.debezium.util.Collect;
 
 import binlogdata.Binlogdata;
@@ -415,8 +413,6 @@ public class VgtidTest {
     @Test
     public void shouldGetMissingShardGtidThrowsDebeziumException() {
         Vgtid vgtid1 = Vgtid.of(VGTID_JSON);
-        assertThatThrownBy(() -> {
-            Vgtid.ShardGtid shardGtid = vgtid1.getShardGtid("missing_shard");
-        }).isInstanceOf(DebeziumException.class);
+        assertThat(vgtid1.getShardGtid("missing_shard")).isNull();
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -6,6 +6,7 @@
 
 package io.debezium.connector.vitess;
 
+import static io.debezium.connector.vitess.TestHelper.TEST_SHARD_TO_EPOCH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -78,6 +79,41 @@ public class VitessConnectorConfigTest {
                 VitessConnectorConfig.EXCLUDE_EMPTY_SHARDS, true).build();
         VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
         assertThat(connectorConfig.excludeEmptyShards()).isTrue();
+    }
+
+    @Test
+    public void shouldGetVitessTaskEpochShardMapConfig() {
+        Configuration configuration = TestHelper.defaultConfig().with(
+                VitessConnectorConfig.VITESS_TASK_SHARD_EPOCH_MAP_CONFIG, TEST_SHARD_TO_EPOCH.toString()).build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getVitessTaskShardEpochMap()).isEqualTo(TEST_SHARD_TO_EPOCH);
+    }
+
+    @Test
+    public void shouldGetVitessEpochShardMapConfig() {
+        Configuration configuration = TestHelper.defaultConfig().with(
+                VitessConnectorConfig.SHARD_EPOCH_MAP, TEST_SHARD_TO_EPOCH.toString()).build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getShardEpochMap()).isEqualTo(TEST_SHARD_TO_EPOCH.toString());
+    }
+
+    @Test
+    public void shouldGetVitessEpochShardMapConfigDefault() {
+        Configuration configuration = TestHelper.defaultConfig().build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getShardEpochMap()).isEqualTo("");
+    }
+
+    @Test
+    public void shouldImproperShardEpochMapFailValidation() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.SHARD_EPOCH_MAP, "foo").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.SHARD_EPOCH_MAP), printConsumer);
+        assertThat(inputs.size()).isEqualTo(1);
     }
 
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -9,6 +9,7 @@ import static io.debezium.connector.vitess.TestHelper.TEST_SERVER;
 import static io.debezium.connector.vitess.TestHelper.TEST_SHARDED_KEYSPACE;
 import static io.debezium.connector.vitess.TestHelper.TEST_UNSHARDED_KEYSPACE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -16,12 +17,14 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
@@ -40,6 +43,9 @@ import org.slf4j.LoggerFactory;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.OffsetReader;
 import io.debezium.connector.vitess.connection.VitessReplicationConnection;
+import io.debezium.connector.vitess.pipeline.txmetadata.ShardEpochMap;
+import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionContext;
+import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionMetadataFactory;
 import io.debezium.embedded.KafkaConnectUtil;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.pipeline.spi.OffsetContext;
@@ -127,6 +133,7 @@ public class VitessConnectorTest {
                 put(VitessConnectorConfig.SNAPSHOT_MODE.name(), VitessConnectorConfig.SnapshotMode.NEVER.getValue());
             }
         };
+        connector.initialize(new ContextHelper().getSourceConnectorContext());
         connector.start(props);
         List<String> shards = Arrays.asList("-4000", "4000-8000", "8000-c000", "c000-");
         List<Map<String, String>> taskConfigs = connector.taskConfigs(1, shards);
@@ -142,6 +149,46 @@ public class VitessConnectorTest {
                 Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID);
         Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
         // assertThat(firstConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG)).isNull();
+        assertEquals(vgtid.toString(), firstConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG));
+        assertEquals("value", firstConfig.get("key"));
+    }
+
+    @Test
+    public void testTaskConfigsOffsetStorageModeSingleWithOrderMetadata() {
+        VitessConnector connector = new VitessConnector();
+        Map<String, String> props = new HashMap<>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.KEYSPACE.name(), TEST_UNSHARDED_KEYSPACE);
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+                put(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name(), "0");
+                put(VitessConnectorConfig.PREV_NUM_TASKS.name(), "1");
+                put(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY.name(), VitessOrderedTransactionMetadataFactory.class.getName());
+                put(VitessConnectorConfig.SNAPSHOT_MODE.name(), VitessConnectorConfig.SnapshotMode.NEVER.getValue());
+            }
+        };
+        connector.initialize(new ContextHelper().getSourceConnectorContext());
+        connector.start(props);
+        List<String> shards = Arrays.asList("-4000", "4000-8000", "8000-c000", "c000-");
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(1, shards);
+        taskConfigs = getConfigWithOffsetsHelper(taskConfigs);
+        assertThat(taskConfigs.size() == 1);
+        Map<String, String> firstConfig = taskConfigs.get(0);
+        assertThat(firstConfig.size() == 4);
+        assertThat(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG)).isEqualTo(
+                VitessConnector.getTaskKeyName(0, 1, 0));
+        assertThat(firstConfig.get(VitessConnectorConfig.VITESS_TASK_SHARDS_CONFIG)).isEqualTo(
+                String.join(",", shards));
+        assertThat(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG)).isEqualTo("task0_1_0");
+
+        ShardEpochMap epochMap = new ShardEpochMap(
+                Map.of("-4000", 0L, "4000-8000", 0L, "8000-c000", 0L, "c000-", 0L));
+        assertThat(firstConfig.get(VitessConnectorConfig.VITESS_TASK_SHARD_EPOCH_MAP_CONFIG)).isEqualTo(
+                epochMap.toString());
+
+        List<String> gtidStrs = Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID,
+                Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID);
+        Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
         assertEquals(vgtid.toString(), firstConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG));
         assertEquals("value", firstConfig.get("key"));
     }
@@ -176,6 +223,35 @@ public class VitessConnectorTest {
     }
 
     @Test
+    public void testTaskConfigsSingleTaskMultipleShardsOrderMetadata() {
+        VitessConnector connector = new VitessConnector();
+        List<String> shards = Arrays.asList("-01", "01-");
+        String shardCsv = String.join(",", shards);
+        Map<String, String> props = new HashMap<>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.KEYSPACE.name(), TEST_SHARDED_KEYSPACE);
+                put(VitessConnectorConfig.SHARD.name(), shardCsv);
+                put(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY.name(), VitessOrderedTransactionMetadataFactory.class.getName());
+                put(VitessConnectorConfig.SNAPSHOT_MODE.name(), VitessConnectorConfig.SnapshotMode.NEVER.getValue());
+            }
+        };
+        connector.start(props);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(1);
+        assertThat(taskConfigs.size() == 1);
+        Map<String, String> firstConfig = taskConfigs.get(0);
+        assertThat(firstConfig.size() == 3);
+        assertEquals(firstConfig.get(VitessConnectorConfig.SHARD.name()),
+                String.join(",", shards));
+        assertThat(firstConfig.get(VitessConnectorConfig.VITESS_TASK_SHARD_EPOCH_MAP_CONFIG)).isNull();
+        Vgtid vgtid = VitessReplicationConnection.defaultVgtid(new VitessConnectorConfig(Configuration.from(firstConfig)));
+        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
+                new Vgtid.ShardGtid(TEST_SHARDED_KEYSPACE, shards.get(0), "current"),
+                new Vgtid.ShardGtid(TEST_SHARDED_KEYSPACE, shards.get(1), "current")));
+        assertEquals("value", firstConfig.get("key"));
+    }
+
+    @Test
     public void testTaskConfigsSingleTaskMultipleShardsMultipleTasks() {
         VitessConnector connector = new VitessConnector();
         List<String> shards = Arrays.asList("-80", "80-90", "90-");
@@ -191,6 +267,7 @@ public class VitessConnectorTest {
                 put(VitessConnectorConfig.SNAPSHOT_MODE.name(), VitessConnectorConfig.SnapshotMode.NEVER.getValue());
             }
         };
+        connector.initialize(new ContextHelper().getSourceConnectorContext());
         connector.start(props);
         List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks);
         taskConfigs = getConfigWithOffsetsHelper(taskConfigs);
@@ -212,6 +289,57 @@ public class VitessConnectorTest {
         assertThat(secondVgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
                 new Vgtid.ShardGtid(TEST_SHARDED_KEYSPACE, shards.get(1), "current")));
         assertEquals("value", firstConfig.get("key"));
+    }
+
+    @Test
+    public void testTaskConfigsSingleTaskMultipleShardsMultipleTasksOrderMetadata() {
+        VitessConnector connector = new VitessConnector();
+        List<String> shards = Arrays.asList("-80", "80-90", "90-");
+        String shardCsv = String.join(",", shards);
+        int maxTasks = 2;
+        Map<String, String> props = new HashMap<>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.KEYSPACE.name(), TEST_SHARDED_KEYSPACE);
+                put(VitessConnectorConfig.SHARD.name(), shardCsv);
+                put(VitessConnectorConfig.TASKS_MAX_CONFIG, String.valueOf(maxTasks));
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+                put(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY.name(), VitessOrderedTransactionMetadataFactory.class.getName());
+                put(VitessConnectorConfig.SNAPSHOT_MODE.name(), VitessConnectorConfig.SnapshotMode.NEVER.getValue());
+            }
+        };
+        connector.initialize(new ContextHelper().getSourceConnectorContext());
+        connector.start(props);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks);
+        taskConfigs = getConfigWithOffsetsHelper(taskConfigs);
+        int expectedConfigSize = 12;
+        assertEquals(taskConfigs.size(), maxTasks);
+        Map<String, String> firstConfig = taskConfigs.get(0);
+        assertThat(firstConfig.size()).isEqualTo(expectedConfigSize);
+        assertEquals(firstConfig.get(VitessConnectorConfig.SHARD.name()),
+                String.join(",", shards));
+        VitessConnectorConfig config = new VitessConnectorConfig(Configuration.from(firstConfig));
+        Vgtid vgtid = VitessReplicationConnection.defaultVgtid(config);
+        assertThat(vgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
+                new Vgtid.ShardGtid(TEST_SHARDED_KEYSPACE, shards.get(0), "current"),
+                new Vgtid.ShardGtid(TEST_SHARDED_KEYSPACE, shards.get(2), "current")));
+
+        ShardEpochMap expectedShardEpochMap = new ShardEpochMap(Map.of("-80", 0L, "90-", 0L));
+        ShardEpochMap actualShardEpochMap = VitessReplicationConnection.defaultShardEpochMap(config);
+        assertThat(actualShardEpochMap).isEqualTo(expectedShardEpochMap);
+
+        Map<String, String> secondConfig = taskConfigs.get(1);
+        assertEquals(secondConfig.size(), expectedConfigSize);
+        assertEquals(secondConfig.get(VitessConnectorConfig.SHARD.name()),
+                String.join(",", shards));
+        Vgtid secondVgtid = VitessReplicationConnection.defaultVgtid(new VitessConnectorConfig(Configuration.from(secondConfig)));
+        assertThat(secondVgtid.getShardGtids()).isEqualTo(Collect.arrayListOf(
+                new Vgtid.ShardGtid(TEST_SHARDED_KEYSPACE, shards.get(1), "current")));
+        assertEquals("value", firstConfig.get("key"));
+
+        ShardEpochMap epochMap2 = new ShardEpochMap(
+                Map.of("80-90", 0L));
+        assertThat(secondConfig.get(VitessConnectorConfig.VITESS_TASK_SHARD_EPOCH_MAP_CONFIG)).isEqualTo(epochMap2.toString());
     }
 
     @Test
@@ -269,7 +397,7 @@ public class VitessConnectorTest {
     }
 
     @Test
-    public void testTaskConfigsSingleTaskNoShardsMultipleGtidsMultipleTasks() {
+    public void testTaskConfigsMultipleTasksNoShardsMultipleGtids() {
         VitessConnector connector = new VitessConnector();
         String vgtid = VgtidTest.VGTID_JSON;
         int maxTasks = 2;
@@ -312,7 +440,7 @@ public class VitessConnectorTest {
     }
 
     @Test
-    public void testTaskConfigsSingleTaskMultipleShardsMultipleGtidsMultipleTasks() {
+    public void testTaskConfigsMultipleTasksMultipleShardsMultipleGtids() {
         VitessConnector connector = new VitessConnector();
         List<String> shards = Arrays.asList("-70", "70-80", "80-90", "90-");
         List<String> gtids = Arrays.asList(TestHelper.TEST_GTID, Vgtid.CURRENT_GTID, TestHelper.TEST_GTID, Vgtid.CURRENT_GTID);
@@ -334,6 +462,7 @@ public class VitessConnectorTest {
                 put(VitessConnectorConfig.SNAPSHOT_MODE.name(), VitessConnectorConfig.SnapshotMode.NEVER.getValue());
             }
         };
+        connector.initialize(new ContextHelper().getSourceConnectorContext());
         connector.start(props);
         List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks);
         taskConfigs = getConfigWithOffsetsHelper(taskConfigs);
@@ -482,6 +611,7 @@ public class VitessConnectorTest {
                 put(VitessConnectorConfig.SNAPSHOT_MODE.name(), VitessConnectorConfig.SnapshotMode.NEVER.getValue());
             }
         };
+        connector.initialize(new ContextHelper().getSourceConnectorContext());
         connector.start(props);
         List<String> shards = Arrays.asList("-4000", "4000-8000", "8000-c000", "c000-");
         List<Map<String, String>> taskConfigs = connector.taskConfigs(2, shards);
@@ -504,6 +634,54 @@ public class VitessConnectorTest {
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs);
         assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG), vgtid1.toString());
         assertEquals(secondConfig.get("key"), "value");
+    }
+
+    @Test
+    public void testTaskConfigsOffsetStorageModeDoubleOrderMetadata() {
+        VitessConnector connector = new VitessConnector();
+        Map<String, String> props = new HashMap<>() {
+            {
+                put("key", "value");
+                put(VitessConnectorConfig.KEYSPACE.name(), TEST_UNSHARDED_KEYSPACE);
+                put(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK.name(), "true");
+                put(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name(), "0");
+                put(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY.name(), VitessOrderedTransactionMetadataFactory.class.getName());
+                put(VitessConnectorConfig.PREV_NUM_TASKS.name(), "1");
+                put(VitessConnectorConfig.SNAPSHOT_MODE.name(), VitessConnectorConfig.SnapshotMode.NEVER.getValue());
+            }
+        };
+        connector.initialize(new ContextHelper().getSourceConnectorContext());
+        connector.start(props);
+        List<String> shards = Arrays.asList("-4000", "4000-8000", "8000-c000", "c000-");
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(2, shards);
+        taskConfigs = getConfigWithOffsetsHelper(taskConfigs);
+        assertThat(taskConfigs.size() == 2);
+        Map<String, String> firstConfig = taskConfigs.get(0);
+        assertThat(firstConfig.size() == 4);
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task0_2_0");
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_SHARDS_CONFIG), "-4000,8000-c000");
+        List<String> gtidStrs = Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID);
+        List<String> shards0 = Arrays.asList("-4000", "8000-c000");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs);
+        assertEquals(firstConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG), vgtid0.toString());
+        assertEquals(firstConfig.get("key"), "value");
+
+        ShardEpochMap epochMap = new ShardEpochMap(
+                Map.of("-4000", 0L, "8000-c000", 0L));
+        assertThat(firstConfig.get(VitessConnectorConfig.VITESS_TASK_SHARD_EPOCH_MAP_CONFIG)).isEqualTo(epochMap.toString());
+
+        Map<String, String> secondConfig = taskConfigs.get(1);
+        assertThat(secondConfig.size() == 4);
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), "task1_2_0");
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_SHARDS_CONFIG), "4000-8000,c000-");
+        List<String> shards1 = Arrays.asList("4000-8000", "c000-");
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs);
+        assertEquals(secondConfig.get(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG), vgtid1.toString());
+        assertEquals(secondConfig.get("key"), "value");
+
+        ShardEpochMap epochMap2 = new ShardEpochMap(
+                Map.of("4000-8000", 0L, "c000-", 0L));
+        assertThat(secondConfig.get(VitessConnectorConfig.VITESS_TASK_SHARD_EPOCH_MAP_CONFIG)).isEqualTo(epochMap2.toString());
     }
 
     @Test
@@ -568,6 +746,7 @@ public class VitessConnectorTest {
     @Test
     public void testTaskConfigsSameNumTasks() {
         VitessConnector connector = new VitessConnector();
+        connector.initialize(new ContextHelper().getSourceConnectorContext());
         Map<String, String> props = new HashMap<>() {
             {
                 put("key", "value");
@@ -598,9 +777,9 @@ public class VitessConnectorTest {
         final int gen = 1;
         final int numTasks = 1;
         try {
-            Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, numTasks, vgtid0.toString(), null);
+            Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen, numTasks, getVgtidOffset(vgtid0.toString()), null);
             fail("Should not reach here because prev.num.tasks and num.tasks are the same, vgtids:"
-                    + vgtids);
+                    + offsets);
         }
         catch (IllegalArgumentException ex) {
             // This is expected();
@@ -617,12 +796,12 @@ public class VitessConnectorTest {
         Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
         final int gen = 1;
         final int numTasks = 2;
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, 1, vgtid0.toString(), null);
-        assertThat(vgtids.size() == numTasks);
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen, 1, getVgtidOffset(vgtid0.toString()), null);
+        assertThat(offsets.size() == numTasks);
         Map<String, String> gtidPerShard = new HashMap<>();
         for (int tid = 0; tid < numTasks; tid++) {
             String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
-            String gtidStr = vgtids.get(key);
+            String gtidStr = offsets.get(key).get(SourceInfo.VGTID_KEY);
             assertThat(gtidStr != null);
             Vgtid vgtid = Vgtid.of(gtidStr);
             assertThat(vgtid.getShardGtids().size() == 1);
@@ -632,6 +811,89 @@ public class VitessConnectorTest {
             }
         }
         assertEquals(expectedGtidPerShard, gtidPerShard);
+    }
+
+    @Test
+    public void testTaskConfigsOffsetMigrationDoubleFromServerToPerTaskOrderMetadata() {
+        List<String> shards = Arrays.asList("s0", "s1");
+        List<String> gtidStrs = Arrays.asList("gtid0", "gtid1");
+        Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "gtid1");
+        ShardEpochMap expectedEpochPerShard = new ShardEpochMap(Collect.hashMapOf("s0", 3L, "s1", 4L));
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        final int gen = 1;
+        final int numTasks = 2;
+
+        Map<String, ?> serverOffsets = Map.of(
+                SourceInfo.VGTID_KEY, vgtid0.toString(),
+                VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, expectedEpochPerShard.toString());
+
+        Function<Configuration.Builder, Configuration.Builder> customConfig = (builder) -> builder.with(
+                VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class);
+
+        // Store offsets for the server, see if we can read those as our previous and use them
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen, 1, serverOffsets, null,
+                customConfig);
+        assertThat(offsets.size() == numTasks);
+        Map<String, String> gtidPerShard = new HashMap<>();
+        for (int tid = 0; tid < numTasks; tid++) {
+            String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
+            String gtidStr = offsets.get(key).get(SourceInfo.VGTID_KEY);
+            assertThat(gtidStr != null);
+            Vgtid vgtid = Vgtid.of(gtidStr);
+            assertThat(vgtid.getShardGtids().size() == 1);
+            for (int i = 0; i < vgtid.getShardGtids().size(); i++) {
+                Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
+                gtidPerShard.put(shardGtid.getShard(), shardGtid.getGtid());
+            }
+        }
+        assertEquals(expectedGtidPerShard, gtidPerShard);
+    }
+
+    @Test
+    public void testTaskConfigsOffsetDoubleSubsetValidation() {
+        List<String> shards = Arrays.asList("s0", "s1");
+        List<String> shardSubset = Arrays.asList("s0");
+        List<String> gtidStrs = Arrays.asList("gtid0", "gtid1");
+
+        ShardEpochMap expectedEpochPerShard = new ShardEpochMap(Collect.hashMapOf("s0", 3L, "s1", 4L));
+
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        final int gen = 1;
+        final int numTasks = 2;
+
+        Map<String, ?> serverOffsets = Map.of(
+                SourceInfo.VGTID_KEY, vgtid0.toString(),
+                VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, expectedEpochPerShard.toString());
+
+        assertThatThrownBy(() -> {
+            getOffsetFromStorage(numTasks, shardSubset, gen, 1, serverOffsets, null);
+        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("We will lose gtid positions for some shards if we continue");
+    }
+
+    @Test
+    public void testTaskConfigsOffsetDoubleSubsetEpochValidation() {
+        List<String> shardSubset = Arrays.asList("s0");
+        ShardEpochMap expectedEpochPerShard = new ShardEpochMap(Collect.hashMapOf("s0", 3L, "s1", 4L));
+
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, Collections.emptyList(), Collections.emptyList());
+        final int gen = 1;
+        final int numTasks = 2;
+
+        Map<String, ?> serverOffsets = Map.of(
+                SourceInfo.VGTID_KEY, vgtid0.toString(),
+                VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, expectedEpochPerShard.toString());
+
+        Function<Configuration.Builder, Configuration.Builder> customConfig = (builder) -> builder.with(
+                VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class);
+
+        assertThatThrownBy(() -> {
+            getOffsetFromStorage(numTasks, shardSubset, gen, 1, serverOffsets, null,
+                    customConfig);
+        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("We will lose epochs for some shards if we continue");
     }
 
     @Test
@@ -649,15 +911,15 @@ public class VitessConnectorTest {
         List<String> gtidStrs1 = List.of("gtid1");
         Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs0);
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs1);
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks, gen), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, numTasks, gen), vgtid1.toString());
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, serverVgtid.toString(), prevVgtids);
-        assertThat(vgtids.size() == numTasks);
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen), getVgtidOffset(vgtid0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen), getVgtidOffset(vgtid1.toString()));
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, getVgtidOffset(serverVgtid.toString()), prevVgtids);
+        assertThat(offsets.size() == numTasks);
         Map<String, String> gtidPerShard = new HashMap<>();
         for (int tid = 0; tid < numTasks; tid++) {
             String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
-            String gtidStr = vgtids.get(key);
+            String gtidStr = offsets.get(key).get(SourceInfo.VGTID_KEY);
             assertThat(gtidStr != null);
             Vgtid vgtid = Vgtid.of(gtidStr);
             assertThat(vgtid.getShardGtids().size() == 1);
@@ -665,6 +927,59 @@ public class VitessConnectorTest {
                 Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
                 gtidPerShard.put(shardGtid.getShard(), shardGtid.getGtid());
             }
+        }
+        Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "gtid1");
+        assertEquals(expectedGtidPerShard, gtidPerShard);
+    }
+
+    @Test
+    public void testTaskConfigsOffsetRestartDoubleOrderMetadata() {
+        List<String> shards = Arrays.asList("s0", "s1");
+        // Note we are not able to fetch old0/old1 since prevGtids takes precedence over serverVgtid
+        List<String> gtidStrs = Arrays.asList("old0", "old1");
+        Vgtid serverVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        final int gen = 1;
+        final int numTasks = 2;
+        final int prevNumTasks = 1;
+        List<String> shards0 = List.of("s0");
+        List<String> shards1 = List.of("s1");
+        List<String> gtidStrs0 = List.of("gtid0");
+        List<String> gtidStrs1 = List.of("gtid1");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs0);
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs1);
+
+        ShardEpochMap expectedEpochPerShard = new ShardEpochMap(Collect.hashMapOf("s0", 3L, "s1", 4L));
+
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen), getVgtidEpochOffset(vgtid0.toString(), expectedEpochPerShard.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen), getVgtidEpochOffset(vgtid1.toString(), expectedEpochPerShard.toString()));
+
+        Function<Configuration.Builder, Configuration.Builder> customConfig = (builder) -> builder.with(
+                VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class);
+
+        Map<String, ?> serverOffsets = Map.of(
+                SourceInfo.VGTID_KEY, serverVgtid.toString(),
+                VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, expectedEpochPerShard.toString());
+
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(
+                numTasks, shards, gen, prevNumTasks, serverOffsets, taskOffsets,
+                customConfig);
+
+        assertThat(offsets.size() == numTasks);
+        Map<String, String> gtidPerShard = new HashMap<>();
+        for (int tid = 0; tid < numTasks; tid++) {
+            String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
+            String gtidStr = offsets.get(key).get(SourceInfo.VGTID_KEY);
+            assertThat(gtidStr != null);
+            Vgtid vgtid = Vgtid.of(gtidStr);
+            assertThat(vgtid.getShardGtids().size() == 1);
+            for (int i = 0; i < vgtid.getShardGtids().size(); i++) {
+                Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
+                gtidPerShard.put(shardGtid.getShard(), shardGtid.getGtid());
+            }
+
+            String epoch = offsets.get(key).get(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH);
+            assertThat(epoch).isEqualTo(expectedEpochPerShard.toString());
         }
         Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "gtid1");
         assertEquals(expectedGtidPerShard, gtidPerShard);
@@ -683,14 +998,14 @@ public class VitessConnectorTest {
         Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs0);
         // Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs1);
         // Note that we omit the vgtid1 in prevVgtids so it will fallback to the serverVgtid
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks, gen), vgtid0.toString());
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, serverVgtid.toString(), prevVgtids);
-        assertThat(vgtids.size() == numTasks);
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen), getVgtidOffset(vgtid0.toString()));
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, getVgtidOffset(serverVgtid.toString()), prevVgtids);
+        assertThat(offsets.size() == numTasks);
         Map<String, String> gtidPerShard = new HashMap<>();
         for (int tid = 0; tid < numTasks; tid++) {
             String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
-            String gtidStr = vgtids.get(key);
+            String gtidStr = offsets.get(key).get(SourceInfo.VGTID_KEY);
             assertThat(gtidStr != null);
             Vgtid vgtid = Vgtid.of(gtidStr);
             assertThat(vgtid.getShardGtids().size() == 1);
@@ -702,6 +1017,61 @@ public class VitessConnectorTest {
         // Note we got gtid0 from prevGtids, but got old1 from serverGtid
         Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "old1");
         assertEquals(expectedGtidPerShard, gtidPerShard);
+    }
+
+    @Test
+    public void testTaskConfigsOffsetRestartDoubleIncompleteOrderMetadata() {
+        List<String> shards = Arrays.asList("s0", "s1");
+        List<String> gtidStrs = Arrays.asList("old0", "old1");
+        Vgtid serverVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards, gtidStrs);
+        final int gen = 1;
+        final int numTasks = 2;
+        final int prevNumTasks = 1;
+        List<String> shards0 = List.of("s0");
+        List<String> gtidStrs0 = List.of("gtid0");
+        Vgtid taskVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs0);
+        // Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs1);
+        // Note that we omit the vgtid1 in prevVgtids so it will fallback to the serverVgtid
+
+        ShardEpochMap serverEpoch = new ShardEpochMap(Collect.hashMapOf("s0", 3L, "s1", 4L));
+        ShardEpochMap taskEpoch = new ShardEpochMap(Collect.hashMapOf("s0", 5L));
+
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen), getVgtidEpochOffset(taskVgtid.toString(), taskEpoch.toString()));
+
+        Function<Configuration.Builder, Configuration.Builder> customConfig = (builder) -> builder.with(
+                VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class);
+
+        Map<String, ?> serverOffsets = Map.of(
+                SourceInfo.VGTID_KEY, serverVgtid.toString(),
+                VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, serverEpoch.toString());
+
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(
+                numTasks, shards, gen, prevNumTasks, serverOffsets, taskOffsets,
+                customConfig);
+
+        assertThat(offsets.size() == numTasks);
+        Map<String, String> gtidPerShard = new HashMap<>();
+        Map<String, Long> epochPerShard = new HashMap<>();
+        for (int tid = 0; tid < numTasks; tid++) {
+            String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
+            String gtidStr = offsets.get(key).get(SourceInfo.VGTID_KEY);
+            assertThat(gtidStr != null);
+            Vgtid vgtid = Vgtid.of(gtidStr);
+            assertThat(vgtid.getShardGtids().size() == 1);
+            String epoch = offsets.get(key).get(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH);
+            for (int i = 0; i < vgtid.getShardGtids().size(); i++) {
+                Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
+                String shard = shardGtid.getShard();
+                gtidPerShard.put(shard, shardGtid.getGtid());
+                epochPerShard.put(shard, ShardEpochMap.of(epoch).get(shard));
+            }
+        }
+        // Note we got gtid0 from prevGtids, but got old1 from serverGtid
+        Map<String, String> expectedGtidPerShard = Collect.hashMapOf("s0", "gtid0", "s1", "old1");
+        Map<String, Long> expectedEpochPerShard = Collect.hashMapOf("s0", 5L, "s1", 4L);
+        assertThat(gtidPerShard).isEqualTo(expectedGtidPerShard);
+        assertThat(epochPerShard).isEqualTo(expectedEpochPerShard);
     }
 
     @Test
@@ -718,16 +1088,16 @@ public class VitessConnectorTest {
         final int gen = 2;
         final int numTasks = 4;
         final int prevNumTasks = 2;
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, prevNumTasks, gen - 1), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, prevNumTasks, gen - 1), vgtid1.toString());
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen - 1), getVgtidOffset(vgtid0.toString()),
+                VitessConnector.getTaskKeyName(1, prevNumTasks, gen - 1), getVgtidOffset(vgtid1.toString()));
 
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, null, prevVgtids);
-        assertThat(vgtids.size() == numTasks);
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, null, prevVgtids);
+        assertThat(offsets.size() == numTasks);
         Map<String, String> gtidPerShard = new HashMap<>();
         for (int tid = 0; tid < numTasks; tid++) {
             String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
-            String gtidStr = vgtids.get(key);
+            String gtidStr = offsets.get(key).get(SourceInfo.VGTID_KEY);
             assertThat(gtidStr != null);
             Vgtid vgtid = Vgtid.of(gtidStr);
             assertThat(vgtid.getShardGtids().size() == 1);
@@ -740,6 +1110,60 @@ public class VitessConnectorTest {
     }
 
     @Test
+    public void testTaskConfigsOffsetMigrationQuadOrderMetadata() {
+        List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
+        Map<String, String> expectedGtidPerShard = Collect.hashMapOf(
+                "s0", "gtid0", "s1", "gtid1", "s2", "gtid2", "s3", "gtid3");
+        Map<String, Long> expectedEpochPerShard = Collect.hashMapOf(
+                "s0", 5L, "s1", 4L, "s2", 6L, "s3", 7L);
+
+        List<String> shards0 = Arrays.asList("s0", "s2");
+        List<String> shards1 = Arrays.asList("s1", "s3");
+        List<String> gtidStrs0 = Arrays.asList("gtid0", "gtid2");
+        List<String> gtidStrs1 = Arrays.asList("gtid1", "gtid3");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards0, gtidStrs0);
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE, shards1, gtidStrs1);
+
+        ShardEpochMap prevEpoch0 = new ShardEpochMap(Collect.hashMapOf("s0", 5L, "s2", 6L));
+        ShardEpochMap prevEpoch1 = new ShardEpochMap(Collect.hashMapOf("s1", 4L, "s3", 7L));
+
+        final int gen = 2;
+        final int numTasks = 4;
+        final int prevNumTasks = 2;
+
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen - 1), getVgtidEpochOffset(vgtid0.toString(), prevEpoch0.toString()),
+                VitessConnector.getTaskKeyName(1, prevNumTasks, gen - 1), getVgtidEpochOffset(vgtid1.toString(), prevEpoch1.toString()));
+
+        Function<Configuration.Builder, Configuration.Builder> customConfig = (builder) -> builder.with(
+                VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class);
+
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(
+                numTasks, shards, gen, prevNumTasks, null, taskOffsets, customConfig);
+
+        assertThat(offsets.size() == numTasks);
+        Map<String, String> gtidPerShard = new HashMap<>();
+        Map<String, Long> epochPerShard = new HashMap<>();
+        for (int tid = 0; tid < numTasks; tid++) {
+            String key = VitessConnector.getTaskKeyName(tid, numTasks, gen);
+            String gtidStr = offsets.get(key).get(SourceInfo.VGTID_KEY);
+            assertThat(gtidStr).isNotNull();
+            Vgtid vgtid = Vgtid.of(gtidStr);
+            assertThat(vgtid.getShardGtids().size() == 1);
+            String epoch = offsets.get(key).get(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH);
+            for (int i = 0; i < vgtid.getShardGtids().size(); i++) {
+                Vgtid.ShardGtid shardGtid = vgtid.getShardGtids().get(i);
+                String shard = shardGtid.getShard();
+                gtidPerShard.put(shard, shardGtid.getGtid());
+                epochPerShard.put(shard, ShardEpochMap.of(epoch).get(shard));
+            }
+        }
+
+        assertThat(gtidPerShard).isEqualTo(expectedGtidPerShard);
+        assertThat(epochPerShard).isEqualTo(expectedEpochPerShard);
+    }
+
+    @Test
     public void testEmptyOffsetStorage() {
         final int numTasks = 2;
         final int gen = 0;
@@ -749,13 +1173,54 @@ public class VitessConnectorTest {
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s1", "s3"), Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID));
 
-        final Map<String, String> expectedVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks, gen), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, numTasks, gen), vgtid1.toString());
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen, -1, null, null);
-        Testing.print(String.format("vgtids: %s", vgtids));
-        assertEquals(vgtids.size(), 2);
-        assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+        final Map<String, Map<String, String>> expectedVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen), getVgtidOffset(vgtid0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen), getVgtidOffset(vgtid1.toString()));
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen, -1, null, null);
+        Testing.print(String.format("offsets: %s", offsets));
+        assertEquals(offsets.size(), 2);
+        assertArrayEquals(offsets.values().toArray(), expectedVgtids.values().toArray());
+    }
+
+    @Test
+    public void testEmptyOffsetStorageOrderMetadata() {
+        final int numTasks = 2;
+        final int gen = 0;
+        final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
+
+        // Define Vgtid for each task
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s2"), Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID));
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s1", "s3"), Arrays.asList(Vgtid.CURRENT_GTID, Vgtid.CURRENT_GTID));
+
+        // Define expected epoch map for each shard (using zero for this test)
+        ShardEpochMap expectedEpochMap0 = new ShardEpochMap(Collect.hashMapOf("s0", 0L, "s2", 0L));
+        ShardEpochMap expectedEpochMap1 = new ShardEpochMap(Collect.hashMapOf("s1", 0L, "s3", 0L));
+
+        // Create expected offsets with Vgtids and epochs
+        final Map<String, Map<String, ?>> expectedOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen),
+                getVgtidEpochOffset(vgtid0.toString(), expectedEpochMap0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen),
+                getVgtidEpochOffset(vgtid1.toString(), expectedEpochMap1.toString()));
+
+        // Retrieve offsets from storage
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen, -1, null, null,
+                builder -> builder.with(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class));
+
+        // Debug print for verification
+        Testing.print(String.format("offsets: %s", offsets));
+
+        // Assertions
+        assertEquals(expectedOffsets.size(), offsets.size());
+        for (Map.Entry<String, Map<String, ?>> entry : expectedOffsets.entrySet()) {
+            String taskKey = entry.getKey();
+            Map<String, ?> expectedValues = entry.getValue();
+            Map<String, String> actualValues = offsets.get(taskKey);
+
+            assertThat(expectedValues).isEqualTo(actualValues);
+        }
     }
 
     @Test
@@ -764,8 +1229,8 @@ public class VitessConnectorTest {
         final int prevNumTasks = 1;
         Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), vgtid.toString());
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidOffset(vgtid.toString()));
 
         final int numTasks = 2;
         final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
@@ -774,13 +1239,63 @@ public class VitessConnectorTest {
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
 
-        final Map<String, Object> expectedVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), vgtid1.toString());
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
-        Testing.print(String.format("vgtids: %s", vgtids));
-        assertEquals(vgtids.size(), 2);
-        assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+        final Map<String, Map<String, String>> expectedVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), getVgtidOffset(vgtid0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), getVgtidOffset(vgtid1.toString()));
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
+        Testing.print(String.format("offsets: %s", offsets));
+        assertEquals(offsets.size(), 2);
+        assertArrayEquals(offsets.values().toArray(), expectedVgtids.values().toArray());
+    }
+
+    @Test
+    public void testPreviousOffsetStorageOrderMetadata() {
+        final int gen = 0;
+        final int prevNumTasks = 1;
+
+        // Define Vgtid for previous tasks
+        Vgtid prevVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
+        ShardEpochMap prevEpochMap = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s1", 1L, "s2", 1L, "s3", 1L));
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidEpochOffset(prevVgtid.toString(), prevEpochMap.toString()));
+
+        final int numTasks = 2;
+        final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
+
+        // Define Vgtids for current tasks
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s2"), Arrays.asList("gt0", "gt2"));
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
+
+        // Define epoch maps for current tasks
+        ShardEpochMap epochMap0 = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s2", 1L));
+        ShardEpochMap epochMap1 = new ShardEpochMap(Collect.hashMapOf("s1", 1L, "s3", 1L));
+
+        // Create expected offsets with Vgtids and epochs
+        final Map<String, Map<String, ?>> expectedOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1),
+                getVgtidEpochOffset(vgtid0.toString(), epochMap0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1),
+                getVgtidEpochOffset(vgtid1.toString(), epochMap1.toString()));
+
+        // Retrieve offsets from storage
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen + 1, prevNumTasks, null, taskOffsets,
+                builder -> builder.with(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class));
+
+        // Debug print for verification
+        Testing.print(String.format("offsets: %s", offsets));
+
+        // Assertions
+        assertEquals(expectedOffsets.size(), offsets.size());
+        for (Map.Entry<String, Map<String, ?>> entry : expectedOffsets.entrySet()) {
+            String taskKey = entry.getKey();
+            Map<String, ?> expectedValues = entry.getValue();
+            Map<String, String> actualValues = offsets.get(taskKey);
+
+            assertThat(actualValues).isEqualTo(expectedValues);
+        }
     }
 
     @Test
@@ -789,8 +1304,8 @@ public class VitessConnectorTest {
         final int prevNumTasks = 1;
         Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s0", "s1"), Arrays.asList("gt0", "gt1"));
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), vgtid.toString());
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidOffset(vgtid.toString()));
 
         final int numTasks = 2;
         final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
@@ -800,13 +1315,64 @@ public class VitessConnectorTest {
                 Arrays.asList("s1", "s3"), Arrays.asList("gt1", "current"));
 
         // We still expect the code will use the current db shards: s0, s1, s2, s3
-        final Map<String, Object> expectedVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), vgtid1.toString());
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
-        Testing.print(String.format("vgtids: %s", vgtids));
-        assertEquals(vgtids.size(), 2);
-        assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+        final Map<String, Map<String, String>> expectedVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), getVgtidOffset(vgtid0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), getVgtidOffset(vgtid1.toString()));
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
+        Testing.print(String.format("offsets: %s", offsets));
+        assertEquals(offsets.size(), 2);
+        assertArrayEquals(offsets.values().toArray(), expectedVgtids.values().toArray());
+    }
+
+    @Test
+    public void testExpandingShardsOrderMetadata() {
+        final int gen = 0;
+        final int prevNumTasks = 1;
+
+        // Define Vgtid for previous tasks
+        Vgtid prevVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s1"), Arrays.asList("gt0", "gt1"));
+        ShardEpochMap prevEpochMap = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s1", 1L));
+
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidEpochOffset(prevVgtid.toString(), prevEpochMap.toString()));
+
+        final int numTasks = 2;
+        final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
+
+        // Define Vgtids for current tasks
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s2"), Arrays.asList("gt0", "current"));
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s1", "s3"), Arrays.asList("gt1", "current"));
+
+        // Define epoch maps for current tasks
+        ShardEpochMap epochMap0 = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s2", 0L));
+        ShardEpochMap epochMap1 = new ShardEpochMap(Collect.hashMapOf("s1", 1L, "s3", 0L));
+
+        // Create expected offsets with Vgtids and epochs
+        final Map<String, Map<String, ?>> expectedOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1),
+                getVgtidEpochOffset(vgtid0.toString(), epochMap0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1),
+                getVgtidEpochOffset(vgtid1.toString(), epochMap1.toString()));
+
+        // Retrieve offsets from storage
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen + 1, prevNumTasks, null, taskOffsets,
+                builder -> builder.with(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class));
+
+        // Debug print for verification
+        Testing.print(String.format("offsets: %s", offsets));
+
+        // Assertions
+        assertEquals(expectedOffsets.size(), offsets.size());
+        for (Map.Entry<String, Map<String, ?>> entry : expectedOffsets.entrySet()) {
+            String taskKey = entry.getKey();
+            Map<String, ?> expectedValues = entry.getValue();
+            Map<String, String> actualValues = offsets.get(taskKey);
+
+            assertThat(actualValues).isEqualTo(expectedValues);
+        }
     }
 
     @Test
@@ -816,8 +1382,8 @@ public class VitessConnectorTest {
         Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "current", "current"));
         // We still expect the code will use the current db shards: s0, s1, s2, s3
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), vgtid0.toString());
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidOffset(vgtid0.toString()));
 
         final int numTasks = 1;
         final List<String> shards = Arrays.asList("s0", "s1");
@@ -834,13 +1400,33 @@ public class VitessConnectorTest {
     }
 
     @Test
+    public void testContractingShardsOrderMetadata() {
+        final int gen = 0;
+        final int prevNumTasks = 1;
+
+        // Define Vgtid for previous tasks
+        Vgtid prevVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "current", "current"));
+        ShardEpochMap prevEpochMap = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s1", 1L, "s2", 1L, "s3", 1L));
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidEpochOffset(prevVgtid.toString(), prevEpochMap.toString()));
+
+        final int numTasks = 1;
+        final List<String> shards = Arrays.asList("s0", "s1");
+
+        assertThatThrownBy(() -> getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, taskOffsets,
+                builder -> builder.with(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class)))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("Previous shards: [s3, s0, s1, s2] is the superset of current shards: [s0, s1].");
+    }
+
+    @Test
     public void testCurrentOffsetStorageShardSplit() {
         final int gen = 0;
         final int prevNumTasks = 1;
         Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), vgtid.toString());
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidOffset(vgtid.toString()));
 
         final int numTasks = 2;
         // "s3" split into "s30", "s31"
@@ -850,16 +1436,68 @@ public class VitessConnectorTest {
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
         // We still expect the code will use the old shards "s3" instead of "s30" and "s31"
-        final Map<String, Object> expectedVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), vgtid1.toString());
+        final Map<String, Map<String, ?>> currentGenVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), getVgtidOffset(vgtid0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), getVgtidOffset(vgtid1.toString()));
         // Add in current gen maps
-        prevVgtids.putAll(expectedVgtids);
+        prevVgtids.putAll(currentGenVgtids);
 
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
-        Testing.print(String.format("vgtids: %s", vgtids));
-        assertEquals(vgtids.size(), 2);
-        assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
+        Testing.print(String.format("offsets: %s", offsets));
+        assertEquals(offsets.size(), 2);
+        // We want to assert on vgtid=
+        assertArrayEquals(offsets.values().toArray(), currentGenVgtids.values().toArray());
+    }
+
+    @Test
+    public void testCurrentOffsetStorageShardSplitOrderMetadata() {
+        final int gen = 0;
+        final int prevNumTasks = 1;
+
+        // Define Vgtid for previous tasks
+        Vgtid prevVgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
+        ShardEpochMap prevEpochMap = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s1", 1L, "s2", 1L, "s3", 1L));
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidEpochOffset(prevVgtid.toString(), prevEpochMap.toString()));
+
+        final int numTasks = 2;
+        // "s3" split into "s30", "s31"
+        final List<String> shards = Arrays.asList("s0", "s1", "s2", "s30", "s31");
+
+        // Define Vgtids for current tasks
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s2"), Arrays.asList("gt0", "gt2"));
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
+
+        // Define epoch maps for current tasks
+        ShardEpochMap epochMap0 = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s2", 1L));
+        ShardEpochMap epochMap1 = new ShardEpochMap(Collect.hashMapOf("s1", 1L, "s3", 1L));
+
+        // Create expected offsets with Vgtids and epochs
+        final Map<String, Map<String, ?>> expectedOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1),
+                getVgtidEpochOffset(vgtid0.toString(), epochMap0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1),
+                getVgtidEpochOffset(vgtid1.toString(), epochMap1.toString()));
+
+        // Retrieve offsets from storage
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, taskOffsets,
+                builder -> builder.with(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class));
+
+        // Debug print for verification
+        Testing.print(String.format("offsets: %s", offsets));
+
+        // Assertions
+        assertEquals(expectedOffsets.size(), offsets.size());
+        for (Map.Entry<String, Map<String, ?>> entry : expectedOffsets.entrySet()) {
+            String taskKey = entry.getKey();
+            Map<String, ?> expectedValues = entry.getValue();
+            Map<String, String> actualValues = offsets.get(taskKey);
+
+            assertThat(actualValues).isEqualTo(expectedValues);
+        }
     }
 
     @Test
@@ -868,8 +1506,8 @@ public class VitessConnectorTest {
         final int prevNumTasks = 1;
         Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), vgtid.toString());
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidOffset(vgtid.toString()));
 
         final int numTasks = 2;
         // "s3" split into "s30", "s31"
@@ -879,19 +1517,51 @@ public class VitessConnectorTest {
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
         // Put in current gen, but missing one task
-        prevVgtids.put(VitessConnector.getTaskKeyName(1, numTasks, gen + 1), vgtid1.toString());
+        prevVgtids.put(VitessConnector.getTaskKeyName(1, numTasks, gen + 1), getVgtidOffset(vgtid1.toString()));
 
         // We still expect the code will use the old shards "s3" instead of "s30" and "s31"
         final Map<String, Object> expectedVgtids = Collect.hashMapOf(
                 VitessConnector.getTaskKeyName(0, numTasks, gen + 1), vgtid0.toString(),
                 VitessConnector.getTaskKeyName(1, numTasks, gen + 1), vgtid1.toString());
         try {
-            Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
+            Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
             fail("This call should not reach here.");
         }
         catch (IllegalArgumentException ex) {
-            Testing.print(String.format("Got expected exception: {}", ex));
+            System.out.println(String.format("Got expected exception: {}", ex));
         }
+    }
+
+    @Test
+    public void testCurrentOffsetStorageShardSplitIncompleteOrderMetadata() {
+        final int gen = 0;
+        final int prevNumTasks = 1;
+        Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidOffset(vgtid.toString()));
+
+        final int numTasks = 2;
+        // "s3" split into "s30", "s31"
+        final List<String> shards = Arrays.asList("s0", "s1", "s2", "s30", "s31");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s2"), Arrays.asList("gt0", "gt2"));
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
+        ShardEpochMap epochMap0 = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s2", 1L));
+        ShardEpochMap epochMap1 = new ShardEpochMap(Collect.hashMapOf("s1", 1L, "s3", 1L));
+
+        // Put in current gen, but missing one task
+        taskOffsets.put(VitessConnector.getTaskKeyName(1, numTasks, gen + 1), getVgtidEpochOffset(vgtid1.toString(), epochMap1.toString()));
+
+        // We still expect the code will use the old shards "s3" instead of "s30" and "s31"
+        final Map<String, Object> expectedTaskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), getVgtidEpochOffset(vgtid0.toString(), epochMap0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), getVgtidEpochOffset(vgtid1.toString(), epochMap1.toString()));
+        assertThatThrownBy(() -> getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, taskOffsets,
+                builder -> builder.with(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class)))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining(
+                        "No offset found for VitessPartition [sourcePartition={server=test_server, task_key=task0_2_1}]");
     }
 
     @Test
@@ -900,8 +1570,8 @@ public class VitessConnectorTest {
         final int prevNumTasks = 1;
         Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
-        final Map<String, Object> prevVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), vgtid.toString());
+        final Map<String, Map<String, ?>> prevVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidOffset(vgtid.toString()));
 
         final int numTasks = 2;
         final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
@@ -910,16 +1580,50 @@ public class VitessConnectorTest {
         Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
                 Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
         // Put in current gen, but missing one task
-        prevVgtids.put(VitessConnector.getTaskKeyName(0, numTasks, gen + 1), vgtid0.toString());
+        prevVgtids.put(VitessConnector.getTaskKeyName(0, numTasks, gen + 1), getVgtidOffset(vgtid0.toString()));
 
         // We still expect the code will use the current db shards: s0, s1, s2, s3
-        final Map<String, Object> expectedVgtids = Collect.hashMapOf(
-                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), vgtid0.toString(),
-                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), vgtid1.toString());
-        Map<String, String> vgtids = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
-        Testing.print(String.format("vgtids: %s", vgtids));
-        assertEquals(vgtids.size(), 2);
-        assertArrayEquals(vgtids.values().toArray(), expectedVgtids.values().toArray());
+        final Map<String, Map<String, String>> expectedVgtids = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), getVgtidOffset(vgtid0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), getVgtidOffset(vgtid1.toString()));
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(numTasks, shards, gen + 1, 1, null, prevVgtids);
+        Testing.print(String.format("offsets: %s", offsets));
+        assertEquals(offsets.size(), 2);
+        assertArrayEquals(offsets.values().toArray(), expectedVgtids.values().toArray());
+    }
+
+    @Test
+    public void testCurrentOffsetStorageIncompleteOrderMetadata() {
+        final int gen = 0;
+        final int prevNumTasks = 1;
+        Vgtid vgtid = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s1", "s2", "s3"), Arrays.asList("gt0", "gt1", "gt2", "gt3"));
+        // Define epoch maps for current tasks
+        ShardEpochMap epochMap = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s1", 1L, "s2", 1L, "s3", 1L));
+
+        final Map<String, Map<String, ?>> taskOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, prevNumTasks, gen), getVgtidEpochOffset(vgtid.toString(), epochMap.toString()));
+
+        final int numTasks = 2;
+        final List<String> shards = Arrays.asList("s0", "s1", "s2", "s3");
+        Vgtid vgtid0 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s0", "s2"), Arrays.asList("gt0", "gt2"));
+        Vgtid vgtid1 = VitessReplicationConnection.buildVgtid(TEST_UNSHARDED_KEYSPACE,
+                Arrays.asList("s1", "s3"), Arrays.asList("gt1", "gt3"));
+        ShardEpochMap epochMap0 = new ShardEpochMap(Collect.hashMapOf("s0", 1L, "s2", 1L));
+        ShardEpochMap epochMap1 = new ShardEpochMap(Collect.hashMapOf("s1", 1L, "s3", 1L));
+        // Put in current gen, but missing one task
+        taskOffsets.put(VitessConnector.getTaskKeyName(0, numTasks, gen + 1), getVgtidEpochOffset(vgtid0.toString(), epochMap0.toString()));
+
+        // We still expect the code will use the current db shards: s0, s1, s2, s3
+        final Map<String, Map<String, ?>> expectedOffsets = Collect.hashMapOf(
+                VitessConnector.getTaskKeyName(0, numTasks, gen + 1), getVgtidEpochOffset(vgtid0.toString(), epochMap0.toString()),
+                VitessConnector.getTaskKeyName(1, numTasks, gen + 1), getVgtidEpochOffset(vgtid1.toString(), epochMap1.toString()));
+        Map<String, Map<String, String>> offsets = getOffsetFromStorage(
+                numTasks, shards, gen + 1, 1, null, taskOffsets,
+                builder -> builder.with(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class));
+        Testing.print(String.format("offsets: %s", offsets));
+        assertThat(offsets).isEqualTo(expectedOffsets);
     }
 
     @Test
@@ -947,36 +1651,35 @@ public class VitessConnectorTest {
         assertEquals(expectedTables, includedTables);
     }
 
-    private void storeOffsets(OffsetBackingStore offsetStore, String serverVgtid, Map<String, Object> prevVgtids) {
-        if (serverVgtid == null && (prevVgtids == null || prevVgtids.isEmpty())) {
+    private boolean isEmptyOffsets(Map<String, ?> offsets) {
+        return offsets == null || offsets.isEmpty();
+    }
+
+    private void storeOffsets(OffsetBackingStore offsetStore, Map<String, ?> serverOffsets, Map<String, Map<String, ?>> taskOffsets) {
+        if (isEmptyOffsets(serverOffsets) && isEmptyOffsets(taskOffsets)) {
             Testing.print("Empty gtids to store to offset.");
             return;
         }
-        final String engineName = "testOffset";
-        final Converter keyConverter = new JsonConverter();
-        Map<String, Object> converterConfig = Collect.hashMapOf("schemas.enable", false);
-        keyConverter.configure(converterConfig, true);
-        final Converter valueConverter = new JsonConverter();
-        valueConverter.configure(converterConfig, false);
-        OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetStore, engineName,
-                keyConverter, valueConverter);
-        if (serverVgtid != null) {
-            Testing.print(String.format("Server vgtids: %s", serverVgtid));
+        OffsetStorageWriter offsetWriter = getWriter(offsetStore);
+
+        if (!isEmptyOffsets(serverOffsets)) {
+            Testing.print(String.format("Server offsets: %s", serverOffsets));
             Map<String, Object> sourcePartition = Collect.hashMapOf(
                     VitessPartition.SERVER_PARTITION_KEY, TEST_SERVER);
-            Map<String, Object> offset = Collect.hashMapOf(SourceInfo.VGTID_KEY, serverVgtid);
-            offsetWriter.offset(sourcePartition, offset);
+            offsetWriter.offset(sourcePartition, serverOffsets);
         }
-        if (prevVgtids != null) {
-            Testing.print(String.format("Previous vgtids: %s", prevVgtids));
-            for (String key : prevVgtids.keySet()) {
+
+        if (!isEmptyOffsets(taskOffsets)) {
+            Testing.print(String.format("Task offsets: %s", taskOffsets));
+            for (String task : taskOffsets.keySet()) {
                 Map<String, Object> sourcePartition = Collect.hashMapOf(
                         VitessPartition.SERVER_PARTITION_KEY, TEST_SERVER,
-                        VitessPartition.TASK_KEY_PARTITION_KEY, key);
-                Map<String, Object> offset = Collect.hashMapOf(SourceInfo.VGTID_KEY, prevVgtids.get(key));
+                        VitessPartition.TASK_KEY_PARTITION_KEY, task);
+                Map<String, ?> offset = taskOffsets.get(task);
                 offsetWriter.offset(sourcePartition, offset);
             }
         }
+
         offsetWriter.beginFlush();
         Future<Void> f = offsetWriter.doFlush(null);
         try {
@@ -985,6 +1688,18 @@ public class VitessConnectorTest {
         catch (Exception ex) {
             fail(ex.getMessage());
         }
+    }
+
+    private static OffsetStorageWriter getWriter(OffsetBackingStore offsetStore) {
+        final String engineName = "testOffset";
+        final Converter keyConverter = new JsonConverter();
+        Map<String, Object> converterConfig = Collect.hashMapOf("schemas.enable", false);
+        keyConverter.configure(converterConfig, true);
+        final Converter valueConverter = new JsonConverter();
+        valueConverter.configure(converterConfig, false);
+        OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetStore, engineName,
+                keyConverter, valueConverter);
+        return offsetWriter;
     }
 
     private static List<Map<String, String>> getConfigWithOffsetsHelper(List<Map<String, String>> initialTaskConfigs) {
@@ -998,9 +1713,18 @@ public class VitessConnectorTest {
         return taskConfigs;
     }
 
-    private Map<String, String> getTaskOffsets(OffsetBackingStore offsetStore, int numTasks, List<String> shards,
-                                               int gen, int prevNumTasks) {
-        final Configuration config = TestHelper.defaultConfig(false, true, numTasks, gen, prevNumTasks, null, VitessConnectorConfig.SnapshotMode.NEVER).build();
+    private Map<String, Map<String, String>> getTaskOffsets(OffsetBackingStore offsetStore, int numTasks, List<String> shards,
+                                                            int gen, int prevNumTasks, Function<Configuration.Builder, Configuration.Builder> customConfig) {
+        final Configuration config = customConfig.apply(
+                TestHelper.defaultConfig(
+                        false,
+                        true,
+                        numTasks,
+                        gen,
+                        prevNumTasks,
+                        null,
+                        VitessConnectorConfig.SnapshotMode.NEVER))
+                .build();
         final String engineName = "testOffset";
         final Converter keyConverter = new JsonConverter();
         Map<String, Object> converterConfig = Collect.hashMapOf("schemas.enable", false);
@@ -1042,8 +1766,9 @@ public class VitessConnectorTest {
         };
 
         List<Map<String, String>> taskConfigs = connector.taskConfigs(numTasks, shards);
-        Map<String, String> vgtids = new HashMap<>();
+        Map<String, Map<String, String>> offsetsMap = new HashMap<>();
         for (Map<String, String> taskConfig : taskConfigs) {
+            Map<String, String> taskOffsetMap = new HashMap();
             VitessConnectorTask task = new VitessConnectorTask();
             task.initialize(sourceTaskContext);
             final VitessConnectorConfig connectorConfig = new VitessConnectorConfig(
@@ -1056,24 +1781,96 @@ public class VitessConnectorTest {
             Offsets<VitessPartition, VitessOffsetContext> previousOffsets = Offsets.of(offsets);
 
             final VitessOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
-            Vgtid vgtid = previousOffset == null ? VitessReplicationConnection.defaultVgtid(connectorConfig)
-                    : previousOffset.getRestartVgtid();
-            vgtids.put(taskConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), vgtid.toString());
+            Vgtid vgtid;
+            if (previousOffset == null) {
+                vgtid = VitessReplicationConnection.defaultVgtid(connectorConfig);
+            }
+            else {
+                vgtid = previousOffset.getRestartVgtid();
+            }
+            taskOffsetMap.put(SourceInfo.VGTID_KEY, vgtid.toString());
+            if (VitessOffsetRetriever.isShardEpochMapEnabled(connectorConfig) && previousOffset == null) {
+                ShardEpochMap shardEpochMap = VitessReplicationConnection.defaultShardEpochMap(connectorConfig);
+                taskOffsetMap.put(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, shardEpochMap.toString());
+            }
+            else if (VitessOffsetRetriever.isShardEpochMapEnabled(connectorConfig)) {
+                ShardEpochMap shardEpochMap = ShardEpochMap.of((String) previousOffset.getOffset().get(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH));
+                taskOffsetMap.put(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, shardEpochMap.toString());
+            }
+            offsetsMap.put(taskConfig.get(VitessConnectorConfig.VITESS_TASK_KEY_CONFIG), taskOffsetMap);
         }
         connector.stop();
         offsetReader.close();
-        return vgtids;
+        return offsetsMap;
     }
 
-    private Map<String, String> getOffsetFromStorage(int numTasks, List<String> shards, int gen, int prevNumTasks,
-                                                     String serverVgtid, Map<String, Object> prevVgtids) {
+    private Map<String, Map<String, String>> getOffsetFromStorage(int numTasks, List<String> shards, int gen, int prevNumTasks,
+                                                                  Map<String, ?> serverOffsets, Map<String, Map<String, ?>> taskOffsets) {
+        return getOffsetFromStorage(numTasks, shards, gen, prevNumTasks, serverOffsets, taskOffsets, Function.identity());
+    }
+
+    private Map<String, Map<String, String>> getOffsetFromStorage(int numTasks, List<String> shards, int gen, int prevNumTasks,
+                                                                  Map<String, ?> serverOffsets, Map<String, Map<String, ?>> taskOffsets,
+                                                                  Function<Configuration.Builder, Configuration.Builder> customConfig) {
         final OffsetBackingStore offsetStore = KafkaConnectUtil.memoryOffsetBackingStore();
         offsetStore.start();
 
-        storeOffsets(offsetStore, serverVgtid, prevVgtids);
-        Map<String, String> vgtids = getTaskOffsets(offsetStore, numTasks, shards, gen, prevNumTasks);
+        storeOffsets(offsetStore, serverOffsets, taskOffsets);
+        Map<String, Map<String, String>> offsets = getTaskOffsets(offsetStore, numTasks, shards, gen, prevNumTasks, customConfig);
 
         offsetStore.stop();
-        return vgtids;
+        return offsets;
+    }
+
+    private Map<String, String> getVgtidOffset(String vgtid) {
+        return Map.of(SourceInfo.VGTID_KEY, vgtid);
+    }
+
+    private Map<String, ?> getVgtidEpochOffset(String vgtid, String epoch) {
+        return Map.of(SourceInfo.VGTID_KEY, vgtid, VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, epoch);
+    }
+
+    static class ContextHelper {
+        OffsetBackingStore offsetStore;
+        String engineName = "testOffset";
+        SourceConnectorContext sourceConnectorContext;
+
+        ContextHelper() {
+            this.offsetStore = KafkaConnectUtil.memoryOffsetBackingStore();
+            this.sourceConnectorContext = initSourceConnectorContext();
+        }
+
+        public SourceConnectorContext getSourceConnectorContext() {
+            return this.sourceConnectorContext;
+        }
+
+        private SourceConnectorContext initSourceConnectorContext() {
+            offsetStore.start();
+
+            final Converter keyConverter = new JsonConverter();
+            Map<String, Object> converterConfig = Collect.hashMapOf("schemas.enable", false);
+            keyConverter.configure(converterConfig, true);
+            final Converter valueConverter = new JsonConverter();
+            valueConverter.configure(converterConfig, false);
+            final OffsetStorageReaderImpl offsetReader = new OffsetStorageReaderImpl(offsetStore, engineName,
+                    keyConverter, valueConverter);
+
+            SourceConnectorContext sourceConnectorContext = new SourceConnectorContext() {
+                @Override
+                public void requestTaskReconfiguration() {
+                }
+
+                @Override
+                public void raiseError(Exception e) {
+                }
+
+                @Override
+                public OffsetStorageReader offsetStorageReader() {
+                    return offsetReader;
+                }
+
+            };
+            return sourceConnectorContext;
+        }
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessOffsetContextTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessOffsetContextTest.java
@@ -143,6 +143,7 @@ public class VitessOffsetContextTest {
         TransactionContext transactionContext = context.getTransactionContext();
         assertThat(transactionContext).isInstanceOf(VitessOrderedTransactionContext.class);
         VitessOrderedTransactionContext orderedTransactionContext = (VitessOrderedTransactionContext) transactionContext;
-        assertThat(orderedTransactionContext.getPreviousVgtid()).isEqualTo(null);
+        assertThat(orderedTransactionContext.getPreviousVgtid()).isEqualTo(
+                "[{\"keyspace\":\"test_unsharded_keyspace\",\"shard\":\"0\",\"gtid\":\"current\",\"table_p_ks\":[]}]");
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessOffsetRetrieverTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessOffsetRetrieverTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionMetadataFactory;
+
+public class VitessOffsetRetrieverTest {
+
+    @Test
+    public void isShardEpochMapEnabled() {
+        Configuration configuration = Configuration.create()
+                .with(VitessConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class).build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(VitessOffsetRetriever.isShardEpochMapEnabled(connectorConfig)).isTrue();
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardEpochMapTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardEpochMapTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.pipeline.txmetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.debezium.connector.vitess.TestHelper;
+
+public class ShardEpochMapTest {
+
+    @Test
+    public void of() {
+        ShardEpochMap epoch = ShardEpochMap.of(TestHelper.TEST_SHARD_TO_EPOCH.toString());
+        assertThat(epoch.get(TestHelper.TEST_SHARD1)).isEqualTo(TestHelper.TEST_SHARD1_EPOCH);
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessEpochProviderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessEpochProviderTest.java
@@ -6,18 +6,27 @@
 package io.debezium.connector.vitess.pipeline.txmetadata;
 
 import static io.debezium.connector.vitess.TestHelper.TEST_SHARD1;
+import static io.debezium.connector.vitess.TestHelper.TEST_SHARD1_EPOCH;
+import static io.debezium.connector.vitess.TestHelper.TEST_SHARD_TO_EPOCH;
 import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
+import static io.debezium.connector.vitess.VgtidTest.VGTID_BOTH_CURRENT;
+import static io.debezium.connector.vitess.VgtidTest.VGTID_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
+import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.connector.vitess.TablePrimaryKeysTest;
+import io.debezium.connector.vitess.TestHelper;
 import io.debezium.connector.vitess.Vgtid;
 import io.debezium.connector.vitess.VgtidTest;
+import io.debezium.connector.vitess.VitessConnectorConfig;
 
 public class VitessEpochProviderTest {
 
@@ -33,24 +42,56 @@ public class VitessEpochProviderTest {
     private String txIdVersion5 = "MySQL57/" + String.join(",", host1Tx2);
     private String txIdVersion8 = "MySQL82/" + String.join(",", host1Tx2);
 
+    private List<String> shards = List.of(VgtidTest.TEST_SHARD, VgtidTest.TEST_SHARD2);
+
+    String vgtidJsonCurrent = String.format(
+            VGTID_JSON_TEMPLATE,
+            VgtidTest.TEST_KEYSPACE,
+            VgtidTest.TEST_SHARD,
+            Vgtid.CURRENT_GTID,
+            VgtidTest.TEST_KEYSPACE,
+            VgtidTest.TEST_SHARD2,
+            Vgtid.CURRENT_GTID);
+
     @Test
     public void testGetEpochSameHostSet() {
-        Long epoch = VitessEpochProvider.getEpochForGtid(0L, previousTxId, txId);
+        Long epoch = VitessEpochProvider.getEpochForGtid(0L, previousTxId, txId, false);
         assertThat(epoch).isEqualTo(0);
     }
 
     @Test
-    public void testGetEpochVgtid() {
-        VitessEpochProvider provider = new VitessEpochProvider();
-        String expectedEpoch = "{\"-80\": 5}";
-        provider.load(Map.of(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, expectedEpoch));
-        Long epoch = provider.getEpoch("-80", VgtidTest.VGTID_JSON, VgtidTest.VGTID_JSON);
-        assertThat(epoch).isEqualTo(5);
+    public void testLoadsEpochFromOffsets() {
+        VitessEpochProvider provider = new VitessEpochProvider(ShardEpochMap.init(shards));
+        provider.load(Map.of(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, TEST_SHARD_TO_EPOCH.toString()));
+        Long epoch = provider.getEpoch(TEST_SHARD1, VGTID_JSON, VGTID_JSON);
+        assertThat(epoch).isEqualTo(TEST_SHARD1_EPOCH);
+    }
+
+    @Test
+    public void testInitializeConfigEpochWithOffsetStorage() {
+        Configuration config = Configuration.create()
+                .with(VitessConnectorConfig.VITESS_TASK_SHARD_EPOCH_MAP_CONFIG, TestHelper.TEST_SHARD_TO_EPOCH.toString())
+                .with(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK, "true")
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(config);
+        VitessEpochProvider provider = VitessEpochProvider.initialize(connectorConfig);
+        Long epoch = provider.getEpoch(TestHelper.TEST_SHARD1, VGTID_JSON, VGTID_JSON);
+        assertThat(epoch).isEqualTo(TEST_SHARD1_EPOCH);
+    }
+
+    @Test
+    public void testInitializeConfigEpochWithShardList() {
+        Configuration config = Configuration.create()
+                .with(VitessConnectorConfig.SHARD, TestHelper.TEST_SHARD1)
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(config);
+        VitessEpochProvider provider = VitessEpochProvider.initialize(connectorConfig);
+        assertThat(provider.getShardEpochMap().get(TEST_SHARD1)).isEqualTo(0);
     }
 
     @Test
     public void snapshotIncrementsEpoch() {
-        VitessEpochProvider provider = new VitessEpochProvider();
+        VitessEpochProvider provider = new VitessEpochProvider(ShardEpochMap.init(shards));
         String vgtidJsonEmpty = String.format(
                 VGTID_JSON_TEMPLATE,
                 VgtidTest.TEST_KEYSPACE,
@@ -59,13 +100,13 @@ public class VitessEpochProviderTest {
                 VgtidTest.TEST_KEYSPACE,
                 VgtidTest.TEST_SHARD2,
                 Vgtid.EMPTY_GTID);
-        Long epoch = provider.getEpoch(VgtidTest.TEST_SHARD, vgtidJsonEmpty, VgtidTest.VGTID_JSON);
+        Long epoch = provider.getEpoch(VgtidTest.TEST_SHARD, vgtidJsonEmpty, VGTID_JSON);
         assertThat(epoch).isEqualTo(1L);
     }
 
     @Test
     public void fastForwardVgtidIncrementsEpoch() {
-        VitessEpochProvider provider = new VitessEpochProvider();
+        VitessEpochProvider provider = new VitessEpochProvider(ShardEpochMap.init(shards));
         String vgtidJsonCurrent = String.format(
                 VGTID_JSON_TEMPLATE,
                 VgtidTest.TEST_KEYSPACE,
@@ -74,34 +115,80 @@ public class VitessEpochProviderTest {
                 VgtidTest.TEST_KEYSPACE,
                 VgtidTest.TEST_SHARD2,
                 Vgtid.EMPTY_GTID);
-        Long epoch = provider.getEpoch(VgtidTest.TEST_SHARD, vgtidJsonCurrent, VgtidTest.VGTID_JSON);
+        Long epoch = provider.getEpoch(VgtidTest.TEST_SHARD, vgtidJsonCurrent, VGTID_JSON);
         assertThat(epoch).isEqualTo(1L);
     }
 
     @Test
+    public void currentVgtidIncrementsEpochForAllShards() {
+        VitessEpochProvider provider = new VitessEpochProvider(ShardEpochMap.init(shards));
+        Long epochShard1 = provider.getEpoch(VgtidTest.TEST_SHARD, vgtidJsonCurrent, VGTID_JSON);
+        Long epochShard2 = provider.getEpoch(VgtidTest.TEST_SHARD2, VGTID_JSON, VGTID_JSON);
+        assertThat(epochShard1).isEqualTo(1L);
+        assertThat(epochShard2).isEqualTo(1L);
+    }
+
+    @Test
+    public void splitShard() {
+        VitessEpochProvider provider = new VitessEpochProvider();
+        String singleShardVgtidTemplate = "[" +
+                "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":%s}" +
+                "]";
+        String vgtid1 = String.format(
+                singleShardVgtidTemplate,
+                TestHelper.TEST_SHARDED_KEYSPACE,
+                TestHelper.TEST_SHARD,
+                txId,
+                TablePrimaryKeysTest.TEST_LAST_PKS_JSON);
+        String vgtid2 = String.format(
+                VGTID_JSON_TEMPLATE,
+                TestHelper.TEST_SHARDED_KEYSPACE,
+                TestHelper.TEST_SHARD1,
+                txId,
+                TestHelper.TEST_SHARDED_KEYSPACE,
+                TestHelper.TEST_SHARD2,
+                txId);
+        Long epochShard1 = provider.getEpoch(TestHelper.TEST_SHARD, VGTID_BOTH_CURRENT, vgtid1);
+        Long epochShard2 = provider.getEpoch(TestHelper.TEST_SHARD1, vgtid1, vgtid2);
+        assertThat(epochShard1).isEqualTo(0L);
+        assertThat(epochShard2).isEqualTo(0L);
+    }
+
+    @Test
     public void nullPreviousVgtidWithStoredEpochShouldThrowException() {
+        VitessEpochProvider provider = new VitessEpochProvider(ShardEpochMap.init(shards));
+        int expectedEpoch = 1;
+        String shardToEpoch = String.format("{\"%s\": %d}", TEST_SHARD1, expectedEpoch);
+        provider.load(Map.of(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, shardToEpoch));
+        assertThatThrownBy(() -> {
+            provider.getEpoch(VgtidTest.TEST_SHARD, null, VGTID_JSON);
+        }).isInstanceOf(DebeziumException.class).hasMessageContaining("Previous vgtid string cannot be null");
+    }
+
+    @Test
+    public void missingEpochWithPreviousVgtidShouldThrowException() {
         VitessEpochProvider provider = new VitessEpochProvider();
         int expectedEpoch = 1;
         String shardToEpoch = String.format("{\"%s\": %d}", TEST_SHARD1, expectedEpoch);
         provider.load(Map.of(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH, shardToEpoch));
         assertThatThrownBy(() -> {
-            provider.getEpoch(VgtidTest.TEST_SHARD, null, VgtidTest.VGTID_JSON);
-        }).isInstanceOf(DebeziumException.class).hasMessageContaining("Previous VGTID is null but shardToEpoch map is not null");
+            provider.getEpoch(VgtidTest.TEST_SHARD, VGTID_JSON, VGTID_JSON);
+        }).isInstanceOf(DebeziumException.class).hasMessageContaining("Previous epoch cannot be null");
     }
 
     @Test
-    public void nullPreviousVgtidWithoutStoredEpochShouldReturnZero() {
-        VitessEpochProvider provider = new VitessEpochProvider();
+    public void matchingGtidReturnsInitialEpoch() {
+        VitessEpochProvider provider = new VitessEpochProvider(ShardEpochMap.init(shards));
         int expectedEpoch = 0;
-        Long epoch = provider.getEpoch(VgtidTest.TEST_SHARD, null, VgtidTest.VGTID_JSON);
+        Long epoch = provider.getEpoch(VgtidTest.TEST_SHARD, VGTID_JSON, VGTID_JSON);
         assertThat(epoch).isEqualTo(expectedEpoch);
     }
 
     @Test
     public void testInvalidCurrentGtid() {
         Long expectedEpoch = 0L;
-        VitessEpochProvider provider = new VitessEpochProvider();
-        Long epoch = provider.getEpoch("-80", VgtidTest.VGTID_JSON, VgtidTest.VGTID_JSON);
+        VitessEpochProvider provider = new VitessEpochProvider(ShardEpochMap.init(shards));
+        Long epoch = provider.getEpoch("-80", VGTID_JSON, VGTID_JSON);
         assertThat(epoch).isEqualTo(expectedEpoch);
         String vgtidJsonCurrent = String.format(
                 VGTID_JSON_TEMPLATE,
@@ -112,15 +199,15 @@ public class VitessEpochProviderTest {
                 VgtidTest.TEST_SHARD2,
                 Vgtid.EMPTY_GTID);
         assertThatThrownBy(() -> {
-            provider.getEpoch("-80", VgtidTest.VGTID_JSON, vgtidJsonCurrent);
+            provider.getEpoch("-80", VGTID_JSON, vgtidJsonCurrent);
         }).isInstanceOf(DebeziumException.class).hasMessageContaining("Invalid");
     }
 
     @Test
     public void testInvalidEmptyGtid() {
         Long expectedEpoch = 0L;
-        VitessEpochProvider provider = new VitessEpochProvider();
-        Long epoch = provider.getEpoch("-80", VgtidTest.VGTID_JSON, VgtidTest.VGTID_JSON);
+        VitessEpochProvider provider = new VitessEpochProvider(ShardEpochMap.init(shards));
+        Long epoch = provider.getEpoch("-80", VGTID_JSON, VGTID_JSON);
         assertThat(epoch).isEqualTo(expectedEpoch);
         String vgtidJsonEmpty = String.format(
                 VGTID_JSON_TEMPLATE,
@@ -131,32 +218,32 @@ public class VitessEpochProviderTest {
                 VgtidTest.TEST_SHARD2,
                 Vgtid.EMPTY_GTID);
         assertThatThrownBy(() -> {
-            provider.getEpoch("-80", VgtidTest.VGTID_JSON, vgtidJsonEmpty);
+            provider.getEpoch("-80", VGTID_JSON, vgtidJsonEmpty);
         }).isInstanceOf(DebeziumException.class).hasMessageContaining("Invalid");
     }
 
     @Test
     public void testGetEpochShrunkHostSet() {
-        Long epoch = VitessEpochProvider.getEpochForGtid(0L, previousTxId, txIdShrunk);
+        Long epoch = VitessEpochProvider.getEpochForGtid(0L, previousTxId, txIdShrunk, false);
         assertThat(epoch).isEqualTo(1);
     }
 
     @Test
     public void testGetEpochExpandHostSet() {
-        Long epoch = VitessEpochProvider.getEpochForGtid(0L, previousTxId, txId);
+        Long epoch = VitessEpochProvider.getEpochForGtid(0L, previousTxId, txId, false);
         assertThat(epoch).isEqualTo(0);
     }
 
     @Test
     public void testGetEpochDisjointThrowsException() {
         Assertions.assertThatThrownBy(() -> {
-            VitessEpochProvider.getEpochForGtid(0L, previousTxId, "foo:1-2,bar:2-4");
+            VitessEpochProvider.getEpochForGtid(0L, previousTxId, "foo:1-2,bar:2-4", false);
         }).isInstanceOf(RuntimeException.class);
     }
 
     @Test
     public void testVersionUpgradeDoesNotAffectEpoch() {
-        Long epoch = VitessEpochProvider.getEpochForGtid(0L, txIdVersion5, txIdVersion8);
+        Long epoch = VitessEpochProvider.getEpochForGtid(0L, txIdVersion5, txIdVersion8, false);
         assertThat(epoch).isEqualTo(0L);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionContextTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionContextTest.java
@@ -65,8 +65,9 @@ public class VitessOrderedTransactionContextTest {
                 0,
                 0,
                 null,
-                VitessConnectorConfig.SnapshotMode.NEVER).with(
-                        VitessConnectorConfig.VGTID, expectedTxId)
+                VitessConnectorConfig.SnapshotMode.NEVER)
+                .with(VitessConnectorConfig.VGTID, expectedTxId)
+                .with(VitessConnectorConfig.SHARD, "-80")
                 .build());
         VitessOrderedTransactionContext metadata = VitessOrderedTransactionContext.initialize(config);
 
@@ -116,8 +117,9 @@ public class VitessOrderedTransactionContextTest {
                 0,
                 0,
                 null,
-                VitessConnectorConfig.SnapshotMode.NEVER).with(
-                        VitessConnectorConfig.VGTID, expectedTxId)
+                VitessConnectorConfig.SnapshotMode.NEVER)
+                .with(VitessConnectorConfig.VGTID, expectedTxId)
+                .with(VitessConnectorConfig.SHARD, "-80")
                 .build());
         VitessOrderedTransactionContext metadata = VitessOrderedTransactionContext.initialize(config);
 
@@ -127,7 +129,7 @@ public class VitessOrderedTransactionContextTest {
         metadata.beginTransaction(transactionInfo);
 
         Map offsets = new HashMap();
-        String expectedEpoch = "{\"-80\":0,\"80-\":0}";
+        String expectedEpoch = "{\"-80\":0}";
         Map actualOffsets = metadata.store(offsets);
         assertThat(actualOffsets.get(VitessOrderedTransactionContext.OFFSET_TRANSACTION_EPOCH)).isEqualTo(expectedEpoch);
     }

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionMetadataFactoryTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionMetadataFactoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.pipeline.txmetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.vitess.TestHelper;
+import io.debezium.connector.vitess.VgtidTest;
+import io.debezium.connector.vitess.VitessConnectorConfig;
+import io.debezium.pipeline.txmetadata.TransactionContext;
+
+public class VitessOrderedTransactionMetadataFactoryTest {
+
+    @Test
+    public void shouldGetDefaultTransactionContext() {
+        Configuration config = TestHelper.defaultConfig().build();
+        TransactionContext context = new VitessOrderedTransactionMetadataFactory(config).getTransactionContext();
+        assertThat(context).isInstanceOf(VitessOrderedTransactionContext.class);
+    }
+
+    @Test
+    public void shouldGetTransactionContextWithShardEpochMapFromConfig() {
+        Configuration config = Configuration.create()
+                .with(VitessConnectorConfig.VITESS_TASK_SHARD_EPOCH_MAP_CONFIG, TestHelper.TEST_SHARD_TO_EPOCH)
+                .with(VitessConnectorConfig.OFFSET_STORAGE_PER_TASK, "true")
+                .with(VitessConnectorConfig.VITESS_TASK_VGTID_CONFIG, VgtidTest.VGTID_JSON)
+                .build();
+        TransactionContext context = new VitessOrderedTransactionMetadataFactory(config).getTransactionContext();
+        VitessOrderedTransactionContext orderedTransactionContext = (VitessOrderedTransactionContext) context;
+        orderedTransactionContext.beginTransaction(new VitessTransactionInfo(VgtidTest.VGTID_JSON, TestHelper.TEST_SHARD1));
+        assertThat(orderedTransactionContext.getTransactionEpoch()).isEqualTo(TestHelper.TEST_SHARD1_EPOCH);
+    }
+
+    @Test
+    public void getTransactionStructMaker() {
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionStructMakerTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionStructMakerTest.java
@@ -29,7 +29,7 @@ public class VitessOrderedTransactionStructMakerTest {
     public void prepareTxStruct() {
         VitessConnectorConfig config = new VitessConnectorConfig(TestHelper.defaultConfig().build());
         VitessOrderedTransactionStructMaker maker = new VitessOrderedTransactionStructMaker(Configuration.empty());
-        TransactionContext transactionContext = new VitessOrderedTransactionContext();
+        TransactionContext transactionContext = VitessOrderedTransactionContext.initialize(config);
         transactionContext.beginTransaction(new VitessTransactionInfo(VgtidTest.VGTID_JSON, VgtidTest.TEST_SHARD));
         OffsetContext context = new VitessOffsetContext(config, Vgtid.of(VgtidTest.VGTID_JSON), Instant.now(), transactionContext);
         Struct struct = maker.addTransactionBlock(context, 0, null);


### PR DESCRIPTION
Right now each task simply reads the epoch from its last stored offsets. As seen by the logic for vgtid, we need to be able to handle changes in generation if task offset storage mode is enabled (e.g., task parallelism change or shard subset change). Add this feature by refactoring the logic for vgtid to be more generic so we can do equivalent operations on the shard epochs (when enabled). Add `ShardEpochMap` for centralizing the ser/deser operations of reading the shard epoch map from state & updating it. Operate on VGTID and ShardEpochMap in similar manners to accomplish the same goal of redistributing correctly on task parallelism or shard change.

Note: there is one "TODO" intentionally left in the code: we will soon put out another PR to establish shard lineage and allow for inheriting the epoch of a parent shard when a split occurs. This PR is already substantial so we will do that in a separate one.