### PR TITLE
DBZ-8561 Correctly handle enum/set types in Vitess v20+

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -91,7 +91,7 @@ public class VitessType {
     }
 
     // Resolve JDBC type from vstream FIELD event
-    public static VitessType resolve(Query.Field field, boolean isInVStreamCopy) {
+    public static VitessType resolve(Query.Field field, boolean isEnumSetStringValue) {
         String type = field.getType().name();
         switch (type) {
             case "INT8":
@@ -105,16 +105,14 @@ public class VitessType {
             case "YEAR":
                 return new VitessType(type, Types.INTEGER);
             case "ENUM":
-                // Use field.getEnumSetStrings once available in new Vitess versions
-                if (isInVStreamCopy) {
+                if (isEnumSetStringValue) {
                     return new VitessType(type, Types.VARCHAR, resolveEnumAndSetValues(field.getColumnType()));
                 }
                 else {
                     return new VitessType(type, Types.INTEGER, resolveEnumAndSetValues(field.getColumnType()));
                 }
             case "SET":
-                // Use field.getEnumSetStrings once available in new Vitess versions
-                if (isInVStreamCopy) {
+                if (isEnumSetStringValue) {
                     return new VitessType(type, Types.VARCHAR, resolveEnumAndSetValues(field.getColumnType()));
                 }
                 else {

--- a/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoder.java
@@ -346,6 +346,10 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
 
     private void handleFieldMessage(Binlogdata.VEvent vEvent, boolean isInVStreamCopy) {
         Binlogdata.FieldEvent fieldEvent = vEvent.getFieldEvent();
+        boolean isEnumSetStringValue = false;
+        if (isInVStreamCopy || fieldEvent.getEnumSetStringValues()) {
+            isEnumSetStringValue = true;
+        }
         if (fieldEvent == null) {
             LOGGER.error("fieldEvent is expected from {}", vEvent);
         }
@@ -368,7 +372,7 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
                 for (short i = 0; i < columnCount; ++i) {
                     Field field = fieldEvent.getFields(i);
                     String columnName = validateColumnName(field.getName(), schemaName, tableName);
-                    VitessType vitessType = VitessType.resolve(field, isInVStreamCopy);
+                    VitessType vitessType = VitessType.resolve(field, isEnumSetStringValue);
                     if (vitessType.getJdbcId() == Types.OTHER) {
                         LOGGER.error("Cannot resolve JDBC type from VStream field {}", field);
                     }

--- a/src/test/docker/Dockerfile
+++ b/src/test/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Use a temporary layer for the build stage.
-FROM quay.io/debezium/vitess-base:19.0.4 AS base
+FROM quay.io/debezium/vitess-base:v19.0.4 AS base
 
-FROM quay.io/debezium/vitess-lite:19.0.4
+FROM quay.io/debezium/vitess-lite:v20.0.4
 
 USER root
 

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -288,15 +288,20 @@ public class TestHelper {
     }
 
     public static Binlogdata.VEvent defaultFieldEvent(String shard, String keyspace) {
-        return newFieldEvent(defaultColumnValues(), shard, keyspace);
+        return newFieldEvent(defaultColumnValues(), shard, keyspace, false);
     }
 
     public static Binlogdata.VEvent newFieldEvent(List<ColumnValue> columnValues) {
-        return newFieldEvent(columnValues, TEST_SHARD, TEST_UNSHARDED_KEYSPACE);
+        return newFieldEvent(columnValues, TEST_SHARD, TEST_UNSHARDED_KEYSPACE, false);
     }
 
     public static Binlogdata.VEvent newFieldEvent(List<ColumnValue> columnValues, String shard, String keyspace) {
+        return newFieldEvent(columnValues, shard, keyspace, false);
+    }
+
+    public static Binlogdata.VEvent newFieldEvent(List<ColumnValue> columnValues, String shard, String keyspace, boolean enumSetStringsValues) {
         Binlogdata.FieldEvent.Builder fieldEventBuilder = Binlogdata.FieldEvent.newBuilder()
+                .setEnumSetStringValues(enumSetStringsValues)
                 .setTableName(getFullTableName(keyspace, TEST_TABLE));
         for (Field field : newFields(columnValues)) {
             fieldEventBuilder.addFields(field);


### PR DESCRIPTION
See this [message](https://debezium.zulipchat.com/#narrow/channel/348255-community-vitess/topic/VStream.20ENUM.20.2F.20SET.20Changes/near/435005995) for core logic used. We read this new flag that is set by newer vitess versions to indicate if the enum/set values are strings (previously only in snapshot, going forward is in snapshot & regular phase).

This makes Debezium forward compatible with Vitess upgrades to v20+ so we handle enum/set types correctly.

Without these changes, if https://github.com/debezium/debezium/pull/6079 is merged then tests trivially fail. With these changes and that other PR then tests pass.

Right now, since the main upgrade isn't merged, tests trivially pass (does not use any of the new code)