### PR TITLE
DBZ-8163 Add inherit epoch feature

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -302,7 +302,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withDescription("Control StopOnReshard VStream flag."
                     + " If set true, the old VStream will be stopped after a reshard operation.");
 
-    public static final Field INHERIT_EPOCH = Field.create(VITESS_CONFIG_GROUP_PREFIX + "inherit_epoch")
+    public static final Field INHERIT_EPOCH = Field.create(VITESS_CONFIG_GROUP_PREFIX + "inherit.epoch")
             .withDisplayName("Inherit epoch")
             .withType(Type.BOOLEAN)
             .withDefault(false)

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineage.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineage.java
@@ -41,11 +41,16 @@ public class ShardLineage {
 
     private static class Shard {
 
-        private final ShardBound lowerBound;
-        private final ShardBound upperBound;
+        // A string lexicographically less than all other strings
+        public static final String NEGATIVE_INFINITY = "";
+        // A string lexicographically greater than all other strings
+        public static final String POSITIVE_INFINITY = "\uFFFF";
+
+        private final String lowerBound;
+        private final String upperBound;
 
         Shard(String shard) {
-            String[] shardInterval = getShardInterval(shard);
+            String[] shardInterval = getShardInterval(shard.toLowerCase());
             this.lowerBound = getLowerBound(shardInterval);
             this.upperBound = getUpperBound(shardInterval);
             validateBounds();
@@ -61,18 +66,18 @@ public class ShardLineage {
             return this.lowerBound.compareTo(shard.upperBound) < 0 && this.upperBound.compareTo(shard.lowerBound) > 0;
         }
 
-        private static ShardBound getLowerBound(String[] shardInterval) {
+        private static String getLowerBound(String[] shardInterval) {
             if (shardInterval.length < 1 || shardInterval[0].isEmpty()) {
-                return ShardBound.negativeInfinity();
+                return NEGATIVE_INFINITY;
             }
-            return new ShardBound(shardInterval[0]);
+            return shardInterval[0];
         }
 
-        private static ShardBound getUpperBound(String[] shardInterval) {
+        private static String getUpperBound(String[] shardInterval) {
             if (shardInterval.length != 2 || shardInterval[1].isEmpty()) {
-                return ShardBound.positiveInfinity();
+                return POSITIVE_INFINITY;
             }
-            return new ShardBound(shardInterval[1]);
+            return shardInterval[1];
         }
 
         private static String[] getShardInterval(String shard) {
@@ -82,46 +87,9 @@ public class ShardLineage {
         @Override
         public String toString() {
             return "Shard{" +
-                    "lowerBound=" + lowerBound.bound +
-                    ", upperBound=" + upperBound.bound +
+                    "lowerBound=" + lowerBound +
+                    ", upperBound=" + upperBound +
                     "}";
         }
-
-        private static class ShardBound implements Comparable<ShardBound> {
-            public static final String NEGATIVE_INFINITY = "NEG_INF";
-            public static final String POSITIVE_INFINITY = "POS_INF";
-            private final String bound;
-
-            ShardBound(String bound) {
-                this.bound = bound;
-            }
-
-            public static ShardBound negativeInfinity() {
-                return new ShardBound(NEGATIVE_INFINITY);
-            }
-
-            public static ShardBound positiveInfinity() {
-                return new ShardBound(POSITIVE_INFINITY);
-            }
-
-            @Override
-            public int compareTo(ShardBound o) {
-                if (this.bound.equals(NEGATIVE_INFINITY) || o.bound.equals(POSITIVE_INFINITY)) {
-                    return -1;
-                }
-                if (this.bound.equals(POSITIVE_INFINITY) || o.bound.equals(NEGATIVE_INFINITY)) {
-                    return 1;
-                }
-                return this.bound.compareTo(o.bound);
-            }
-
-            @Override
-            public String toString() {
-                return "Bound{" +
-                        "value=" + this.bound +
-                        "}";
-            }
-        }
     }
-
 }

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineage.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineage.java
@@ -41,10 +41,10 @@ public class ShardLineage {
 
     private static class Shard {
 
-        // A string lexicographically less than all other strings
-        public static final String NEGATIVE_INFINITY = "";
-        // A string lexicographically greater than all other strings
-        public static final String POSITIVE_INFINITY = "\uFFFF";
+        // A string of a single char that is lexicographically less than all other chars
+        public static final String NEGATIVE_INFINITY = String.valueOf(Character.MIN_VALUE);
+        // A string of a single char that is lexicographically greater than all other chars
+        public static final String POSITIVE_INFINITY = String.valueOf(Character.MAX_VALUE);
 
         private final String lowerBound;
         private final String upperBound;

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineage.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineage.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.pipeline.txmetadata;
+
+import java.util.Map;
+
+/**
+ * Class used to determine which parents a shard range descended from. Used to set the epoch to the succeediing
+ * epoch of its parents.
+ */
+public class ShardLineage {
+
+    /**
+     * Return the epoch value of the shard, based on its parents epochs.
+     * If there are parents present, return the max of the parent epochs plus one.
+     * If there are no parents present, it returns zero.
+     *
+     * @param shardString The descendant shard to find parents of
+     * @param shardEpochMap The map to search for parents
+     * @return The epoch value of the descendant shard
+     */
+    public static Long getInheritedEpoch(String shardString, ShardEpochMap shardEpochMap) {
+        Shard shard = new Shard(shardString);
+
+        Long maxParentEpoch = -1L;
+        for (Map.Entry<String, Long> shardEpoch : shardEpochMap.getMap().entrySet()) {
+            String currentShardString = shardEpoch.getKey();
+            Long currentEpoch = shardEpoch.getValue();
+            Shard currentShard = new Shard(currentShardString);
+            if (shard.overlaps(currentShard)) {
+                maxParentEpoch = Math.max(maxParentEpoch, currentEpoch);
+            }
+        }
+
+        return maxParentEpoch + 1;
+    }
+
+    private static class Shard {
+
+        private final ShardBound lowerBound;
+        private final ShardBound upperBound;
+
+        Shard(String shard) {
+            String[] shardInterval = getShardInterval(shard);
+            this.lowerBound = getLowerBound(shardInterval);
+            this.upperBound = getUpperBound(shardInterval);
+            validateBounds();
+        }
+
+        private void validateBounds() {
+            if (this.lowerBound.compareTo(this.upperBound) >= 0) {
+                throw new IllegalArgumentException("Invalid shard range " + this);
+            }
+        }
+
+        public boolean overlaps(Shard shard) {
+            return this.lowerBound.compareTo(shard.upperBound) < 0 && this.upperBound.compareTo(shard.lowerBound) > 0;
+        }
+
+        private static ShardBound getLowerBound(String[] shardInterval) {
+            if (shardInterval.length < 1 || shardInterval[0].isEmpty()) {
+                return ShardBound.negativeInfinity();
+            }
+            return new ShardBound(shardInterval[0]);
+        }
+
+        private static ShardBound getUpperBound(String[] shardInterval) {
+            if (shardInterval.length != 2 || shardInterval[1].isEmpty()) {
+                return ShardBound.positiveInfinity();
+            }
+            return new ShardBound(shardInterval[1]);
+        }
+
+        private static String[] getShardInterval(String shard) {
+            return shard.split("-");
+        }
+
+        @Override
+        public String toString() {
+            return "Shard{" +
+                    "lowerBound=" + lowerBound.bound +
+                    ", upperBound=" + upperBound.bound +
+                    "}";
+        }
+
+        private static class ShardBound implements Comparable<ShardBound> {
+            public static final String NEGATIVE_INFINITY = "NEG_INF";
+            public static final String POSITIVE_INFINITY = "POS_INF";
+            private final String bound;
+
+            ShardBound(String bound) {
+                this.bound = bound;
+            }
+
+            public static ShardBound negativeInfinity() {
+                return new ShardBound(NEGATIVE_INFINITY);
+            }
+
+            public static ShardBound positiveInfinity() {
+                return new ShardBound(POSITIVE_INFINITY);
+            }
+
+            @Override
+            public int compareTo(ShardBound o) {
+                if (this.bound.equals(NEGATIVE_INFINITY) || o.bound.equals(POSITIVE_INFINITY)) {
+                    return -1;
+                }
+                if (this.bound.equals(POSITIVE_INFINITY) || o.bound.equals(NEGATIVE_INFINITY)) {
+                    return 1;
+                }
+                return this.bound.compareTo(o.bound);
+            }
+
+            @Override
+            public String toString() {
+                return "Bound{" +
+                        "value=" + this.bound +
+                        "}";
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionContext.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessOrderedTransactionContext.java
@@ -8,6 +8,7 @@ package io.debezium.connector.vitess.pipeline.txmetadata;
 import java.math.BigDecimal;
 import java.util.Map;
 
+import io.debezium.annotation.VisibleForTesting;
 import io.debezium.connector.vitess.SourceInfo;
 import io.debezium.connector.vitess.Vgtid;
 import io.debezium.connector.vitess.VitessConnectorConfig;
@@ -22,6 +23,7 @@ public class VitessOrderedTransactionContext extends TransactionContext {
     protected Long transactionEpoch = 0L;
     protected BigDecimal transactionRank = null;
     private VitessEpochProvider epochProvider = new VitessEpochProvider();
+    private VitessConnectorConfig config = null;
 
     public VitessOrderedTransactionContext() {
     }
@@ -76,14 +78,14 @@ public class VitessOrderedTransactionContext extends TransactionContext {
      */
     @Override
     public TransactionContext newTransactionContextFromOffsets(Map<String, ?> offsets) {
-        return VitessOrderedTransactionContext.load(offsets);
+        return VitessOrderedTransactionContext.load(offsets, this.config);
     }
 
-    public static VitessOrderedTransactionContext load(Map<String, ?> offsets) {
+    public static VitessOrderedTransactionContext load(Map<String, ?> offsets, VitessConnectorConfig config) {
         TransactionContext transactionContext = TransactionContext.load(offsets);
         VitessOrderedTransactionContext vitessOrderedTransactionContext = new VitessOrderedTransactionContext(transactionContext);
         vitessOrderedTransactionContext.previousVgtid = (String) offsets.get(SourceInfo.VGTID_KEY);
-        vitessOrderedTransactionContext.epochProvider.load(offsets);
+        vitessOrderedTransactionContext.epochProvider.load(offsets, config);
         return vitessOrderedTransactionContext;
     }
 
@@ -99,6 +101,7 @@ public class VitessOrderedTransactionContext extends TransactionContext {
         VitessOrderedTransactionContext vitessOrderedTransactionContext = new VitessOrderedTransactionContext();
         vitessOrderedTransactionContext.epochProvider = VitessEpochProvider.initialize(config);
         vitessOrderedTransactionContext.previousVgtid = VitessReplicationConnection.defaultVgtid(config).toString();
+        vitessOrderedTransactionContext.config = config;
         return vitessOrderedTransactionContext;
     }
 
@@ -139,6 +142,11 @@ public class VitessOrderedTransactionContext extends TransactionContext {
 
     public BigDecimal getTransactionRank() {
         return transactionRank;
+    }
+
+    @VisibleForTesting
+    public VitessEpochProvider getEpochProvider() {
+        return epochProvider;
     }
 
 }

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -69,6 +69,10 @@ public class TestHelper {
             "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\"}" +
             "]";
 
+    public static final String VGTID_SINGLE_SHARD_JSON_TEMPLATE = "[" +
+            "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}" +
+            "]";
+
     public static final String VGTID_JSON_TEMPLATE = "[" +
             "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}," +
             "{\"keyspace\":\"%s\",\"shard\":\"%s\",\"gtid\":\"%s\",\"table_p_ks\":[]}" +

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -15,7 +15,9 @@ import java.util.function.Consumer;
 
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionMetadataFactory;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.schema.SchemaNameAdjuster;
@@ -114,6 +116,40 @@ public class VitessConnectorConfigTest {
         };
         connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.SHARD_EPOCH_MAP), printConsumer);
         assertThat(inputs.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldEnableInheritEpoch() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.INHERIT_EPOCH, true).build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getInheritEpoch()).isTrue();
+    }
+
+    @Test
+    public void shouldValidateInheritEpochWithoutOrderedTransactionMetadata() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.INHERIT_EPOCH, true).build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.INHERIT_EPOCH), printConsumer);
+        assertThat(inputs.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldValidateInheritEpochWithOrderedTransactionMetadata() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.INHERIT_EPOCH, true)
+                .with(CommonConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class)
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.INHERIT_EPOCH), printConsumer);
+        assertThat(inputs.size()).isEqualTo(0);
     }
 
 }

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineageTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineageTest.java
@@ -47,6 +47,17 @@ public class ShardLineageTest {
     }
 
     @Test
+    public void shouldGetInheritedEpoch_MultiShard_SplitOneShard_UpperEqualsLowerBound() {
+        Long parentEpoch = 3L;
+        Long parentEpoch2 = 1L;
+        ShardEpochMap shardEpochMap = new ShardEpochMap(Map.of("-80", parentEpoch, "80-", parentEpoch2));
+        // The lower bound (80) is equal to a previous shard's upper bound (-80)
+        Long epoch2 = ShardLineage.getInheritedEpoch("80-c0", shardEpochMap);
+        // This is not a descendant so assert the epoch is from the actual parent (which is less than the other parent)
+        assertThat(epoch2).isEqualTo(parentEpoch2 + 1);
+    }
+
+    @Test
     public void shouldGetInheritedEpoch_TwoToFourShards() {
         Long parentEpoch = 1L;
         Long parentEpoch2 = 3L;

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineageTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineageTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.pipeline.txmetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class ShardLineageTest {
+
+    @Test
+    public void shouldGetInheritedEpoch_SingleShard_SplitOneShard() {
+        Long parentEpoch = 1L;
+        ShardEpochMap shardEpochMap = new ShardEpochMap(Map.of("0", parentEpoch));
+        Long epoch = ShardLineage.getInheritedEpoch("-80", shardEpochMap);
+        assertThat(epoch).isEqualTo(parentEpoch + 1);
+        Long epoch2 = ShardLineage.getInheritedEpoch("80-", shardEpochMap);
+        assertThat(epoch2).isEqualTo(parentEpoch + 1);
+    }
+
+    @Test
+    public void shouldGetInheritedEpoch_IllegalShardRange() {
+        Long parentEpoch = 1L;
+        ShardEpochMap shardEpochMap = new ShardEpochMap(Map.of("0", parentEpoch));
+        assertThatThrownBy(() -> ShardLineage.getInheritedEpoch("80-30", shardEpochMap))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("Invalid shard range");
+    }
+
+    @Test
+    public void shouldGetInheritedEpoch_MultiShard_SplitOneShard() {
+        Long parentEpoch = 1L;
+        Long parentEpoch2 = 3L;
+        ShardEpochMap shardEpochMap = new ShardEpochMap(Map.of("-80", parentEpoch, "80-", parentEpoch2));
+        Long epoch = ShardLineage.getInheritedEpoch("-40", shardEpochMap);
+        assertThat(epoch).isEqualTo(parentEpoch + 1);
+        Long epoch2 = ShardLineage.getInheritedEpoch("80-c0", shardEpochMap);
+        assertThat(epoch2).isEqualTo(parentEpoch2 + 1);
+        Long epoch3 = ShardLineage.getInheritedEpoch("c0-", shardEpochMap);
+        assertThat(epoch3).isEqualTo(parentEpoch2 + 1);
+    }
+
+    @Test
+    public void shouldGetInheritedEpoch_TwoToFourShards() {
+        Long parentEpoch = 1L;
+        Long parentEpoch2 = 3L;
+        ShardEpochMap shardEpochMap = new ShardEpochMap(Map.of("-80", parentEpoch, "80-", parentEpoch2));
+        Long epoch = ShardLineage.getInheritedEpoch("-4000", shardEpochMap);
+        assertThat(epoch).isEqualTo(parentEpoch + 1);
+        Long epoch2 = ShardLineage.getInheritedEpoch("8000-c000", shardEpochMap);
+        assertThat(epoch2).isEqualTo(parentEpoch2 + 1);
+    }
+
+    @Test
+    public void shouldGetInheritedEpoch_FourShards() {
+        Long parentEpoch1 = 1L;
+        Long parentEpoch2 = 2L;
+        Long parentEpoch3 = 3L;
+        Long parentEpoch4 = 4L;
+        ShardEpochMap shardEpochMap = new ShardEpochMap(Map.of("-4000", parentEpoch1,
+                "4000-8000", parentEpoch2, "8000-c000", parentEpoch3, "c000-", parentEpoch4));
+        Long epoch = ShardLineage.getInheritedEpoch("4000-6000", shardEpochMap);
+        assertThat(epoch).isEqualTo(parentEpoch2 + 1);
+        Long epoch2 = ShardLineage.getInheritedEpoch("5000-9000", shardEpochMap);
+        assertThat(epoch2).isEqualTo(Math.max(parentEpoch2, parentEpoch3) + 1);
+    }
+
+    @Test
+    public void shouldGetInheritedEpoch_OneToTwoShardsHigherHexRange() {
+        Long parentEpoch1 = 1L;
+        ShardEpochMap shardEpochMap = new ShardEpochMap(Map.of("b7-b8", parentEpoch1));
+        Long epoch = ShardLineage.getInheritedEpoch("b720-b750", shardEpochMap);
+        assertThat(epoch).isEqualTo(parentEpoch1 + 1);
+        Long epoch2 = ShardLineage.getInheritedEpoch("b750-b820", shardEpochMap);
+        assertThat(epoch2).isEqualTo(parentEpoch1 + 1);
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineageTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/ShardLineageTest.java
@@ -80,4 +80,20 @@ public class ShardLineageTest {
         Long epoch2 = ShardLineage.getInheritedEpoch("b750-b820", shardEpochMap);
         assertThat(epoch2).isEqualTo(parentEpoch1 + 1);
     }
+
+    @Test
+    public void shouldGetInheritedEpoch_OneToTwoShardsMixedCase() {
+        Long parentEpoch1 = 4L;
+        ShardEpochMap shardEpochMap = new ShardEpochMap(Map.of("B7-B8", parentEpoch1));
+        Long epoch = ShardLineage.getInheritedEpoch("b720-b750", shardEpochMap);
+        assertThat(epoch).isEqualTo(parentEpoch1 + 1);
+        Long epoch2 = ShardLineage.getInheritedEpoch("b750-b820", shardEpochMap);
+        assertThat(epoch2).isEqualTo(parentEpoch1 + 1);
+
+        ShardEpochMap shardEpochMap2 = new ShardEpochMap(Map.of("b7-b8", parentEpoch1));
+        Long epoch3 = ShardLineage.getInheritedEpoch("B720-B750", shardEpochMap);
+        assertThat(epoch3).isEqualTo(parentEpoch1 + 1);
+        Long epoch4 = ShardLineage.getInheritedEpoch("B750-B820", shardEpochMap);
+        assertThat(epoch4).isEqualTo(parentEpoch1 + 1);
+    }
 }


### PR DESCRIPTION
Add a config feature for inherit epoch. When enabled, the parent shards will be deduced from the hex ranges and we will take the max of the parent shards + 1 to get a newer epoch value. Refactor some things to allow us to read in this config. Also refactor the epoch logic so that our shard epoch map does not drift from the vgtid we receive.

I am hoping to expand our integration test suite in a separate PR to test reshard operations. Since this PR is already substantial putting this out now and will have a separate one for adding reshards to itests.