### PR TITLE
DBZ-8775 Add support for new VStream feature: streamKeyspaceHeartbeats

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -226,6 +226,15 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withDescription(
                     "Vitess Keyspace is equivalent to MySQL database (a.k.a schema). E.p. \"commerce\"");
 
+    public static final Field STREAM_KEYSPACE_HEARTBEATS = Field.create(VITESS_CONFIG_GROUP_PREFIX + "stream.keyspace.heartbeats")
+            .withDisplayName("stream.keyspace.heartbeats")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withDefault(false)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("Streams the events for the vitess heartbeat tables. Heartbeats must also be enabled on the Vitess tablets. " +
+                    "If a Debezium table include list is configured, the heartbeat table should be specified there, the format is `<keyspace>.heartbeat)`");
+
     public static final Field SHARD = Field.create(VITESS_CONFIG_GROUP_PREFIX + "shard")
             .withDisplayName("Shard")
             .withType(Type.STRING)
@@ -500,6 +509,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     OVERRIDE_DATETIME_TO_NULLABLE,
                     OFFSET_STORAGE_TASK_KEY_GEN,
                     PREV_NUM_TASKS,
+                    STREAM_KEYSPACE_HEARTBEATS,
                     EXCLUDE_EMPTY_SHARDS)
             .events(
                     INCLUDE_UNKNOWN_DATATYPES,
@@ -608,6 +618,10 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public boolean excludeEmptyShards() {
         return getConfig().getBoolean(EXCLUDE_EMPTY_SHARDS);
+    }
+
+    public boolean getStreamKeyspaceHeartbeats() {
+        return getConfig().getBoolean(STREAM_KEYSPACE_HEARTBEATS);
     }
 
     private static int validateVgtids(Configuration config, Field field, ValidationOutput problems) {

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -288,6 +288,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
         Vtgate.VStreamFlags vStreamFlags = Vtgate.VStreamFlags.newBuilder()
                 .setStopOnReshard(config.getStopOnReshard())
                 .setHeartbeatInterval(getHeartbeatSeconds())
+                .setStreamKeyspaceHeartbeats(config.getStreamKeyspaceHeartbeats())
                 .build();
         // Add filtering for whitelist tables
         Binlogdata.Filter.Builder filterBuilder = Binlogdata.Filter.newBuilder();

--- a/src/test/docker/Dockerfile
+++ b/src/test/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Use a temporary layer for the build stage.
 FROM quay.io/debezium/vitess-base:v19.0.4 AS base
 
-FROM quay.io/debezium/vitess-lite:v20.0.4
+FROM quay.io/debezium/vitess-lite:v21.0.3
 
 USER root
 

--- a/src/test/docker/local/initial_cluster.sh
+++ b/src/test/docker/local/initial_cluster.sh
@@ -46,7 +46,7 @@ wait_for_healthy_shard test_sharded_keyspace 80- || exit 1
 # start vttablets for non-empty shard of the keyspace test_empty_shard_keyspace
 for i in 400 401 402; do
 	CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
-	SHARD=-80 CELL=zone1 KEYSPACE=test_empty_shard_keyspace TABLET_UID=$i ./scripts/vttablet-up.sh
+	SHARD=-80 CELL=zone1 KEYSPACE=test_empty_shard_keyspace TABLET_UID=$i HEARTBEAT_ON_DEMAND=false ./scripts/vttablet-up.sh
 done
 
 # intentionally do not start any tablets in the 80- shard

--- a/src/test/docker/local/scripts/vttablet-up.sh
+++ b/src/test/docker/local/scripts/vttablet-up.sh
@@ -18,6 +18,7 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
 cell=${CELL:-'test'}
 keyspace=${KEYSPACE:-'test_keyspace'}
+heartbeat_on_demand=${HEARTBEAT_ON_DEMAND:-'true'}
 shard=${SHARD:-'0'}
 uid=$TABLET_UID
 mysql_port=$[17000 + $uid]
@@ -55,8 +56,8 @@ vttablet \
  --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
  --heartbeat_enable \
- --heartbeat_interval=250ms \
- --heartbeat_on_demand_duration=5s \
+ --heartbeat_interval 1s \
+ $( [[ $heartbeat_on_demand == "true" ]] && echo "--heartbeat_on_demand_duration=5s" ) \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 
 # Block waiting for the tablet to be listening

--- a/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
+++ b/src/test/java/io/debezium/connector/vitess/TableTopicNamingStrategyTest.java
@@ -43,6 +43,19 @@ public class TableTopicNamingStrategyTest {
     }
 
     @Test
+    public void shouldGetOverrideDataChangeTopicForHeartbeatTable() {
+        TableId tableId = new TableId("shard", "keyspace", "heartbeat");
+        final Properties props = new Properties();
+        props.put("topic.delimiter", ".");
+        props.put("topic.prefix", "prefix");
+        props.put(TableTopicNamingStrategy.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX_EXCLUDE_LIST.name(), "keyspace.heartbeat");
+        props.put(TableTopicNamingStrategy.OVERRIDE_DATA_CHANGE_TOPIC_PREFIX.name(), "override-prefix");
+        TopicNamingStrategy strategy = new TableTopicNamingStrategy(props);
+        String topicName = strategy.dataChangeTopic(tableId);
+        assertThat(topicName).isEqualTo("prefix.heartbeat");
+    }
+
+    @Test
     public void shouldUseTopicPrefixIfOverrideIsNotSpecified() {
         TableId tableId = new TableId("shard", "keyspace", "table");
         final Properties props = new Properties();

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -128,4 +128,20 @@ public class VitessConnectorConfigTest {
         assertThat(inputs.size()).isEqualTo(0);
     }
 
+    @Test
+    public void shouldEnableStreamKeyspaceHeartbeatsConfig() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.STREAM_KEYSPACE_HEARTBEATS, true)
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getStreamKeyspaceHeartbeats()).isTrue();
+    }
+
+    @Test
+    public void shouldDefaultDisableStreamKeyspaceHeartbeatsConfig() {
+        Configuration configuration = TestHelper.defaultConfig().build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getStreamKeyspaceHeartbeats()).isFalse();
+    }
+
 }


### PR DESCRIPTION
[DBZ-8775](https://issues.redhat.com/browse/DBZ-8775)

https://github.com/debezium/debezium/pull/6224 must first be merged (tests will fail trivially until then, once it's merged all tests will pass)

This was added in [Vitess v21](https://github.com/vitessio/vitess/issues/16477).

Add support to pass in this VStream API flag.

Since these heartbeat tables are regular data change events, add a config that allows user to pass in a regex exclude list for the override data change topic config (ie multiple connectors in the same DB streaming the same heartbeat table should output to separate topics).