### PR TITLE
DBZ-8438 Pin netty versions to prevent data corruption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
           work on all platforms. We'll set some of these as system properties during integration testing.
         -->
         <vitess.image>vitess/test-database</vitess.image>
+        <!-- Prevent data corruption with 4.1.111.Final -->
+        <version.netty>4.1.110.Final</version.netty>
         <!--suppress UnresolvedMavenProperty -->
         <vitess.vtgate.host>${docker.host.address}</vitess.vtgate.host>
         <vitess.vtgate.grpc.port>15991</vitess.vtgate.grpc.port>
@@ -68,6 +70,18 @@
                 <groupId>io.debezium</groupId>
                 <artifactId>debezium-embedded</artifactId>
                 <version>${version.debezium}</version>
+            </dependency>
+
+            <!-- Netty artifacts -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${version.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
+                <version>${version.netty}</version>
             </dependency>
 
             <!-- Building -->


### PR DESCRIPTION
4.1.111 has data corruption see [here](https://debezium.zulipchat.com/#narrow/channel/348255-community-vitess/topic/Data.20Corruption.20with.20Kafka.203.2E9.2E0/near/483564599)

I could pin this in debezium-core, but I figure Debezium may want to keep the versions aligned with kafka for those that do not use grpc-java package. Any other connectors that use grpc-java should have this fix as well.