### PR TITLE
DBZ-8479 Improve DDL parsing logic

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/DdlMetadataExtractor.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/DdlMetadataExtractor.java
@@ -9,6 +9,9 @@ package io.debezium.connector.vitess.connection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.connector.vitess.VitessDatabaseSchema;
 import io.debezium.schema.SchemaChangeEvent;
 
@@ -17,10 +20,17 @@ import io.debezium.schema.SchemaChangeEvent;
  */
 public class DdlMetadataExtractor {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DdlMetadataExtractor.class);
+
     // VStream DDL statements do not contain any database/keyspace, only contains the table name
     private static final Pattern TABLE_NAME_PATTERN = Pattern.compile(
             "(?i)(CREATE|ALTER|TRUNCATE|DROP|RENAME)\\s+TABLE\\s+['\\\"`]?([\\w]+)['\\\"`]?",
             Pattern.CASE_INSENSITIVE);
+
+    // Regex to match in-line or multi-line comments (e.g., /* comment */)
+    private static final Pattern COMMENT_PATTERN = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+
+    private static final String UNKNOWN_TABLE_NAME = "<UNKNOWN>";
 
     private final DdlMessage ddlMessage;
     private String operation;
@@ -32,7 +42,8 @@ public class DdlMetadataExtractor {
     }
 
     public void extractMetadata() {
-        Matcher matcher = TABLE_NAME_PATTERN.matcher(this.ddlMessage.getStatement());
+        String cleanedStatement = removeComments(this.ddlMessage.getStatement());
+        Matcher matcher = TABLE_NAME_PATTERN.matcher(cleanedStatement);
         if (matcher.find()) {
             operation = matcher.group(1).split("\s+")[0].toUpperCase();
             if (operation.equals("RENAME")) {
@@ -42,11 +53,33 @@ public class DdlMetadataExtractor {
         }
     }
 
+    private String removeComments(String statement) {
+        return COMMENT_PATTERN.matcher(statement).replaceAll("");
+    }
+
     public SchemaChangeEvent.SchemaChangeEventType getSchemaChangeEventType() {
+        if (operation == null) {
+            logUnknownMessage("schema change event type");
+            // An event type is required to build a schema change event, so if we got an empty event type, default to ALTER
+            return SchemaChangeEvent.SchemaChangeEventType.ALTER;
+        }
         return SchemaChangeEvent.SchemaChangeEventType.valueOf(operation);
     }
 
     public String getTable() {
+        if (table == null) {
+            logUnknownMessage("table");
+            table = UNKNOWN_TABLE_NAME;
+        }
         return VitessDatabaseSchema.buildTableId(ddlMessage.getShard(), ddlMessage.getKeyspace(), table).toDoubleQuotedString();
+    }
+
+    private void logUnknownMessage(String message) {
+        LOGGER.warn("Unknown {}, keyspace: {}, shard: {}, commit time {}, transaction ID: {}",
+                message,
+                ddlMessage.getKeyspace(),
+                ddlMessage.getShard(),
+                ddlMessage.getCommitTime(),
+                ddlMessage.getTransactionId());
     }
 }

--- a/src/test/docker/Dockerfile
+++ b/src/test/docker/Dockerfile
@@ -5,7 +5,6 @@ FROM vitess/lite:v19.0.4
 
 USER root
 
-RUN apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com B7B3B788A8D3785C
 RUN apt-get update
 RUN apt-get install -y sudo curl vim jq
 

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -47,7 +47,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1367,7 +1366,6 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     }
 
     @Test
-    @Ignore // TODO: enable the test once DBZ-8432 is fixed
     public void shouldMultiShardMultiTaskConfigSubscriptionHaveMultiShardGtidsInVgtid() throws Exception {
         final boolean hasMultipleShards = true;
 
@@ -1378,7 +1376,8 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         int expectedRecordsCount = 1;
         consumer = testConsumer(expectedRecordsCount);
-        assertInsert(INSERT_NUMERIC_TYPES_STMT, schemasAndValuesForNumericTypes(), TEST_SHARDED_KEYSPACE, TestHelper.PK_FIELD, hasMultipleShards);
+        // Since there are two tasks and each gets one shard this is expected to only have one shard
+        assertInsert(INSERT_NUMERIC_TYPES_STMT, schemasAndValuesForNumericTypes(), TEST_SHARDED_KEYSPACE, TestHelper.PK_FIELD, false);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/connection/DdlMetadataExtractorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/DdlMetadataExtractorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 import io.debezium.connector.vitess.TestHelper;
+import io.debezium.connector.vitess.VitessDatabaseSchema;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.schema.SchemaChangeEvent;
 
@@ -19,61 +20,87 @@ import io.debezium.schema.SchemaChangeEvent;
  */
 public class DdlMetadataExtractorTest {
 
+    private static String expectedTableName = VitessDatabaseSchema.buildTableId(
+            TestHelper.TEST_SHARD, TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_TABLE).toDoubleQuotedString();
+
     @Test
     public void shouldGetAlterType() {
-        DdlMessage ddlMessage = new DdlMessage(null, null, "ALTER TABLE foo ADD COLUMN bar",
+        DdlMessage ddlMessage = new DdlMessage(null, null,
+                String.format("ALTER TABLE %s ADD COLUMN bar", TestHelper.TEST_TABLE),
                 TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
         DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
         assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.ALTER);
+        assertThat(extractor.getTable()).isEqualTo(expectedTableName);
     }
 
     @Test
     public void shouldGetCreateType() {
-        DdlMessage ddlMessage = new DdlMessage(null, null, "CREATE    TABLE foo",
+        DdlMessage ddlMessage = new DdlMessage(null, null,
+                String.format("CREATE    TABLE %s", TestHelper.TEST_TABLE),
                 TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
         DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
         assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.CREATE);
+        assertThat(extractor.getTable()).isEqualTo(expectedTableName);
     }
 
     @Test
     public void shouldGetTruncateType() {
-        DdlMessage ddlMessage = new DdlMessage(null, null, "TRUNCATE    TABLE foo",
+        DdlMessage ddlMessage = new DdlMessage(null, null,
+                String.format("TRUNCATE    TABLE %s", TestHelper.TEST_TABLE),
                 TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
         DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
         assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.TRUNCATE);
+        assertThat(extractor.getTable()).isEqualTo(expectedTableName);
     }
 
     @Test
     public void shouldGetTable() {
-        DdlMessage ddlMessage = new DdlMessage(null, null, "TRUNCATE    TABLE foo",
+        DdlMessage ddlMessage = new DdlMessage(null, null,
+                String.format("TRUNCATE    TABLE %s", TestHelper.TEST_TABLE),
                 TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
         DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
-        assertThat(extractor.getTable()).isEqualTo("\"0\".\"test_unsharded_keyspace\".\"foo\"");
+        assertThat(extractor.getTable()).isEqualTo(expectedTableName);
     }
 
     @Test
     public void shouldGetDropType() {
-        DdlMessage ddlMessage = new DdlMessage(null, null, "DROP TABLE foo",
+        DdlMessage ddlMessage = new DdlMessage(null, null,
+                String.format("DROP TABLE %s", TestHelper.TEST_TABLE),
                 TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
         DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
         assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.DROP);
+        assertThat(extractor.getTable()).isEqualTo(expectedTableName);
     }
 
     @Test
     public void shouldGetRenameType() {
-        DdlMessage ddlMessage = new DdlMessage(null, null, "RENAME TABLE foo TO bar",
+        DdlMessage ddlMessage = new DdlMessage(null, null,
+                String.format("RENAME TABLE %s TO %s_suffix", TestHelper.TEST_TABLE, TestHelper.TEST_TABLE),
                 TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
         DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
         assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.ALTER);
+        assertThat(extractor.getTable()).isEqualTo(expectedTableName);
     }
 
     @Test
     public void shouldParseStatementWithComments() {
-        DdlMessage ddlMessage = new DdlMessage(null, null, "rename /* gh-ost */ table `keyspace`.`table1` to " +
-                "`keyspace`.`_table1_del`, `keyspace`.`_table_gho` to `keyspace`.`table`",
+        DdlMessage ddlMessage = new DdlMessage(null, null,
+                String.format("rename /* gh-ost */ table `keyspace`.`%s` to `keyspace`.`_table1_del`, `keyspace`.`_table_gho` to `keyspace`.`table`",
+                        TestHelper.TEST_TABLE),
                 TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
         DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
         assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.ALTER);
+        assertThat(extractor.getTable()).isEqualTo(expectedTableName);
+    }
+
+    @Test
+    public void shouldParseStatementWithSingleLineComment() {
+        DdlMessage ddlMessage = new DdlMessage(null, null,
+                String.format("create \n # gh-ost \n table `keyspace`.`%s`;", TestHelper.TEST_TABLE),
+                TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        DdlMetadataExtractor extractor = new DdlMetadataExtractor(ddlMessage);
+        assertThat(extractor.getSchemaChangeEventType()).isEqualTo(SchemaChangeEvent.SchemaChangeEventType.CREATE);
+        assertThat(extractor.getTable()).isEqualTo(expectedTableName);
     }
 
     @Test


### PR DESCRIPTION
A few changes to make this DDL logic more fault tolerant
1. Only parse DDLs if that schema history is enabled (otherwise this is unnecessary work)
2. Strip comments to ensure we parse correctly
3. Make table & type fault tolerant so we gracefully handle cases where we didn't parse either

Also fix [DBZ-8432](https://issues.redhat.com/browse/DBZ-8432)

Also dockerfile failing with the apt-key statement so remove that as it's unnecessary 