### PR TITLE
DBZ-8354 Fix table filter logic for vstream

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -295,8 +295,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
         if (!Strings.isNullOrEmpty(config.tableIncludeList())) {
             final String keyspace = config.getKeyspace();
             final List<String> allTables = new VitessMetadata(config).getTables();
-            List<String> includedTables = VitessConnector.getIncludedTables(config.getKeyspace(),
-                    config.tableIncludeList(), allTables);
+            List<String> includedTables = VitessConnector.getIncludedTables(config, allTables);
             for (String table : includedTables) {
                 String sql = "select * from `" + table + "`";
                 // See rule in: https://github.com/vitessio/vitess/blob/release-14.0/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go#L316

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -1646,8 +1646,26 @@ public class VitessConnectorTest {
         String keyspace = "ks";
         List<String> allTables = Arrays.asList("t1", "t22", "t3");
         String tableIncludeList = new String("ks.t1,ks.t2.*");
-        List<String> includedTables = VitessConnector.getIncludedTables(keyspace, tableIncludeList, allTables);
+        Configuration config = Configuration.from(Map.of(
+                VitessConnectorConfig.TABLE_INCLUDE_LIST.name(), tableIncludeList,
+                VitessConnectorConfig.KEYSPACE.name(), keyspace));
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(config);
+        List<String> includedTables = VitessConnector.getIncludedTables(connectorConfig, allTables);
         List<String> expectedTables = Arrays.asList("t1", "t22");
+        assertEquals(expectedTables, includedTables);
+    }
+
+    @Test
+    public void testTableIncludeListShouldExcludeTablesWithSuffix() {
+        String keyspace = "ks";
+        List<String> allTables = Arrays.asList("t1", "t2", "t22", "t13");
+        String tableIncludeList = new String("ks.t1,ks.t2");
+        Configuration config = Configuration.from(Map.of(
+                VitessConnectorConfig.TABLE_INCLUDE_LIST.name(), tableIncludeList,
+                VitessConnectorConfig.KEYSPACE.name(), keyspace));
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(config);
+        List<String> includedTables = VitessConnector.getIncludedTables(connectorConfig, allTables);
+        List<String> expectedTables = Arrays.asList("t1", "t2");
         assertEquals(expectedTables, includedTables);
     }
 


### PR DESCRIPTION
The previous code had custom regex filtering which meant it would match all tables with suffixes for the table filter (eg filter is keyspace.table1 and would also match keyspace.table1_suffix1, keyspace.table1_suffix2, keyspace.table1_suffix3). These events would later be filtered out with the call to emit data change event which uses the Debezium Filters construct correctly (it only matches the full table name). This means there could be lots of unnecessary events being requested & deserialized from the vstream. This PR removes this custom regex logic and instead use the Debezium `Filters` to determine which tables to filter fixing this edge case.

This should significantly help with CPU & performance (and cost savings) for keyspaces that have many tables that have the same prefix and different suffixes.