### PR TITLE
DBZ-8824 Add integration test for keyspace heartbeats during snapshot

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -293,7 +293,6 @@ public class VitessReplicationConnection implements ReplicationConnection {
         // Add filtering for whitelist tables
         Binlogdata.Filter.Builder filterBuilder = Binlogdata.Filter.newBuilder();
         if (!Strings.isNullOrEmpty(config.tableIncludeList())) {
-            final String keyspace = config.getKeyspace();
             final List<String> allTables = new VitessMetadata(config).getTables();
             List<String> includedTables = VitessConnector.getIncludedTables(config, allTables);
             for (String table : includedTables) {

--- a/src/test/docker/local/scripts/vttablet-up.sh
+++ b/src/test/docker/local/scripts/vttablet-up.sh
@@ -19,6 +19,8 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 cell=${CELL:-'test'}
 keyspace=${KEYSPACE:-'test_keyspace'}
 heartbeat_on_demand=${HEARTBEAT_ON_DEMAND:-'true'}
+heartbeat_interval=${HEARTBEAT_INTERVAL:-'1s'}
+copy_phase_duration=${COPY_PHASE_DURATION:-'1h'}
 shard=${SHARD:-'0'}
 uid=$TABLET_UID
 mysql_port=$[17000 + $uid]
@@ -56,7 +58,8 @@ vttablet \
  --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
  --heartbeat_enable \
- --heartbeat_interval 1s \
+ --heartbeat_interval $heartbeat_interval \
+ --vreplication_copy_phase_duration $copy_phase_duration \
  $( [[ $heartbeat_on_demand == "true" ]] && echo "--heartbeat_on_demand_duration=5s" ) \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -44,6 +44,7 @@ public class TestHelper {
     public static final String TEST_UNSHARDED_KEYSPACE = "test_unsharded_keyspace";
     public static final String TEST_SHARDED_KEYSPACE = "test_sharded_keyspace";
     public static final String TEST_EMPTY_SHARD_KEYSPACE = "test_empty_shard_keyspace";
+    public static final String TEST_HEARTBEAT_KEYSPACE = "test_heartbeat_keyspace";
     public static final String TEST_NON_EMPTY_SHARD = "-80";
     public static final String TEST_SHARD = "0";
     public static final String TEST_SHARD1 = "-80";


### PR DESCRIPTION
[DBZ-8824](https://issues.redhat.com/browse/DBZ-8824)

Adds an integration test for keyspace heartbeats during a copy. In particular we need to verify that heartbeat events are not sent during the [catch up phase](https://github.com/vitessio/vitess/issues/6277) of a vstream copy. This is so that downstream users do not wrongfully trigger jobs during a snapshot (thinking data is all caught up).

A few other changes
1. Remove unused variables
2. DRY up some code
3. Extend some test utilities
4. Isolate heartbeat keyspace