### PR TITLE
DBZ-8679 Send string types with binary collation as strings

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -221,7 +221,7 @@ public class VitessValueConverter extends JdbcValueConverters {
      * @param upperCaseMatch the upper case form of the expected type or prefix of the type; may not be null
      * @return {@code true} if the type matches the specified type, or {@code false} otherwise
      */
-    protected boolean matches(String upperCaseTypeName, String upperCaseMatch) {
+    protected static boolean matches(String upperCaseTypeName, String upperCaseMatch) {
         if (upperCaseTypeName == null) {
             return false;
         }

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -105,6 +105,22 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
             + "longtext_col,"
             + "json_col)"
             + " VALUES ('a', 'bc', '상품 명1', 'リンゴ', 'gh', 'ij', 'kl', 'mn', '{\"key1\": \"value1\", \"key2\": {\"key21\": \"value21\", \"key22\": \"value22\"}}');";
+    protected static final String INSERT_CHAR_SET_COLLATE_STMT = "INSERT INTO character_set_collate_table (" +
+            "varchar_ascii_collate_ascii_bin_col," +
+            "varchar_col," +
+            "char_ascii_collate_ascii_bin_col," +
+            "char_col," +
+            "binary_ascii_collate_ascii_bin_col," +
+            "varbinary_col," +
+            "text_ascii_collate_ascii_bin_col," +
+            "text_col," +
+            "blob_ascii_collate_ascii_bin_col," +
+            "enum_ascii_collate_ascii_bin_col," +
+            "enum_col," +
+            "set_ascii_collate_ascii_bin_col," +
+            "set_col" +
+            ") " +
+            "VALUES (\"foo\", \"foo\", \"foobarfoo\", \"foobarfoo\", \"foobarfoo\", \"foo\", \"foo\", \"foo\", \"foo\", \"small\", \"small\", \"a\", \"a\");";
     protected static final String INSERT_BYTES_TYPES_STMT = "INSERT INTO string_table ("
             + "binary_col,"
             + "varbinary_col,"
@@ -188,6 +204,26 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField("longtext_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "mn"),
                         new SchemaAndValueField("json_col", Json.builder().optional().build(),
                                 "{\"key1\":\"value1\",\"key2\":{\"key21\":\"value21\",\"key22\":\"value22\"}}")));
+        return fields;
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForCharSetCollateTypes() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField("varchar_ascii_collate_ascii_bin_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "foo"),
+                        new SchemaAndValueField("varchar_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "foo"),
+                        new SchemaAndValueField("char_ascii_collate_ascii_bin_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "foobarfoo"),
+                        new SchemaAndValueField("char_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "foobarfoo"),
+                        new SchemaAndValueField("binary_ascii_collate_ascii_bin_col", SchemaBuilder.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("foobarfoo".getBytes())),
+                        new SchemaAndValueField("varbinary_col", SchemaBuilder.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("foo".getBytes())),
+                        new SchemaAndValueField("text_ascii_collate_ascii_bin_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "foo"),
+                        new SchemaAndValueField("text_col", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "foo"),
+                        new SchemaAndValueField("blob_ascii_collate_ascii_bin_col", SchemaBuilder.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("foo".getBytes())),
+                        new SchemaAndValueField("enum_ascii_collate_ascii_bin_col", io.debezium.data.Enum.builder("small,medium,large").optional().build(), "small"),
+                        new SchemaAndValueField("enum_col", io.debezium.data.Enum.builder("small,medium,large").optional().build(), "small"),
+                        new SchemaAndValueField("set_ascii_collate_ascii_bin_col", io.debezium.data.EnumSet.builder("a,b,c,d").optional().build(), "a"),
+                        new SchemaAndValueField("set_col", io.debezium.data.EnumSet.builder("a,b,c,d").optional().build(), "a")));
         return fields;
     }
 

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -1597,7 +1597,6 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         int expectedRecordsCount = 1;
         consumer = testConsumer(expectedRecordsCount);
-        System.out.println(INSERT_CHAR_SET_COLLATE_STMT);
         SourceRecord record = assertInsert(INSERT_CHAR_SET_COLLATE_STMT, schemasAndValuesForCharSetCollateTypes(), TEST_UNSHARDED_KEYSPACE, TestHelper.PK_FIELD,
                 hasMultipleShards);
     }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -142,7 +142,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
     @Test
     @FixFor("DBZ-2776")
-    public void shouldReceiveChangesForInsertsWithDifferentDataTypes() throws Exception {
+    public void shouldReceiveChangesForInsertsWithNumericTypes() throws Exception {
         TestHelper.executeDDL("vitess_create_tables.ddl");
         startConnector();
         assertConnectorIsRunning();
@@ -152,15 +152,48 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         consumer.expects(expectedRecordsCount);
         assertInsert(INSERT_NUMERIC_TYPES_STMT, schemasAndValuesForNumericTypes(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    @FixFor("DBZ-2776")
+    public void shouldReceiveChangesForInsertsWithStringTypes() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector();
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
 
         consumer.expects(expectedRecordsCount);
         assertInsert(INSERT_STRING_TYPES_STMT, schemasAndValuesForStringTypes(), TestHelper.PK_FIELD);
+    }
 
-        consumer.expects(expectedRecordsCount);
-        assertInsert(INSERT_BYTES_TYPES_STMT, schemasAndValuesForBytesTypesAsBytes(), TestHelper.PK_FIELD);
+    @Test
+    @FixFor("DBZ-2776")
+    public void shouldReceiveChangesForInsertsWithByteTypes() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector();
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
 
         consumer.expects(expectedRecordsCount);
         assertInsert(INSERT_SET_TYPE_STMT, schemasAndValuesForSetType(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    @FixFor("DBZ-2776")
+    public void shouldReceiveChangesForInsertsWithSetTypes() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector();
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_BYTES_TYPES_STMT, schemasAndValuesForBytesTypesAsBytes(), TestHelper.PK_FIELD);
     }
 
     @Test
@@ -1555,41 +1588,18 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     @Test
     @FixFor("DBZ-2578")
     public void shouldConvertVarcharCharacterSetCollateColumnToString() throws Exception {
-        final boolean hasMultipleShards = true;
+        final boolean hasMultipleShards = false;
 
-        TestHelper.executeDDL("vitess_create_tables.ddl", TEST_SHARDED_KEYSPACE);
+        TestHelper.executeDDL("vitess_create_tables.ddl", TEST_UNSHARDED_KEYSPACE);
         TestHelper.applyVSchema("vitess_vschema.json");
         startConnector(hasMultipleShards);
         assertConnectorIsRunning();
 
         int expectedRecordsCount = 1;
         consumer = testConsumer(expectedRecordsCount);
-        String varcharCharacterSetCollateColumnAsciiBin = "varchar_character_set_ascii_collate_ascii_bin_col";
-        String varcharCharacterSetCollateColumnAscii = "varchar_character_set_ascii_collate_ascii_col";
-        String varcharCharacterSetCollateColumnLatin1Bin = "varchar_character_set_ascii_collate_latin1_bin_col";
-        String varcharColumn = "varchar_col";
-        String varbinaryColumn = "varbinary_col";
-        String expectedVarchar = "foo";
-        String query = String.format("INSERT INTO character_set_collate_table (%s, %s, %s, %s, %s) VALUES (\"%s\", \"%s\", \"%s\", \"%s\", \"%s\");",
-                varcharCharacterSetCollateColumnAsciiBin,
-                varcharCharacterSetCollateColumnAscii,
-                varcharCharacterSetCollateColumnLatin1Bin,
-                varcharColumn,
-                varbinaryColumn,
-                expectedVarchar,
-                expectedVarchar,
-                expectedVarchar,
-                expectedVarchar,
-                expectedVarchar);
-        SourceRecord record = assertInsert(query, null, TEST_SHARDED_KEYSPACE, null, hasMultipleShards);
-        Struct recordValueStruct = (Struct) record.value();
-        Struct afterStruct = (Struct) recordValueStruct.get("after");
-        Object actualVarchar = afterStruct.get(varcharColumn);
-        assertThat(actualVarchar).isEqualTo(expectedVarchar);
-        assertThat(afterStruct.get(varcharCharacterSetCollateColumnAsciiBin)).isEqualTo(actualVarchar);
-        assertThat(afterStruct.get(varcharCharacterSetCollateColumnAscii)).isEqualTo(actualVarchar);
-        assertThat(afterStruct.get(varcharCharacterSetCollateColumnLatin1Bin)).isEqualTo(actualVarchar);
-        assertThat(afterStruct.get(varbinaryColumn).getClass()).isNotEqualTo(actualVarchar);
+        System.out.println(INSERT_CHAR_SET_COLLATE_STMT);
+        SourceRecord record = assertInsert(INSERT_CHAR_SET_COLLATE_STMT, schemasAndValuesForCharSetCollateTypes(), TEST_UNSHARDED_KEYSPACE, TestHelper.PK_FIELD,
+                hasMultipleShards);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
@@ -47,6 +47,20 @@ public class VitessTypeTest {
     }
 
     @Test
+    public void shouldResolveVitessTypeWhereColumnTypeDiffers() {
+        Query.Field varcharCollateBinary = Query.Field.newBuilder().setType(Query.Type.VARBINARY).setColumnType("varchar(32)").build();
+        assertThat(VitessType.resolve(varcharCollateBinary).getJdbcId()).isEqualTo(Types.VARCHAR);
+        Query.Field charCollateBinary = Query.Field.newBuilder().setType(Query.Type.BINARY).setColumnType("char(9)").build();
+        assertThat(VitessType.resolve(charCollateBinary).getJdbcId()).isEqualTo(Types.VARCHAR); // TODO: Why not char?
+        Query.Field binary = Query.Field.newBuilder().setType(Query.Type.BINARY).setColumnType("binary(9)").build();
+        assertThat(VitessType.resolve(binary).getJdbcId()).isEqualTo(Types.BINARY);
+        Query.Field varBinary = Query.Field.newBuilder().setType(Query.Type.VARBINARY).setColumnType("varbinary(9)").build();
+        assertThat(VitessType.resolve(varBinary).getJdbcId()).isEqualTo(Types.BINARY); // TODO: Why not varbinary
+        Query.Field textCollateBinary = Query.Field.newBuilder().setType(Query.Type.BLOB).setColumnType("text").build();
+        assertThat(VitessType.resolve(textCollateBinary).getJdbcId()).isEqualTo(Types.VARCHAR); // Why not
+    }
+
+    @Test
     public void shouldResolveEnumToVitessTypeWithIntMappingWhenNotInCopyPhase() {
         Query.Field enumField = Query.Field.newBuilder()
                 .setType(Query.Type.ENUM)

--- a/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
@@ -51,11 +51,11 @@ public class VitessTypeTest {
         Query.Field varcharCollateBinary = Query.Field.newBuilder().setType(Query.Type.VARBINARY).setColumnType("varchar(32)").build();
         assertThat(VitessType.resolve(varcharCollateBinary).getJdbcId()).isEqualTo(Types.VARCHAR);
         Query.Field charCollateBinary = Query.Field.newBuilder().setType(Query.Type.BINARY).setColumnType("char(9)").build();
-        assertThat(VitessType.resolve(charCollateBinary).getJdbcId()).isEqualTo(Types.VARCHAR); // TODO: Why not char?
+        assertThat(VitessType.resolve(charCollateBinary).getJdbcId()).isEqualTo(Types.VARCHAR);
         Query.Field binary = Query.Field.newBuilder().setType(Query.Type.BINARY).setColumnType("binary(9)").build();
         assertThat(VitessType.resolve(binary).getJdbcId()).isEqualTo(Types.BINARY);
         Query.Field varBinary = Query.Field.newBuilder().setType(Query.Type.VARBINARY).setColumnType("varbinary(9)").build();
-        assertThat(VitessType.resolve(varBinary).getJdbcId()).isEqualTo(Types.BINARY); // TODO: Why not varbinary
+        assertThat(VitessType.resolve(varBinary).getJdbcId()).isEqualTo(Types.BINARY);
         Query.Field textCollateBinary = Query.Field.newBuilder().setType(Query.Type.BLOB).setColumnType("text").build();
         assertThat(VitessType.resolve(textCollateBinary).getJdbcId()).isEqualTo(Types.VARCHAR); // Why not
     }

--- a/src/test/resources/vitess_create_tables.ddl
+++ b/src/test/resources/vitess_create_tables.ddl
@@ -157,10 +157,19 @@ CREATE TABLE comp_pk_table
 DROP TABLE IF EXISTS character_set_collate_table;
 CREATE TABLE character_set_collate_table
 (
-    id                                                   BIGINT NOT NULL,
-    `varchar_character_set_ascii_collate_ascii_bin_col`      VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
-    `varchar_character_set_ascii_collate_ascii_col`          VARCHAR(32) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
-    `varchar_character_set_ascii_collate_latin1_bin_col`     VARCHAR(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
-    `varchar_col`                                            VARCHAR(32) NOT NULL,
-    `varbinary_col`                                          VARBINARY(32) NOT NULL
+    id                                         BIGINT NOT NULL AUTO_INCREMENT,
+    `varchar_ascii_collate_ascii_bin_col`      VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin,
+    `varchar_col`                              VARCHAR(32),
+    `char_ascii_collate_ascii_bin_col`         CHAR(9) CHARACTER SET ascii COLLATE ascii_bin,
+    `char_col`                                 CHAR(9),
+    `binary_ascii_collate_ascii_bin_col`       BINARY(9), -- character set & collation are binary by default
+    `varbinary_col`                            VARBINARY(32), -- character set & collation are binary by default
+    `text_ascii_collate_ascii_bin_col`         TEXT CHARACTER SET ascii COLLATE ascii_bin,
+    `text_col`                                 TEXT,
+    `blob_ascii_collate_ascii_bin_col`         BLOB, -- character set & collation are binary by default
+    `enum_ascii_collate_ascii_bin_col`         ENUM('small', 'medium', 'large') CHARACTER SET ascii COLLATE ascii_bin DEFAULT 'medium',
+    `enum_col`                                 ENUM('small', 'medium', 'large') DEFAULT 'medium',
+    `set_ascii_collate_ascii_bin_col`          SET ('a', 'b', 'c', 'd') CHARACTER SET ascii COLLATE ascii_bin DEFAULT 'b',
+    `set_col`                                  SET ('a', 'b', 'c', 'd') DEFAULT 'b',
+    PRIMARY KEY (id)
 );


### PR DESCRIPTION
Ticket: [DBZ-8679](https://issues.redhat.com/browse/DBZ-8679)

We worked on this previously in [DBZ-6748](https://issues.redhat.com/browse/DBZ-6748) to do this for varchars. However, there are other string types (e.g., text, enum, set) that also experience the same issue (binary collation only affects ordering in mysql but affects how the vstream sends the data and ends up that the final change data value is treated as byte array). Added unit & integration tests to confirm the issue with this behavior. Introduced additional logic primarily in VitessType to allow for these data types to still be output as strings.