### PR TITLE
DBZ-8594 Prevent data loss when primary key update is last operation in transaction

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
@@ -94,16 +94,25 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
 
     private ReplicationMessageProcessor newReplicationMessageProcessor(VitessPartition partition,
                                                                        VitessOffsetContext offsetContext) {
-        return (message, newVgtid, isLastRowOfTransaction) -> {
+        return (message, newVgtid) -> {
             if (message.isTransactionalMessage()) {
-                // Tx BEGIN/END event
-                offsetContext.rotateVgtid(newVgtid, message.getCommitTime());
+                // Tx BEGIN/COMMIT event
                 if (message.getOperation() == ReplicationMessage.Operation.BEGIN) {
+                    // When BEGIN event is received, newVgtid will have been populated with the transaction's vgtid, rotate
+                    // to set currentVgtid to newVgtid and restartVgtid to the previous transaction VGTID
+                    offsetContext.rotateVgtid(newVgtid, message.getCommitTime());
                     // send to transaction topic
                     VitessTransactionInfo transactionInfo = new VitessTransactionInfo(message.getTransactionId(), message.getShard());
                     dispatcher.dispatchTransactionStartedEvent(partition, transactionInfo, offsetContext, message.getCommitTime());
                 }
                 else if (message.getOperation() == ReplicationMessage.Operation.COMMIT) {
+                    // When COMMIT event is received, all events have been processed except for this COMMIT event
+                    // We reset the VGTID such that current & restart VGTIDs are equal to this transaction's VGTID
+                    // We send one final event (transaction committed), the offset will only be committed if that event
+                    // is sent successfully.
+                    // If transaction metadata is disabled, then the offset will not be updated until a message of the next
+                    // transaction is sent (next transaction's restartVgtid = this transaction's currentVgtid)
+                    offsetContext.resetVgtid(newVgtid, message.getCommitTime());
                     // send to transaction topic
                     dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext, message.getCommitTime());
                     // Send a heartbeat event if time has elapsed
@@ -154,10 +163,6 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
 
                 offsetContext.event(tableId, message.getCommitTime());
                 offsetContext.setShard(message.getShard());
-                if (isLastRowOfTransaction) {
-                    // Right before processing the last row, reset the previous offset to the new vgtid so the last row has the new vgtid as offset.
-                    offsetContext.resetVgtid(newVgtid, message.getCommitTime());
-                }
                 dispatcher.dispatchDataChangeEvent(
                         partition,
                         tableId,

--- a/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
@@ -105,7 +105,7 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
                     VitessTransactionInfo transactionInfo = new VitessTransactionInfo(message.getTransactionId(), message.getShard());
                     dispatcher.dispatchTransactionStartedEvent(partition, transactionInfo, offsetContext, message.getCommitTime());
                 }
-                else if (message.getOperation() == ReplicationMessage.Operation.COMMIT) {
+                else {
                     // When COMMIT event is received, all events have been processed except for this COMMIT event
                     // We reset the VGTID such that current & restart VGTIDs are equal to this transaction's VGTID
                     // We send one final event (transaction committed), the offset will only be committed if that event
@@ -118,7 +118,6 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
                     // Send a heartbeat event if time has elapsed
                     dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
                 }
-                return;
             }
             else if (message.getOperation() == ReplicationMessage.Operation.OTHER) {
                 offsetContext.rotateVgtid(newVgtid, message.getCommitTime());

--- a/src/main/java/io/debezium/connector/vitess/connection/MessageDecoder.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/MessageDecoder.java
@@ -14,7 +14,7 @@ import binlogdata.Binlogdata;
 /** Decode VStream gRPC VEvent and process it with the ReplicationMessageProcessor. */
 public interface MessageDecoder {
 
-    void processMessage(Binlogdata.VEvent event, ReplicationMessageProcessor processor, Vgtid newVgtid, boolean isLastRowEventOfTransaction,
+    void processMessage(Binlogdata.VEvent event, ReplicationMessageProcessor processor, Vgtid newVgtid,
                         boolean isInVStreamCopy)
             throws InterruptedException;
 

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageProcessor.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageProcessor.java
@@ -12,9 +12,8 @@ public interface ReplicationMessageProcessor {
     /**
      * Processes the given replication message.
      *
-     * @param message The replication message, never {@code null}.
+     * @param message  The replication message, never {@code null}.
      * @param newVgtid The VGTID in the gRPC response, can be {@code null}.
-     * @param isLastRowOfTransaction Whether the message is the last row change of the last row event of the transaction.
      */
-    void process(ReplicationMessage message, Vgtid newVgtid, boolean isLastRowOfTransaction) throws InterruptedException;
+    void process(ReplicationMessage message, Vgtid newVgtid) throws InterruptedException;
 }

--- a/src/main/java/io/debezium/connector/vitess/connection/TransactionalMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/TransactionalMessage.java
@@ -18,6 +18,9 @@ public class TransactionalMessage implements ReplicationMessage {
     private final String shard;
 
     public TransactionalMessage(Operation operation, String transactionId, Instant commitTime, String keyspace, String shard) {
+        if (operation != Operation.BEGIN && operation != Operation.COMMIT) {
+            throw new IllegalArgumentException("TransactionalMessage can only have BEGIN or COMMIT operations");
+        }
         this.transactionId = transactionId;
         this.commitTime = commitTime;
         this.operation = operation;

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -233,11 +233,10 @@ public class VitessReplicationConnection implements ReplicationConnection {
                         if (event.getType() == Binlogdata.VEventType.ROW) {
                             rowEventSeen++;
                         }
-                        boolean isLastRowEventOfTransaction = newVgtid != null && numOfRowEvents != 0 && rowEventSeen == numOfRowEvents;
                         if (isInVStreamCopy && event.getType() == Binlogdata.VEventType.COPY_COMPLETED) {
                             isInVStreamCopy = false;
                         }
-                        messageDecoder.processMessage(bufferedEvents.get(i), processor, newVgtid, isLastRowEventOfTransaction, isInVStreamCopy);
+                        messageDecoder.processMessage(bufferedEvents.get(i), processor, newVgtid, isInVStreamCopy);
                     }
                 }
                 catch (InterruptedException e) {

--- a/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/Gtid.java
+++ b/src/main/java/io/debezium/connector/vitess/pipeline/txmetadata/Gtid.java
@@ -8,11 +8,12 @@ package io.debezium.connector.vitess.pipeline.txmetadata;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import io.debezium.DebeziumException;
 
-class Gtid {
+public class Gtid {
 
     public String getVersion() {
         return version;
@@ -53,7 +54,7 @@ class Gtid {
         }
     }
 
-    Gtid(String transactionId) {
+    public Gtid(String transactionId) {
         try {
             initializeVersion(transactionId);
             parseGtid(transactionId);
@@ -79,5 +80,36 @@ class Gtid {
 
     public boolean isHostSetSupersetOf(Gtid otherHosts) {
         return this.hosts.containsAll(otherHosts.hosts);
+    }
+
+    @Override
+    public String toString() {
+        return "Gtid{"
+                + "versions="
+                + version
+                + ", hosts="
+                + hosts
+                + ", sequenceValues="
+                + sequenceValues
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Gtid gtid = (Gtid) o;
+        return Objects.equals(version, gtid.version) &&
+                Objects.equals(hosts, gtid.hosts) &&
+                Objects.equals(sequenceValues, gtid.sequenceValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, hosts, sequenceValues);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
@@ -87,7 +87,7 @@ public class VitessBigIntUnsignedTest {
                 (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig));
         decoder = new VStreamOutputMessageDecoder(schema);
         // initialize schema by FIELD event
-        decoder.processMessage(TestHelper.newFieldEvent(defaultColumnValues(mode)), null, null, false, false);
+        decoder.processMessage(TestHelper.newFieldEvent(defaultColumnValues(mode)), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
         assertThat(table.columnWithName("bigint_unsigned_col").jdbcType() == Types.BIGINT);
 

--- a/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
@@ -38,7 +38,7 @@ public class VitessChangeRecordEmitterTest {
                 (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig));
         decoder = new VStreamOutputMessageDecoder(schema);
         // initialize schema by FIELD event
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -2169,7 +2169,8 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         startConnector(Function.identity(), hasMultipleShards, offsetStoragePerTask, numTasks, gen, 1, null, "");
 
         consumer = testConsumer(1);
-        executeAndWait("INSERT INTO pk_single_unique_key_table (id, int_col) VALUES (1, 1);", TEST_UNSHARDED_KEYSPACE);
+        executeAndWait("INSERT INTO pk_single_unique_key_table (id, int_col) VALUES (1, 1);",
+                TEST_UNSHARDED_KEYSPACE);
 
         SourceRecord record = consumer.remove();
         Map<String, ?> prevOffset = record.sourceOffset();

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -81,7 +81,7 @@ public class VitessReplicationConnectionIT {
         AtomicBoolean started = new AtomicBoolean(false);
         connection.startStreaming(
                 startingVgtid,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     if (!started.get()) {
                         started.set(true);
                     }
@@ -125,7 +125,7 @@ public class VitessReplicationConnectionIT {
         AtomicBoolean started = new AtomicBoolean(false);
         connection.startStreaming(
                 startingVgtid,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     if (!started.get()) {
                         started.set(true);
                     }
@@ -168,7 +168,7 @@ public class VitessReplicationConnectionIT {
         AtomicBoolean started = new AtomicBoolean(false);
         connection.startStreaming(
                 startingVgtid,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     if (!started.get()) {
                         started.set(true);
                     }
@@ -212,7 +212,7 @@ public class VitessReplicationConnectionIT {
         AtomicBoolean started = new AtomicBoolean(false);
         connection.startStreaming(
                 startingVgtid,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     if (!started.get()) {
                         started.set(true);
                     }
@@ -252,7 +252,7 @@ public class VitessReplicationConnectionIT {
             AtomicBoolean started = new AtomicBoolean(false);
             connection.startStreaming(
                     startingVgtid,
-                    (message, vgtid, isLastRowEventOfTransaction) -> {
+                    (message, vgtid) -> {
                         if (!started.get()) {
                             started.set(true);
                         }
@@ -319,7 +319,7 @@ public class VitessReplicationConnectionIT {
             AtomicBoolean started = new AtomicBoolean(false);
             connection.startStreaming(
                     startingVgtid,
-                    (message, vgtid, isLastRowEventOfTransaction) -> {
+                    (message, vgtid) -> {
                         if (!started.get()) {
                             started.set(true);
                         }
@@ -381,7 +381,7 @@ public class VitessReplicationConnectionIT {
             AtomicBoolean started = new AtomicBoolean(false);
             connection.startStreaming(
                     startingVgtid,
-                    (message, vgtid, isLastRowEventOfTransaction) -> {
+                    (message, vgtid) -> {
                         if (!started.get()) {
                             started.set(true);
                         }
@@ -490,7 +490,7 @@ public class VitessReplicationConnectionIT {
             BlockingQueue<MessageAndVgtid> consumedMessages = new ArrayBlockingQueue<>(100);
             connection.startStreaming(
                     startingVgtid,
-                    (message, vgtid, isLastRowEventOfTransaction) -> {
+                    (message, vgtid) -> {
                         consumedMessages.add(new MessageAndVgtid(message, vgtid));
                     },
                     error);
@@ -566,7 +566,7 @@ public class VitessReplicationConnectionIT {
             AtomicBoolean started = new AtomicBoolean(false);
             connection.startStreaming(
                     startingVgtid,
-                    (message, vgtid, isLastRowEventOfTransaction) -> {
+                    (message, vgtid) -> {
                         if (!started.get()) {
                             started.set(true);
                         }
@@ -649,7 +649,7 @@ public class VitessReplicationConnectionIT {
             BlockingQueue<MessageAndVgtid> consumedMessages = new ArrayBlockingQueue<>(100);
             connection.startStreaming(
                     startingVgtid,
-                    (message, vgtid, isLastRowEventOfTransaction) -> {
+                    (message, vgtid) -> {
                         consumedMessages.add(new MessageAndVgtid(message, vgtid));
                     },
                     error);

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
@@ -107,7 +107,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldGetInt64SchemaBuilderForTime() throws InterruptedException {
-        decoder.processMessage(temporalFieldEvent(), null, null, false, false);
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("time_col");
@@ -118,7 +118,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldGetYearSchemaBuilderForYear() throws InterruptedException {
-        decoder.processMessage(temporalFieldEvent(), null, null, false, false);
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("year_col");
@@ -129,7 +129,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldConverterWorkForTimeColumn() throws InterruptedException {
-        decoder.processMessage(temporalFieldEvent(), null, null, false, false);
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("time_col");
@@ -142,7 +142,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldConverterWorkForEnumColumnString() throws InterruptedException {
-        decoder.processMessage(enumFieldEventString(), null, null, false, true);
+        decoder.processMessage(enumFieldEventString(), null, null, true);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("enum_col");
@@ -155,7 +155,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldConverterReturnEmptyStringForInvalid() throws InterruptedException {
-        decoder.processMessage(enumFieldEventString(), null, null, false, true);
+        decoder.processMessage(enumFieldEventString(), null, null, true);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("enum_col");
@@ -167,7 +167,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldConverterWorkForEnumColumnIntToString() throws InterruptedException {
-        decoder.processMessage(enumFieldEventInt(), null, null, false, false);
+        decoder.processMessage(enumFieldEventInt(), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("enum_col");
@@ -181,7 +181,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldConverterWorkForSetColumnString() throws InterruptedException {
-        decoder.processMessage(enumFieldEventString(), null, null, false, true);
+        decoder.processMessage(enumFieldEventString(), null, null, true);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("set_col");
@@ -194,7 +194,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldConverterWorkForSetColumnIntToString() throws InterruptedException {
-        decoder.processMessage(enumFieldEventInt(), null, null, false, false);
+        decoder.processMessage(enumFieldEventInt(), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("set_col");
@@ -207,7 +207,7 @@ public class VitessValueConverterTest {
 
     @Test
     public void shouldConverterWorkForDatetimeColumn() throws InterruptedException {
-        decoder.processMessage(temporalFieldEvent(), null, null, false, false);
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         Column column = table.columnWithName("datetime_col");

--- a/src/test/java/io/debezium/connector/vitess/connection/TransactionalMessageTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/TransactionalMessageTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import io.debezium.connector.vitess.TestHelper;
+
+/**
+ * @author Thomas Thornton
+ */
+public class TransactionalMessageTest {
+
+    @Test
+    public void shouldInstantiateBeginMessage() {
+        ReplicationMessage message = new TransactionalMessage(
+                ReplicationMessage.Operation.BEGIN, "tx_id", Instant.now(), TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        assertThat(message.isTransactionalMessage()).isTrue();
+        assertThat(message.getOperation()).isEqualTo(ReplicationMessage.Operation.BEGIN);
+    }
+
+    @Test
+    public void shouldInstantiateCommitMessage() {
+        ReplicationMessage message = new TransactionalMessage(
+                ReplicationMessage.Operation.COMMIT, "tx_id", Instant.now(), TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        assertThat(message.isTransactionalMessage()).isTrue();
+        assertThat(message.getOperation()).isEqualTo(ReplicationMessage.Operation.COMMIT);
+    }
+
+    @Test
+    public void shouldThrowExceptionForNonTransactionalOperation() {
+        assertThatThrownBy(() -> {
+            new TransactionalMessage(
+                    ReplicationMessage.Operation.INSERT, "tx_id", Instant.now(), TestHelper.TEST_UNSHARDED_KEYSPACE, TestHelper.TEST_SHARD);
+        }).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("TransactionalMessage can only have BEGIN or COMMIT operations");
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
@@ -65,7 +65,7 @@ public class VStreamOutputMessageDecoderTest {
         final boolean[] processed = { false };
         decoder.processMessage(
                 event,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(TransactionalMessage.class);
@@ -76,7 +76,6 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 newVgtid,
-                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -96,7 +95,7 @@ public class VStreamOutputMessageDecoderTest {
         final boolean[] processed = { false };
         decoder.processMessage(
                 event,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(HeartbeatMessage.class);
@@ -104,7 +103,6 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 newVgtid,
-                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -122,7 +120,7 @@ public class VStreamOutputMessageDecoderTest {
         final boolean[] processed = { false };
         decoder.processMessage(
                 event,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(TransactionalMessage.class);
@@ -130,7 +128,6 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
-                false,
                 false);
         assertThat(processed[0]).isFalse();
     }
@@ -151,7 +148,7 @@ public class VStreamOutputMessageDecoderTest {
         final boolean[] processed = { false };
         decoder.processMessage(
                 event,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(TransactionalMessage.class);
@@ -162,7 +159,6 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 newVgtid,
-                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -180,7 +176,7 @@ public class VStreamOutputMessageDecoderTest {
         final boolean[] processed = { false };
         decoder.processMessage(
                 event,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(TransactionalMessage.class);
@@ -188,7 +184,6 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
-                false,
                 false);
         assertThat(processed[0]).isFalse();
     }
@@ -206,7 +201,7 @@ public class VStreamOutputMessageDecoderTest {
         final boolean[] processed = { false };
         decoder.processMessage(
                 event,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(DdlMessage.class);
@@ -214,7 +209,6 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
-                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -231,7 +225,7 @@ public class VStreamOutputMessageDecoderTest {
         final boolean[] processed = { false };
         decoder.processMessage(
                 event,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(OtherMessage.class);
@@ -239,7 +233,6 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
-                false,
                 false);
         assertThat(processed[0]).isTrue();
     }
@@ -247,7 +240,7 @@ public class VStreamOutputMessageDecoderTest {
     @Test
     public void shouldProcessFieldEvent() throws Exception {
         // exercise SUT
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         // verify outcome
@@ -266,7 +259,7 @@ public class VStreamOutputMessageDecoderTest {
         List<TestHelper.ColumnValue> columnValues = List.of(new TestHelper.ColumnValue("enum", Query.Type.ENUM, Types.VARCHAR, "foo".getBytes(), "foo"));
         Binlogdata.VEvent event = TestHelper.newFieldEvent(columnValues, TestHelper.TEST_SHARD, TestHelper.TEST_UNSHARDED_KEYSPACE, false);
 
-        decoder.processMessage(event, null, null, false, false);
+        decoder.processMessage(event, null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         // verify outcome
@@ -290,7 +283,7 @@ public class VStreamOutputMessageDecoderTest {
                 new TestHelper.ColumnValue("set", Query.Type.SET, Types.VARCHAR, "foo".getBytes(), "foo", List.of("foo", "bar"), "set"));
         Binlogdata.VEvent event = TestHelper.newFieldEvent(columnValues, TestHelper.TEST_SHARD, TestHelper.TEST_UNSHARDED_KEYSPACE, true);
 
-        decoder.processMessage(event, null, null, false, false);
+        decoder.processMessage(event, null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         // verify outcome
@@ -310,9 +303,9 @@ public class VStreamOutputMessageDecoderTest {
         String shard2 = "80-";
         // exercise SUT
         decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard1, TestHelper.TEST_SHARDED_KEYSPACE),
-                null, null, false, false);
+                null, null, false);
         decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
-                null, null, false, false);
+                null, null, false);
         Table table = schema.tableFor(new TableId(shard1, TestHelper.TEST_SHARDED_KEYSPACE, TestHelper.TEST_TABLE));
 
         // verify outcome
@@ -326,7 +319,7 @@ public class VStreamOutputMessageDecoderTest {
 
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.columnValuesSubset(), shard1, TestHelper.TEST_SHARDED_KEYSPACE),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -334,11 +327,11 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.columnSubsetNumOfColumns());
                 },
-                null, false, false);
+                null, false);
 
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -346,11 +339,11 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.columnSubsetNumOfColumns());
                 },
-                null, false, false);
+                null, false);
 
         // update schema for shard 2
         decoder.processMessage(TestHelper.newFieldEvent(TestHelper.defaultColumnValues(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
-                null, null, false, false);
+                null, null, false);
         Table tableAfterSchemaChange = schema.tableFor(new TableId(shard2, TestHelper.TEST_SHARDED_KEYSPACE, TestHelper.TEST_TABLE));
 
         // verify outcome
@@ -365,7 +358,7 @@ public class VStreamOutputMessageDecoderTest {
         // shard 2 has been updated with new schema, so should handle values that match the new schema
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.defaultColumnValues(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -373,12 +366,12 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                 },
-                null, false, false);
+                null, false);
 
         // shard 1 has not been updated with new schema so it should still be able to handle values with the old schema
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.columnValuesSubset(), shard1, TestHelper.TEST_SHARDED_KEYSPACE),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -386,7 +379,7 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.columnSubsetNumOfColumns());
                 },
-                null, false, false);
+                null, false);
     }
 
     @Test
@@ -395,9 +388,9 @@ public class VStreamOutputMessageDecoderTest {
         String shard2 = "80-";
         // exercise SUT
         decoder.processMessage(TestHelper.defaultFieldEvent(shard1, TestHelper.TEST_SHARDED_KEYSPACE),
-                null, null, false, false);
+                null, null, false);
         decoder.processMessage(TestHelper.defaultFieldEvent(shard2, TestHelper.TEST_SHARDED_KEYSPACE),
-                null, null, false, false);
+                null, null, false);
         Table table = schema.tableFor(new TableId(shard1, TestHelper.TEST_SHARDED_KEYSPACE, TestHelper.TEST_TABLE));
 
         // verify outcome
@@ -411,7 +404,7 @@ public class VStreamOutputMessageDecoderTest {
 
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.defaultColumnValues(), shard1, TestHelper.TEST_SHARDED_KEYSPACE),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -419,11 +412,11 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                 },
-                null, false, false);
+                null, false);
 
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.defaultColumnValues(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -431,11 +424,11 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                 },
-                null, false, false);
+                null, false);
 
         // update schema for shard 2
         decoder.processMessage(TestHelper.newFieldEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
-                null, null, false, false);
+                null, null, false);
         Table tableAfterSchemaChange = schema.tableFor(new TableId(shard2, TestHelper.TEST_SHARDED_KEYSPACE, TestHelper.TEST_TABLE));
 
         // verify outcome
@@ -450,7 +443,7 @@ public class VStreamOutputMessageDecoderTest {
         // shard 2 has been updated with new schema, so should handle values that match the new schema
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.columnValuesSubset(), shard2, TestHelper.TEST_SHARDED_KEYSPACE),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -458,12 +451,12 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.columnSubsetNumOfColumns());
                 },
-                null, false, false);
+                null, false);
 
         // shard 1 has not been updated with new schema so it should still be able to handle values with the old schema
         decoder.processMessage(
                 TestHelper.insertEvent(TestHelper.defaultColumnValues(), shard1, TestHelper.TEST_SHARDED_KEYSPACE),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -471,13 +464,13 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getOldTupleList()).isNull();
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                 },
-                null, false, false);
+                null, false);
     }
 
     @Test
     public void shouldThrowExceptionWithDetailedMessageOnRowSchemaMismatch() throws Exception {
         // exercise SUT
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
         Table table = schema.tableFor(TestHelper.defaultTableId());
 
         // verify outcome
@@ -491,7 +484,7 @@ public class VStreamOutputMessageDecoderTest {
 
         assertThatThrownBy(() -> {
             decoder.processMessage(TestHelper.insertEvent(
-                    TestHelper.columnValuesSubset()), null, null, false, false);
+                    TestHelper.columnValuesSubset()), null, null, false);
         }).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("bool_col")
                 .hasMessageContaining("long_col");
@@ -500,14 +493,14 @@ public class VStreamOutputMessageDecoderTest {
     @Test
     public void shouldProcessInsertEvent() throws Exception {
         // setup fixture
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
         schema.tableFor(TestHelper.defaultTableId());
 
         // exercise SUT
         final boolean[] processed = { false };
         decoder.processMessage(
                 TestHelper.defaultInsertEvent(),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -517,21 +510,21 @@ public class VStreamOutputMessageDecoderTest {
                     assertThat(message.getNewTupleList().size()).isEqualTo(TestHelper.defaultNumOfColumns());
                     processed[0] = true;
                 },
-                null, false, false);
+                null, false);
         assertThat(processed[0]).isTrue();
     }
 
     @Test
     public void shouldProcessDeleteEvent() throws Exception {
         // setup fixture
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
         schema.tableFor(TestHelper.defaultTableId());
 
         // exercise SUT
         final boolean[] processed = { false };
         decoder.processMessage(
                 TestHelper.defaultDeleteEvent(),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -541,21 +534,21 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
-                false, false);
+                false);
         assertThat(processed[0]).isTrue();
     }
 
     @Test
     public void shouldProcessUpdateEvent() throws Exception {
         // setup fixture
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
         schema.tableFor(TestHelper.defaultTableId());
 
         // exercise SUT
         final boolean[] processed = { false };
         decoder.processMessage(
                 TestHelper.defaultUpdateEvent(),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message).isNotNull();
                     assertThat(message).isInstanceOf(VStreamOutputReplicationMessage.class);
@@ -565,7 +558,7 @@ public class VStreamOutputMessageDecoderTest {
                     processed[0] = true;
                 },
                 null,
-                false, false);
+                false);
         assertThat(processed[0]).isTrue();
     }
 
@@ -583,7 +576,7 @@ public class VStreamOutputMessageDecoderTest {
                 .setTimestamp(expectedCommitTimestamp)
                 .build();
         decoder.setCommitTimestamp(Instant.ofEpochSecond(commitEvent.getTimestamp()));
-        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false, false);
+        decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);
         schema.tableFor(TestHelper.defaultTableId());
         schema.tableFor(TestHelper.defaultTableId());
         Vgtid newVgtid = Vgtid.of(VgtidTest.VGTID_JSON);
@@ -591,44 +584,44 @@ public class VStreamOutputMessageDecoderTest {
         // exercise SUT
         decoder.processMessage(
                 beginEvent,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedBeginTimestamp);
                 },
                 newVgtid,
-                false, false);
+                false);
         decoder.processMessage(
                 TestHelper.defaultInsertEvent(),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 null,
-                false, false);
+                false);
         decoder.processMessage(
                 TestHelper.defaultUpdateEvent(),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 null,
-                false, false);
+                false);
         decoder.processMessage(
                 TestHelper.defaultDeleteEvent(),
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 null,
-                false, false);
+                false);
         decoder.processMessage(
                 commitEvent,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 newVgtid,
-                false, false);
+                false);
     }
 
     @Test
@@ -652,27 +645,27 @@ public class VStreamOutputMessageDecoderTest {
 
         decoder.processMessage(
                 otherEvent,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedEventTimestamp);
                 },
                 newVgtid,
-                false, false);
+                false);
         decoder.processMessage(
                 ddlEvent,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedEventTimestamp);
                 },
                 null,
-                false, false);
+                false);
         decoder.processMessage(
                 commitEvent,
-                (message, vgtid, isLastRowEventOfTransaction) -> {
+                (message, vgtid) -> {
                     // verify outcome
                     assertThat(message.getCommitTime().getEpochSecond()).isEqualTo(expectedCommitTimestamp);
                 },
                 null,
-                false, false);
+                false);
     }
 }

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -114,7 +114,7 @@ CREATE TABLE no_pk_table
 DROP TABLE IF EXISTS pk_single_unique_key_table;
 CREATE TABLE pk_single_unique_key_table
 (
-    id             BIGINT NOT NULL,
+    id             INT NOT NULL,
     int_col        INT,
     PRIMARY KEY (id),
     UNIQUE KEY unique_col (int_col)


### PR DESCRIPTION
We found an edge case described in [DBZ-8594](https://issues.redhat.com/browse/DBZ-8594)

There's another possible way to implement this: Modify VitessChangeRecordEmitter - we could modify our implementation to set the offset before emitting the final delete record [here](https://github.com/debezium/debezium/blob/main/debezium-core/src/main/java/io/debezium/relational/RelationalChangeRecordEmitter.java#L184). This would be possible but it seemed like a more custom solution, we'd prefer to be as standard as possible. Let me know if you think this is preferred. I think VitessOffsetContext would be called there to resetVgtid (and maybe in create/delete/update functions as well). The thing I don't like is we don't get the bug fixes or changes from the class we inherit from so we have to maintain more custom/overridden logic.

The main downside of this approach is seen in `testCopyTableAndRestart` ie if we do a special gtid (for snapshot or to speed up to current) then after that no other operations happen (no new vgtid's) then the restart vgtid is still the special one (snapshot or fastforward to current) so that operation would get repeated. Perhaps the gudiance we can give users is to enable transaction metadata (so begin/commit events are always sent even if tables are unaffected), but even that is not a guarantee.

Couple examples of other connectors I think may be at risk
[Postgres](https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java#L328-L331)
[SQL Server](https://github.com/debezium/debezium/blob/main/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java#L329)