### PR TITLE
DBZ-8325 Emit DDL events

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/TableTopicNamingStrategy.java
+++ b/src/main/java/io/debezium/connector/vitess/TableTopicNamingStrategy.java
@@ -15,18 +15,37 @@ import io.debezium.util.Collect;
 import io.debezium.util.Strings;
 
 /**
+ * <p>
  * Topic naming strategy where only the table name is added. This is used to avoid including
  * the shard which is now part of the catalog of the table ID and would be included if
  * the DefaultTopicNamingStrategy is being used.
+ *</p>
+ * Additionally, supports some Vitess-specific configs:
+ * <ul>
+ *     <li>
+ *        overrideDataChangeTopicPrefix: in the case of mulitple connectors for the same keyspace,
+ *        a unique `topic.prefix` is required for proper metric reporting, so in order for a consistent topic
+ *        naming convention, the data change topic prefix can be set here (typically shared between connectors of the same
+ *        keyspace
+ *      </li>
+ *      <li>
+ *        overrideSchemaChangeTopic: in the case of multiple connectors for the same keyspace and `include.schema.changes` being enabled,
+ *        this is used to prevent the ddl events from being written to the topic named `topic.prefix`, which is the default behavior.
+ *        The reason why this is necessary is that the `topic.prefix` may include the table name for uniqueness, so it may actually be the name
+ *        of a data change topic.
+ *      </li>
+ * </ul>
  */
 public class TableTopicNamingStrategy extends AbstractTopicNamingStrategy<TableId> {
 
     private final String overrideDataChangeTopicPrefix;
+    private final String overrideSchemaChangeTopic;
 
     public TableTopicNamingStrategy(Properties props) {
         super(props);
         Configuration config = Configuration.from(props);
         this.overrideDataChangeTopicPrefix = config.getString(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX);
+        this.overrideSchemaChangeTopic = config.getString(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC);
     }
 
     public static TableTopicNamingStrategy create(CommonConnectorConfig config) {
@@ -43,5 +62,23 @@ public class TableTopicNamingStrategy extends AbstractTopicNamingStrategy<TableI
             topicName = mkString(Collect.arrayListOf(prefix, id.table()), delimiter);
         }
         return topicNames.computeIfAbsent(id, t -> sanitizedTopicName(topicName));
+    }
+
+    /**
+     * Return the schema change topic. There are two cases:
+     * 1. If override schema change topic is specified - use this as the topic name
+     * 2. If override schema change topic is not specified - call the super method to get the typical
+     * schema change topic name.
+     *
+     * @return String representing the schema change topic name.
+     */
+    @Override
+    public String schemaChangeTopic() {
+        if (!Strings.isNullOrBlank(overrideSchemaChangeTopic)) {
+            return overrideSchemaChangeTopic;
+        }
+        else {
+            return super.schemaChangeTopic();
+        }
     }
 }

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -374,22 +374,6 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                             + "'false' (the default) offsets are stored as a single unit under the database name. "
                             + "'true' stores the offsets per task id");
 
-    public static final Field OVERRIDE_DATA_CHANGE_TOPIC_PREFIX = Field.create("override.data.change.topic.prefix")
-            .withDisplayName("Override Data Topic prefix")
-            .withType(Type.STRING)
-            .withWidth(Width.MEDIUM)
-            .withImportance(ConfigDef.Importance.LOW)
-            .withValidation(CommonConnectorConfig::validateTopicName)
-            .withDescription("Overrides the topic.prefix used for the data change topic.");
-
-    public static final Field OVERRIDE_SCHEMA_CHANGE_TOPIC = Field.create("override.schema.change.topic")
-            .withDisplayName("Override schema change topic name")
-            .withType(Type.STRING)
-            .withWidth(Width.MEDIUM)
-            .withImportance(ConfigDef.Importance.LOW)
-            .withValidation(CommonConnectorConfig::validateTopicName)
-            .withDescription("Overrides the name of the schema change topic (if not set uses topic.prefx).");
-
     public static final Field OFFSET_STORAGE_TASK_KEY_GEN = Field.create(VITESS_CONFIG_GROUP_PREFIX + "offset.storage.task.key.gen")
             .withDisplayName("Offset storage task key generation number")
             .withType(Type.INT)
@@ -500,8 +484,6 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     GRPC_HEADERS,
                     GRPC_MAX_INBOUND_MESSAGE_SIZE,
                     BINARY_HANDLING_MODE,
-                    OVERRIDE_DATA_CHANGE_TOPIC_PREFIX,
-                    OVERRIDE_SCHEMA_CHANGE_TOPIC,
                     SCHEMA_NAME_ADJUSTMENT_MODE,
                     OFFSET_STORAGE_PER_TASK,
                     OFFSET_STORAGE_TASK_KEY_GEN,

--- a/src/main/java/io/debezium/connector/vitess/connection/DdlMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/DdlMessage.java
@@ -14,11 +14,17 @@ public class DdlMessage implements ReplicationMessage {
     private final String transactionId;
     private final Instant commitTime;
     private final Operation operation;
+    private final String statement;
+    private final String shard;
+    private final String keyspace;
 
-    public DdlMessage(String transactionId, Instant commitTime) {
+    public DdlMessage(String transactionId, Instant commitTime, String statement, String keyspace, String shard) {
         this.transactionId = transactionId;
         this.commitTime = commitTime;
         this.operation = Operation.DDL;
+        this.statement = statement;
+        this.keyspace = keyspace;
+        this.shard = shard;
     }
 
     @Override
@@ -42,8 +48,18 @@ public class DdlMessage implements ReplicationMessage {
     }
 
     @Override
+    public String getStatement() {
+        return statement;
+    }
+
+    @Override
+    public String getKeyspace() {
+        return keyspace;
+    }
+
+    @Override
     public String getShard() {
-        throw new UnsupportedOperationException();
+        return shard;
     }
 
     @Override
@@ -67,8 +83,14 @@ public class DdlMessage implements ReplicationMessage {
                 + "transactionId='"
                 + transactionId
                 + '\''
+                + ", keyspace="
+                + keyspace
+                + ", shard="
+                + shard
                 + ", commitTime="
                 + commitTime
+                + ", statement="
+                + statement
                 + ", operation="
                 + operation
                 + '}';

--- a/src/main/java/io/debezium/connector/vitess/connection/DdlMetadataExtractor.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/DdlMetadataExtractor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.connection;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.debezium.connector.vitess.VitessDatabaseSchema;
+import io.debezium.schema.SchemaChangeEvent;
+
+/**
+ * @author Thomas Thornton
+ */
+public class DdlMetadataExtractor {
+
+    // VStream DDL statements do not contain any database/keyspace, only contains the table name
+    private static final Pattern TABLE_NAME_PATTERN = Pattern.compile(
+            "(?i)(CREATE|ALTER|TRUNCATE|DROP|RENAME)\\s+TABLE\\s+['\\\"`]?([\\w]+)['\\\"`]?",
+            Pattern.CASE_INSENSITIVE);
+
+    private final DdlMessage ddlMessage;
+    private String operation;
+    private String table;
+
+    public DdlMetadataExtractor(ReplicationMessage ddlMessage) {
+        this.ddlMessage = (DdlMessage) ddlMessage;
+        extractMetadata();
+    }
+
+    public void extractMetadata() {
+        Matcher matcher = TABLE_NAME_PATTERN.matcher(this.ddlMessage.getStatement());
+        if (matcher.find()) {
+            operation = matcher.group(1).split("\s+")[0].toUpperCase();
+            if (operation.equals("RENAME")) {
+                operation = "ALTER";
+            }
+            table = matcher.group(2);
+        }
+    }
+
+    public SchemaChangeEvent.SchemaChangeEventType getSchemaChangeEventType() {
+        return SchemaChangeEvent.SchemaChangeEventType.valueOf(operation);
+    }
+
+    public String getTable() {
+        return VitessDatabaseSchema.buildTableId(ddlMessage.getShard(), ddlMessage.getKeyspace(), table).toDoubleQuotedString();
+    }
+}

--- a/src/main/java/io/debezium/connector/vitess/connection/HeartbeatMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/HeartbeatMessage.java
@@ -35,12 +35,22 @@ public class HeartbeatMessage implements ReplicationMessage {
     }
 
     @Override
+    public String getKeyspace() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String getTable() {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public String getShard() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getStatement() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/io/debezium/connector/vitess/connection/OtherMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/OtherMessage.java
@@ -37,7 +37,17 @@ public class OtherMessage implements ReplicationMessage {
     }
 
     @Override
+    public String getKeyspace() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String getTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getStatement() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
@@ -72,6 +72,8 @@ public interface ReplicationMessage {
 
     String getTransactionId();
 
+    String getKeyspace();
+
     String getTable();
 
     String getShard();
@@ -79,6 +81,8 @@ public interface ReplicationMessage {
     List<Column> getOldTupleList();
 
     List<Column> getNewTupleList();
+
+    String getStatement();
 
     default boolean isTransactionalMessage() {
         return getOperation() == Operation.BEGIN || getOperation() == Operation.COMMIT;

--- a/src/main/java/io/debezium/connector/vitess/connection/TransactionalMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/TransactionalMessage.java
@@ -14,12 +14,14 @@ public class TransactionalMessage implements ReplicationMessage {
     private final String transactionId;
     private final Instant commitTime;
     private final Operation operation;
+    private final String keyspace;
     private final String shard;
 
-    public TransactionalMessage(Operation operation, String transactionId, Instant commitTime, String shard) {
+    public TransactionalMessage(Operation operation, String transactionId, Instant commitTime, String keyspace, String shard) {
         this.transactionId = transactionId;
         this.commitTime = commitTime;
         this.operation = operation;
+        this.keyspace = keyspace;
         this.shard = shard;
     }
 
@@ -39,6 +41,11 @@ public class TransactionalMessage implements ReplicationMessage {
     }
 
     @Override
+    public String getKeyspace() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String getTable() {
         throw new UnsupportedOperationException();
     }
@@ -46,6 +53,11 @@ public class TransactionalMessage implements ReplicationMessage {
     @Override
     public String getShard() {
         return shard;
+    }
+
+    @Override
+    public String getStatement() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -100,7 +100,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
             this.transactionId = newVgtid.toString();
         }
         processor.process(
-                new DdlMessage(transactionId, eventTimestamp), newVgtid, false);
+                new DdlMessage(transactionId, eventTimestamp, vEvent.getStatement(), vEvent.getKeyspace(), vEvent.getShard()), newVgtid, false);
     }
 
     private void handleOther(Binlogdata.VEvent vEvent, ReplicationMessageProcessor processor, Vgtid newVgtid)
@@ -133,7 +133,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
         }
         LOGGER.trace("Timestamp of begin transaction: {}", eventTimestamp);
         processor.process(
-                new TransactionalMessage(Operation.BEGIN, transactionId, eventTimestamp, vEvent.getShard()), newVgtid, false);
+                new TransactionalMessage(Operation.BEGIN, transactionId, eventTimestamp, vEvent.getKeyspace(), vEvent.getShard()), newVgtid, false);
     }
 
     private void handleCommitMessage(
@@ -147,7 +147,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
         }
         LOGGER.trace("Timestamp of commit transaction: {}", commitTimestamp);
         processor.process(
-                new TransactionalMessage(Operation.COMMIT, transactionId, eventTimestamp, vEvent.getShard()), newVgtid, false);
+                new TransactionalMessage(Operation.COMMIT, transactionId, eventTimestamp, vEvent.getKeyspace(), vEvent.getShard()), newVgtid, false);
     }
 
     private void decodeRows(Binlogdata.VEvent vEvent, ReplicationMessageProcessor processor, Vgtid newVgtid, boolean isLastRowEventOfTransaction)
@@ -216,6 +216,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                         Operation.INSERT,
                         commitTimestamp,
                         transactionId,
+                        schemaName,
                         tableId.toDoubleQuotedString(),
                         shard,
                         null,
@@ -256,6 +257,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                         Operation.UPDATE,
                         commitTimestamp,
                         transactionId,
+                        schemaName,
                         tableId.toDoubleQuotedString(),
                         shard,
                         oldColumns,
@@ -294,6 +296,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                         Operation.DELETE,
                         commitTimestamp,
                         transactionId,
+                        schemaName,
                         tableId.toDoubleQuotedString(),
                         shard,
                         columns,

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputReplicationMessage.java
@@ -17,6 +17,7 @@ public class VStreamOutputReplicationMessage implements ReplicationMessage {
     private final Operation op;
     private final Instant commitTimestamp;
     private final String transactionId;
+    private final String keyspace;
     private final String table;
     private final String shard;
     private final List<Column> oldColumns;
@@ -26,6 +27,7 @@ public class VStreamOutputReplicationMessage implements ReplicationMessage {
                                            Operation op,
                                            Instant commitTimestamp,
                                            String transactionId,
+                                           String keyspace,
                                            String table,
                                            String shard,
                                            List<Column> oldColumns,
@@ -33,6 +35,7 @@ public class VStreamOutputReplicationMessage implements ReplicationMessage {
         this.op = op;
         this.commitTimestamp = commitTimestamp;
         this.transactionId = transactionId;
+        this.keyspace = keyspace;
         this.table = table;
         this.shard = shard;
         this.oldColumns = oldColumns;
@@ -55,6 +58,11 @@ public class VStreamOutputReplicationMessage implements ReplicationMessage {
     }
 
     @Override
+    public String getKeyspace() {
+        return keyspace;
+    }
+
+    @Override
     public String getTable() {
         return table;
     }
@@ -62,6 +70,11 @@ public class VStreamOutputReplicationMessage implements ReplicationMessage {
     @Override
     public String getShard() {
         return shard;
+    }
+
+    @Override
+    public String getStatement() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -414,8 +414,8 @@ public class VitessReplicationConnection implements ReplicationConnection {
         if (config.offsetStoragePerTask()) {
             List<String> shards = config.getVitessTaskKeyShards();
             vgtid = config.getVitessTaskVgtid();
-            LOGGER.info("VGTID '{}' is set for the keyspace: {} shards: {}",
-                    vgtid, config.getKeyspace(), shards);
+            LOGGER.info("VGTID is set for the keyspace: {}, shards: {}, vgtid: {}",
+                    config.getKeyspace(), shards, vgtid);
         }
         else {
             // If offset storage per task is disabled, then find the vgtid elsewhere

--- a/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
@@ -52,4 +52,26 @@ public class TableTopicNamingStrategyTest {
         assertThat(topicName).isEqualTo("prefix.table");
     }
 
+    @Test
+    public void shouldGetOverrideSchemaChangeTopic() {
+        TableId tableId = new TableId("shard", "keyspace", "table");
+        final Properties props = new Properties();
+        props.put("topic.prefix", "prefix");
+        props.put(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC.name(), "override-prefix");
+        TopicNamingStrategy strategy = new TableTopicNamingStrategy(props);
+        String topicName = strategy.schemaChangeTopic();
+        assertThat(topicName).isEqualTo("override-prefix");
+    }
+
+    @Test
+    public void shouldUseTopicPrefixIfOverrideSchemaIsBlank() {
+        TableId tableId = new TableId("shard", "keyspace", "table");
+        final Properties props = new Properties();
+        props.put("topic.prefix", "prefix");
+        props.put(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC.name(), "");
+        TopicNamingStrategy strategy = new TableTopicNamingStrategy(props);
+        String topicName = strategy.schemaChangeTopic();
+        assertThat(topicName).isEqualTo("prefix");
+    }
+
 }

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -31,6 +31,7 @@ import io.debezium.connector.vitess.connection.ReplicationMessage;
 import io.debezium.connector.vitess.connection.ReplicationMessageColumn;
 import io.debezium.connector.vitess.connection.VitessTabletType;
 import io.debezium.connector.vitess.pipeline.txmetadata.ShardEpochMap;
+import io.debezium.embedded.EmbeddedEngineConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.vitess.proto.Query;
@@ -149,6 +150,8 @@ public class TestHelper {
                 .with(VitessConnectorConfig.VTGATE_PORT, VTGATE_PORT)
                 .with(VitessConnectorConfig.VTGATE_USER, USERNAME)
                 .with(VitessConnectorConfig.VTGATE_PASSWORD, PASSWORD)
+                // Only wait 5 seconds to stop, not default of 5 minutes
+                .with(EmbeddedEngineConfig.WAIT_FOR_COMPLETION_BEFORE_INTERRUPT_MS, 5000)
                 .with(VitessConnectorConfig.POLL_INTERVAL_MS, 100);
         if (!Strings.isNullOrEmpty(tableInclude)) {
             builder.with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, tableInclude);

--- a/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
@@ -96,6 +96,7 @@ public class VitessBigIntUnsignedTest {
                 ReplicationMessage.Operation.INSERT,
                 AnonymousValue.getInstant(),
                 AnonymousValue.getString(),
+                AnonymousValue.getString(),
                 TestHelper.defaultTableId().toDoubleQuotedString(),
                 TestHelper.TEST_SHARD,
                 null,

--- a/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
@@ -48,6 +48,7 @@ public class VitessChangeRecordEmitterTest {
                 ReplicationMessage.Operation.INSERT,
                 AnonymousValue.getInstant(),
                 AnonymousValue.getString(),
+                AnonymousValue.getString(),
                 TestHelper.defaultTableId().toDoubleQuotedString(),
                 AnonymousValue.getString(),
                 null,
@@ -74,6 +75,7 @@ public class VitessChangeRecordEmitterTest {
         ReplicationMessage message = new VStreamOutputReplicationMessage(
                 ReplicationMessage.Operation.DELETE,
                 AnonymousValue.getInstant(),
+                AnonymousValue.getString(),
                 AnonymousValue.getString(),
                 TestHelper.defaultTableId().toDoubleQuotedString(),
                 AnonymousValue.getString(),
@@ -102,6 +104,7 @@ public class VitessChangeRecordEmitterTest {
                 ReplicationMessage.Operation.UPDATE,
                 AnonymousValue.getInstant(),
                 AnonymousValue.getString(),
+                AnonymousValue.getString(),
                 TestHelper.defaultTableId().toDoubleQuotedString(),
                 AnonymousValue.getString(),
                 TestHelper.defaultRelationMessageColumns(),
@@ -126,7 +129,7 @@ public class VitessChangeRecordEmitterTest {
     public void shouldNotSupportBeginMessage() {
         // setup fixture
         ReplicationMessage message = new TransactionalMessage(ReplicationMessage.Operation.BEGIN, AnonymousValue.getString(), AnonymousValue.getInstant(),
-                AnonymousValue.getString());
+                AnonymousValue.getString(), AnonymousValue.getString());
 
         // exercise SUT
         new VitessChangeRecordEmitter(
@@ -142,7 +145,7 @@ public class VitessChangeRecordEmitterTest {
     public void shouldNotSupportCommitMessage() {
         // setup fixture
         ReplicationMessage message = new TransactionalMessage(ReplicationMessage.Operation.COMMIT, AnonymousValue.getString(), AnonymousValue.getInstant(),
-                AnonymousValue.getString());
+                AnonymousValue.getString(), AnonymousValue.getString());
 
         // exercise SUT
         new VitessChangeRecordEmitter(

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -52,67 +52,6 @@ public class VitessConnectorConfigTest {
     }
 
     @Test
-    public void shouldImproperOverrideTopicPrefixFailValidation() {
-        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX, "hello@world").build();
-        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
-        List<String> inputs = new ArrayList<>();
-        Consumer<String> printConsumer = (input) -> {
-            inputs.add(input);
-        };
-        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX), printConsumer);
-        assertThat(inputs.size()).isEqualTo(1);
-    }
-
-    @Test
-    public void shouldBlankOverrideTopicPrefixFailValidation() {
-        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX, "").build();
-        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
-        List<String> inputs = new ArrayList<>();
-        Consumer<String> printConsumer = (input) -> {
-            inputs.add(input);
-        };
-        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX), printConsumer);
-        assertThat(inputs.size()).isEqualTo(1);
-    }
-
-    @Test
-    public void shouldImproperOverrideSchemaTopicPrefixFailValidation() {
-        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC, "hello@world").build();
-        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
-        List<String> inputs = new ArrayList<>();
-        Consumer<String> printConsumer = (input) -> {
-            inputs.add(input);
-        };
-        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC), printConsumer);
-        assertThat(inputs.size()).isEqualTo(1);
-    }
-
-    @Test
-    public void shouldUseSchemaTopicPrefix() {
-        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC,
-                "__debezium-ddl.dev.msgdata.precomputed_channel_summary_partitioned").build();
-        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
-        List<String> inputs = new ArrayList<>();
-        Consumer<String> printConsumer = (input) -> {
-            inputs.add(input);
-        };
-        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC), printConsumer);
-        assertThat(inputs.size()).isEqualTo(0);
-    }
-
-    @Test
-    public void shouldBlankOverrideSchemaTopicPrefixFailValidation() {
-        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC, "").build();
-        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
-        List<String> inputs = new ArrayList<>();
-        Consumer<String> printConsumer = (input) -> {
-            inputs.add(input);
-        };
-        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC), printConsumer);
-        assertThat(inputs.size()).isEqualTo(1);
-    }
-
-    @Test
     public void shouldExcludeEmptyShards() {
         Configuration configuration = TestHelper.defaultConfig().with(
                 VitessConnectorConfig.EXCLUDE_EMPTY_SHARDS, true).build();

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -76,6 +76,43 @@ public class VitessConnectorConfigTest {
     }
 
     @Test
+    public void shouldImproperOverrideSchemaTopicPrefixFailValidation() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC, "hello@world").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC), printConsumer);
+        assertThat(inputs.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldUseSchemaTopicPrefix() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC,
+                "__debezium-ddl.dev.msgdata.precomputed_channel_summary_partitioned").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC), printConsumer);
+        assertThat(inputs.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldBlankOverrideSchemaTopicPrefixFailValidation() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC, "").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC), printConsumer);
+        assertThat(inputs.size()).isEqualTo(1);
+    }
+
+    @Test
     public void shouldExcludeEmptyShards() {
         Configuration configuration = TestHelper.defaultConfig().with(
                 VitessConnectorConfig.EXCLUDE_EMPTY_SHARDS, true).build();

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -261,8 +261,8 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         String overrideSchemaChangeTopic = "schema.alternate.topic";
         startConnector(config -> config
                 .with(VitessConnectorConfig.TOPIC_NAMING_STRATEGY, TableTopicNamingStrategy.class)
-                .with(VitessConnectorConfig.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX, overrideDataChangeTopicPrefix)
-                .with(VitessConnectorConfig.OVERRIDE_SCHEMA_CHANGE_TOPIC, overrideSchemaChangeTopic)
+                .with(TableTopicNamingStrategy.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX, overrideDataChangeTopicPrefix)
+                .with(TableTopicNamingStrategy.OVERRIDE_SCHEMA_CHANGE_TOPIC, overrideSchemaChangeTopic)
                 .with(VitessConnectorConfig.INCLUDE_SCHEMA_CHANGES, true),
                 false);
         assertConnectorIsRunning();

--- a/src/test/java/io/debezium/connector/vitess/connection/DdlMessageTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/DdlMessageTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+/**
+ * Verify the behavior of {@link DdlMessage}
+ *
+ * @author Thomas Thornton
+ */
+public class DdlMessageTest {
+
+    @Test
+    public void shouldSetQuery() {
+        String statement = "ALTER TABLE foo RENAME TO bar";
+        String keyspace = "keyspace";
+        String shard = "-80";
+        DdlMessage ddlMessage = new DdlMessage("gtid", Instant.EPOCH, statement, keyspace, shard);
+        assertThat(ddlMessage.getStatement()).isEqualTo(statement);
+    }
+
+    @Test
+    public void shouldSetShard() {
+        String statement = "ALTER TABLE foo RENAME TO bar";
+        String shard = "-80";
+        String keyspace = "keyspace";
+        DdlMessage ddlMessage = new DdlMessage("gtid", Instant.EPOCH, statement, keyspace, shard);
+        assertThat(ddlMessage.getShard()).isEqualTo(shard);
+    }
+
+    @Test
+    public void shouldSetKeyspace() {
+        String statement = "ALTER TABLE foo RENAME TO bar";
+        String shard = "-80";
+        String keyspace = "keyspace";
+        DdlMessage ddlMessage = new DdlMessage("gtid", Instant.EPOCH, statement, keyspace, shard);
+        assertThat(ddlMessage.getKeyspace()).isEqualTo(keyspace);
+    }
+
+    @Test
+    public void shouldConvertToString() {
+        String statement = "ALTER TABLE foo RENAME TO bar";
+        String shard = "-80";
+        String keyspace = "keyspace";
+        ReplicationMessage replicationMessage = new DdlMessage("gtid", Instant.EPOCH, statement, keyspace, shard);
+        assertThat(replicationMessage.toString()).isEqualTo(
+                "DdlMessage{transactionId='gtid', keyspace=keyspace, shard=-80, commitTime=1970-01-01T00:00:00Z, statement=ALTER TABLE foo RENAME TO bar, operation=DDL}");
+    }
+
+}

--- a/src/test/java/io/debezium/connector/vitess/connection/DdlMetadataExtractorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/DdlMetadataExtractorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.debezium.connector.vitess.TestHelper;
+import io.debezium.schema.SchemaChangeEvent;
+
+/**
+ * @author Thomas Thornton
+ */
+public class DdlMetadataExtractorTest {
+
+    @Test
+    public void shouldGetAlterType() {
+        DdlMessage ddlMessage = new DdlMessage(null, null, "ALTER TABLE foo ADD COLUMN bar",
+                TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
+        assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.ALTER);
+    }
+
+    @Test
+    public void shouldGetCreateType() {
+        DdlMessage ddlMessage = new DdlMessage(null, null, "CREATE    TABLE foo",
+                TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
+        assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.CREATE);
+    }
+
+    @Test
+    public void shouldGetTruncateType() {
+        DdlMessage ddlMessage = new DdlMessage(null, null, "TRUNCATE    TABLE foo",
+                TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
+        assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.TRUNCATE);
+    }
+
+    @Test
+    public void shouldGetTable() {
+        DdlMessage ddlMessage = new DdlMessage(null, null, "TRUNCATE    TABLE foo",
+                TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
+        assertThat(extractor.getTable()).isEqualTo("\"0\".\"test_unsharded_keyspace\".\"foo\"");
+    }
+
+    @Test
+    public void shouldGetDropType() {
+        DdlMessage ddlMessage = new DdlMessage(null, null, "DROP TABLE foo",
+                TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
+        assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.DROP);
+    }
+
+    @Test
+    public void shouldGetRenameType() {
+        DdlMessage ddlMessage = new DdlMessage(null, null, "RENAME TABLE foo TO bar",
+                TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
+        assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.ALTER);
+    }
+
+}

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -20,6 +20,18 @@ CREATE TABLE numeric_table
     PRIMARY KEY (id)
 );
 
+DROP TABLE IF EXISTS ddl_table;
+CREATE TABLE ddl_table
+(
+    id                              BIGINT NOT NULL AUTO_INCREMENT,
+    int_unsigned_col                INT UNSIGNED DEFAULT 0,
+    json_col                        JSON,
+    PRIMARY KEY (id)
+)
+PARTITION BY RANGE (id) (
+    PARTITION p0 VALUES LESS THAN (1000)
+);
+
 DROP TABLE IF EXISTS string_table;
 CREATE TABLE string_table
 (

--- a/src/test/resources/vitess_vschema.json
+++ b/src/test/resources/vitess_vschema.json
@@ -18,6 +18,18 @@
         "sequence": "my_seq"
       }
     },
+    "ddl_table": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ],
+      "autoIncrement": {
+        "column": "id",
+        "sequence": "my_seq"
+      }
+    },
     "string_table": {
       "columnVindexes": [
         {


### PR DESCRIPTION
Based on feedback on https://github.com/debezium/debezium-connector-vitess/pull/210 creating this PR. Depends on https://github.com/debezium/debezium/pull/5979 (so tests won't pass until that is merged) which allows for publishing schema change events without using the Historized configs/schemas. These are not necessary to use for Vitess VStream so it simplifies the code greatly.

Note: although Vitess DDLs use MySQL syntax, there is a requirement to use the MySQL parser that the [databaseTables](https://github.com/debezium/debezium/blob/44251bc442a8481c8ae3ee9bf70f06b405f328d2/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java#L62) be up to date prior to receiving a DDL event otherwise it is trivially ignored (eg [here](https://github.com/debezium/debezium/blob/44251bc442a8481c8ae3ee9bf70f06b405f328d2/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/AlterTableParserListener.java#L50)). Since Vitess VStream may send a DDL as the first event (with no prior FIELD event to establish the table schema), then this is not feasible to know (without doing a full historized snapshot with CREATE table statements). To work around this we use a simple regex and don't bother parsing the full SQL text. This still allows us to set fields correctly (eg `ddl` and `table` field are correct, and we simply leave `tableChanges` field empty). In a separate ticket we can change the parser to possibly support this, but that is a larger change/refactor that I believe would best be in a separate PR.

Example DDL event:
```
SourceRecord{sourcePartition={server=test_server}, sourceOffset={vgtid=[{"keyspace":"test_unsharded_keyspace","shard":"0","gtid":"MySQL56/7359ecd4-9d4c-11ef-971d-0242ac110002:1-1783","table_p_ks":[]}]}} ConnectRecord{topic='test_server', kafkaPartition=0, key=Struct{databaseName=test_unsharded_keyspace}, keySchema=Schema{io.debezium.connector.vitess.SchemaChangeKey:STRUCT}, value=Struct{source=Struct{version=3.0.0-SNAPSHOT,connector=vitess,name=test_server,ts_ms=1731014782000,db=,ts_us=1731014782000000,ts_ns=1731014782000000000,keyspace=test_unsharded_keyspace,table=ddl_table,shard=0,vgtid=[{"keyspace":"test_unsharded_keyspace","shard":"0","gtid":"MySQL56/7359ecd4-9d4c-11ef-971d-0242ac110002:1-1784","table_p_ks":[]}]},ts_ms=1731014782527,databaseName=test_unsharded_keyspace,ddl=alter table ddl_table add column new_column_name INT,tableChanges=[]}, valueSchema=Schema{io.debezium.connector.vitess.SchemaChangeValue:STRUCT}, timestamp=null, headers=ConnectHeaders(headers=)}
```