### PR TITLE
DBZ-8541 Handle partially overridden transactions

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorTask.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorTask.java
@@ -90,7 +90,7 @@ public class VitessConnectorTask extends BaseSourceTask<VitessPartition, VitessO
                 LOGGER.info("No previous offset found");
             }
             else {
-                LOGGER.info("Found previous offset {}", previousOffset);
+                LOGGER.info("Found task {} previous offset {}", config.getString(VitessConnectorConfig.TASK_ID), previousOffset);
             }
 
             replicationConnection = new VitessReplicationConnection(connectorConfig, schema);

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/Gtid.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/Gtid.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.vitess.pipeline.txmetadata;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -77,15 +78,7 @@ class Gtid {
         }
     }
 
-    public boolean isHostSetEqual(Gtid hosts) {
-        return this.hosts.equals(hosts.hosts);
-    }
-
-    public boolean isHostSetSupersetOf(Gtid previousHosts) {
-        return this.hosts.containsAll(previousHosts.hosts);
-    }
-
-    public boolean isHostSetSubsetOf(Gtid previousHosts) {
-        return previousHosts.hosts.containsAll(this.hosts);
+    public boolean isHostSetSupersetOf(Gtid otherHosts) {
+        return this.hosts.containsAll(otherHosts.hosts);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/GtidTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/GtidTest.java
@@ -17,37 +17,53 @@ import io.debezium.DebeziumException;
 
 public class GtidTest {
 
+    private static final String EXPECTED_VERSION = "MySQL56";
+    private static final String HOST_SET1 = "/host1:1,host2:2-10";
+    private static final String GTID1 = EXPECTED_VERSION + HOST_SET1;
+
     @Test
     public void shouldInit() {
-        String expectedVersion = "MySQL56";
-        Gtid gtid = new Gtid(expectedVersion + "/host1:1-4,host2:2-10");
-        assertThat(gtid.getVersion()).isEqualTo(expectedVersion);
+        Gtid gtid = new Gtid(EXPECTED_VERSION + "/host1:1-4,host2:2-10");
+        assertThat(gtid.getVersion()).isEqualTo(EXPECTED_VERSION);
         assertThat(gtid.getSequenceValues()).isEqualTo(List.of("4", "10"));
         assertThat(gtid.getHosts()).isEqualTo(Set.of("host1", "host2"));
     }
 
     @Test
     public void shouldHandleSingleValue() {
-        String expectedVersion = "MySQL56";
-        Gtid gtid = new Gtid(expectedVersion + "/host1:1,host2:2-10");
-        assertThat(gtid.getVersion()).isEqualTo(expectedVersion);
+        Gtid gtid = new Gtid(GTID1);
+        assertThat(gtid.getVersion()).isEqualTo(EXPECTED_VERSION);
         assertThat(gtid.getSequenceValues()).isEqualTo(List.of("1", "10"));
         assertThat(gtid.getHosts()).isEqualTo(Set.of("host1", "host2"));
     }
 
     @Test
+    public void testHostSupersetWithLargerSet() {
+        Gtid gtid = new Gtid(GTID1);
+        Gtid gtidSuperset = new Gtid(EXPECTED_VERSION + "/host1:1,host2:2-10,host3:1-5");
+        assertThat(gtidSuperset.isHostSetSupersetOf(gtid)).isTrue();
+        assertThat(gtid.isHostSetSupersetOf(gtidSuperset)).isFalse();
+    }
+
+    @Test
+    public void testHostSupersetWithEqualSet() {
+        Gtid gtid = new Gtid(GTID1);
+        Gtid gtid2 = new Gtid(GTID1);
+        assertThat(gtid.isHostSetSupersetOf(gtid2)).isTrue();
+        assertThat(gtid2.isHostSetSupersetOf(gtid)).isTrue();
+    }
+
+    @Test
     public void shouldThrowExceptionOnEmptyStringWithPrefix() {
-        String expectedVersion = "MySQL56";
         assertThatThrownBy(() -> {
-            Gtid gtid = new Gtid(expectedVersion + "/");
+            Gtid gtid = new Gtid(EXPECTED_VERSION + "/");
         }).isInstanceOf(DebeziumException.class);
     }
 
     @Test
     public void shouldThrowExceptionOnVersionOnly() {
-        String expectedVersion = "MySQL56";
         assertThatThrownBy(() -> {
-            Gtid gtid = new Gtid(expectedVersion);
+            Gtid gtid = new Gtid(EXPECTED_VERSION);
         }).isInstanceOf(DebeziumException.class);
     }
 


### PR DESCRIPTION
See ticket
https://issues.redhat.com/browse/DBZ-8541

If we have the task with shards
s1: current
s2: current

Then the first vgtid we will receive will be
s1: gtid1
s2: current

Then at some point we will get a transaction for s2 as well and will be
s1: gtid1
s2: gtid2

Right now we fail on this case even though it's valid.

Also do some miscellaneous improvements
- Simply vitess epoch provider logic
- Add tests for gtid, remove unnecessary methods
- Make validation & other checks more thorough
- Make handling more general so we fail less often
- Add more tests for above case and others