### PR TITLE
DBZ-8826 Support temporal precision mode for strings

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessChangeRecordEmitter.java
@@ -103,7 +103,7 @@ class VitessChangeRecordEmitter extends RelationalChangeRecordEmitter<VitessPart
             final String columnName = Strings.unquoteIdentifierPart(column.getName());
             int position = getPosition(columnName, table, values.length);
             if (position != -1) {
-                Object value = column.getValue(connectorConfig.includeUnknownDatatypes());
+                Object value = column.getValue(connectorConfig.includeUnknownDatatypes(), connectorConfig.getTemporalPrecisionMode());
                 values[position] = value;
             }
             else {

--- a/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
@@ -129,7 +129,6 @@ public class VitessMetadata {
     private static List<String> getFlattenedRowsFromResponse(Vtgate.ExecuteResponse response) {
         validateResponse(response);
         Query.QueryResult result = response.getResult();
-        validateResult(result);
         List<List<String>> rows = parseRows(result.getRowsList());
         return flattenAndConcat(rows);
     }
@@ -137,18 +136,12 @@ public class VitessMetadata {
     private static List<List<String>> getRowsFromResponse(Vtgate.ExecuteResponse response) {
         validateResponse(response);
         Query.QueryResult result = response.getResult();
-        validateResult(result);
         return parseRows(result.getRowsList());
     }
 
     private static void validateResponse(Vtgate.ExecuteResponse response) {
         assert response != null && !response.hasError() && response.hasResult()
                 : String.format("Error response: %s", response);
-    }
-
-    private static void validateResult(Query.QueryResult result) {
-        List<Query.Row> rows = result.getRowsList();
-        assert !rows.isEmpty() : String.format("Empty response: %s", result);
     }
 
     @VisibleForTesting

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessage.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.List;
 
 import io.debezium.connector.vitess.VitessType;
+import io.debezium.jdbc.TemporalPrecisionMode;
 
 /**
  * Logic representation of a replication message. It can be a transactional message (begin, commit),
@@ -38,7 +39,7 @@ public interface ReplicationMessage {
          * Converts the value (string representation) coming from VStream to a Java value based on the
          * type of the column from the message.
          */
-        Object getValue(boolean includeUnknownDatatypes);
+        Object getValue(boolean includeUnknownDatatypes, TemporalPrecisionMode temporalPrecisionMode);
 
         boolean isOptional();
     }

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumn.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumn.java
@@ -10,6 +10,7 @@ import static io.debezium.connector.vitess.connection.ReplicationMessage.Column;
 import java.nio.charset.StandardCharsets;
 
 import io.debezium.connector.vitess.VitessType;
+import io.debezium.jdbc.TemporalPrecisionMode;
 
 /** Logical represenation of both column type and value. */
 public class ReplicationMessageColumn implements Column {
@@ -43,11 +44,11 @@ public class ReplicationMessageColumn implements Column {
     }
 
     @Override
-    public Object getValue(boolean includeUnknownDatatypes) {
+    public Object getValue(boolean includeUnknownDatatypes, TemporalPrecisionMode temporalPrecisionMode) {
         final VitessColumnValue columnValue = new VitessColumnValue(rawValue);
 
         return ReplicationMessageColumnValueResolver.resolveValue(
-                type, columnValue, includeUnknownDatatypes);
+                type, columnValue, includeUnknownDatatypes, temporalPrecisionMode);
     }
 
     public byte[] getRawValue() {

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -145,8 +145,10 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
     protected static final String TIMESTAMP = "2020-02-13 01:02:03";
 
     protected static final String ZERO_TIME = "00:00:00";
+    protected static final String ZERO_TIME_PRECISION4 = ZERO_TIME + ".0000";
     protected static final String ZERO_DATE = "0000-00-00";
     protected static final String ZERO_DATETIME = "0000-00-00 00:00:00";
+    protected static final String ZERO_DATETIME_PRECISION4 = ZERO_DATETIME + ".0000";
     protected static final String ZERO_TIMESTAMP = "0000-00-00 00:00:00";
     protected static final String ZERO_TIMESTAMP_PRECISION6 = ZERO_TIMESTAMP + ".000000";
     protected static final String ZERO_YEAR = "0000";
@@ -412,6 +414,25 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                                 "datetime_col", Timestamp.schema(), getMillisForDatetime(EPOCH_DATETIME, 0)),
                         new SchemaAndValueField(
                                 "datetime_col4", MicroTimestamp.schema(), getMicrosForDatetime(EPOCH_DATETIME_PRECISION4, 4)),
+                        new SchemaAndValueField(
+                                "timestamp_col", ZonedTimestamp.schema(), ZERO_TIMESTAMP),
+                        new SchemaAndValueField(
+                                "timestamp_col6", ZonedTimestamp.schema(), ZERO_TIMESTAMP_PRECISION6),
+                        new SchemaAndValueField("year_col", Year.schema(), Integer.valueOf(ZERO_YEAR))));
+        return fields;
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForTimeTypeZeroDateString() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField("time_col", Schema.STRING_SCHEMA, ZERO_TIME),
+                        new SchemaAndValueField("time_col4", Schema.STRING_SCHEMA, ZERO_TIME_PRECISION4),
+                        new SchemaAndValueField("date_col", Schema.STRING_SCHEMA, ZERO_DATE),
+                        new SchemaAndValueField(
+                                "datetime_col", Schema.STRING_SCHEMA, ZERO_DATETIME),
+                        new SchemaAndValueField(
+                                "datetime_col4", Schema.STRING_SCHEMA, ZERO_DATETIME_PRECISION4),
                         new SchemaAndValueField(
                                 "timestamp_col", ZonedTimestamp.schema(), ZERO_TIMESTAMP),
                         new SchemaAndValueField(

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -115,6 +115,10 @@ public class TestHelper {
         return defaultConfig(false, false, 1, -1, -1, null, VitessConnectorConfig.SnapshotMode.NEVER, TEST_SHARD, null, null);
     }
 
+    public static VitessConnectorConfig defaultConnectorConfig() {
+        return new VitessConnectorConfig(defaultConfig().build());
+    }
+
     /**
      * Get the default configuration of the connector
      *

--- a/src/test/java/io/debezium/connector/vitess/TestHelper.java
+++ b/src/test/java/io/debezium/connector/vitess/TestHelper.java
@@ -115,10 +115,6 @@ public class TestHelper {
         return defaultConfig(false, false, 1, -1, -1, null, VitessConnectorConfig.SnapshotMode.NEVER, TEST_SHARD, null, null);
     }
 
-    public static VitessConnectorConfig defaultConnectorConfig() {
-        return new VitessConnectorConfig(defaultConfig().build());
-    }
-
     /**
      * Get the default configuration of the connector
      *

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -565,6 +565,21 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     }
 
     @Test
+    public void shouldReceiveChangesForInsertsWithTimestampTypesPrecisionString() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(
+                VitessConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.ISOSTRING),
+                false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_TIME_TYPES_ZERO_VALUE_STMT, schemasAndValuesForTimeTypeZeroDateString(), TestHelper.PK_FIELD);
+    }
+
+    @Test
     public void shouldConsumeEventsWithTruncatedColumn() throws Exception {
         TestHelper.executeDDL("vitess_create_tables.ddl");
         final String truncateConfigValue = schemasAndValuesForStringTypesTruncated().stream().map(

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -33,6 +33,7 @@ import io.debezium.connector.vitess.connection.ReplicationMessage;
 import io.debezium.connector.vitess.connection.VitessReplicationConnection;
 import io.debezium.doc.FixFor;
 import io.debezium.heartbeat.Heartbeat;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.schema.DefaultTopicNamingStrategy;
@@ -605,11 +606,11 @@ public class VitessReplicationConnectionIT {
             assertThat(dml.getOldTupleList().get(0).getName()).isEqualTo("id");
             assertThat(dml.getOldTupleList().get(1).getName()).isEqualTo("int_col");
             assertThat(dml.getOldTupleList().get(2).getName()).isEqualTo("name");
-            assertThat(dml.getOldTupleList().get(2).getValue(false)).isNull();
+            assertThat(dml.getOldTupleList().get(2).getValue(false, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS)).isNull();
             assertThat(dml.getNewTupleList().get(0).getName()).isEqualTo("id");
             assertThat(dml.getNewTupleList().get(1).getName()).isEqualTo("int_col");
             assertThat(dml.getNewTupleList().get(2).getName()).isEqualTo("name");
-            assertThat(dml.getNewTupleList().get(2).getValue(false)).isEqualTo("abc");
+            assertThat(dml.getNewTupleList().get(2).getValue(false, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS)).isEqualTo("abc");
         }
         finally {
             if (error.get() != null) {

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTemporalTypesTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTemporalTypesTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import static io.debezium.connector.vitess.VitessValueConverterTest.temporalFieldEvent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneOffset;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
+import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.ValueConverter;
+import io.debezium.schema.DefaultTopicNamingStrategy;
+import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.spi.topic.TopicNamingStrategy;
+
+/**
+ * @author Thomas Thornton
+ */
+public class VitessValueConverterTemporalTypesTest {
+    /*
+     * Copyright Debezium Authors.
+     *
+     * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     */
+    private VitessDatabaseSchema schema;
+    private VitessValueConverter converter;
+    private VStreamOutputMessageDecoder decoder;
+
+    @Before
+    public void before() {
+        VitessConnectorConfig config = new VitessConnectorConfig(
+                TestHelper.defaultConfig().with(
+                        VitessConnectorConfig.TIME_PRECISION_MODE.name(), TemporalPrecisionMode.ISOSTRING).build());
+        converter = new VitessValueConverter(
+                config.getDecimalMode(),
+                config.getTemporalPrecisionMode(),
+                ZoneOffset.UTC,
+                config.binaryHandlingMode(),
+                config.includeUnknownDatatypes(),
+                config.getBigIntUnsgnedHandlingMode(),
+                false);
+        schema = new VitessDatabaseSchema(
+                config,
+                SchemaNameAdjuster.create(),
+                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(config));
+        decoder = new VStreamOutputMessageDecoder(schema);
+    }
+
+    @Test
+    public void shouldGetStringSchemaBuilderForTemporalTypesWithIsoStringTimePrecisionMode() throws InterruptedException {
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        for (String columnName : List.of("date_col", "time_col", "datetime_col")) {
+            Column column = table.columnWithName(columnName);
+            SchemaBuilder schemaBuilder = converter.schemaBuilder(column);
+            assertThat(schemaBuilder.schema()).isEqualTo(Schema.STRING_SCHEMA);
+        }
+    }
+
+    @Test
+    public void shouldConvertDatetimeToString() throws InterruptedException {
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        String col = "datetime_col";
+        Column column = table.columnWithName(col);
+        Field field = new Field(col, 2, Schema.STRING_SCHEMA);
+
+        ValueConverter valueConverter = converter.converter(column, field);
+        String datetimeString = "0000-00-00 00:00:00";
+        Object actual = valueConverter.convert(datetimeString);
+        assertThat(actual).isEqualTo(datetimeString);
+    }
+
+    @Test
+    public void shouldConvertTimeToString() throws InterruptedException {
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        String col = "time_col";
+        Column column = table.columnWithName(col);
+        Field field = new Field(col, 0, Schema.STRING_SCHEMA);
+
+        ValueConverter valueConverter = converter.converter(column, field);
+        String timeString = "00:00:00";
+        Object actual = valueConverter.convert(timeString);
+        assertThat(actual).isEqualTo(timeString);
+    }
+
+}

--- a/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import io.debezium.connector.vitess.AnonymousValue;
 import io.debezium.connector.vitess.VitessType;
+import io.debezium.jdbc.TemporalPrecisionMode;
 
 public class ReplicationMessageColumnTest {
 
@@ -23,7 +24,7 @@ public class ReplicationMessageColumnTest {
                 new VitessType(AnonymousValue.getString(), Types.INTEGER),
                 true,
                 "10".getBytes());
-        Object columnValue = column.getValue(false);
+        Object columnValue = column.getValue(false, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(columnValue).isEqualTo(10);
     }
 
@@ -34,6 +35,6 @@ public class ReplicationMessageColumnTest {
                 new VitessType(AnonymousValue.getString(), Types.INTEGER),
                 true,
                 "10.1".getBytes());
-        column.getValue(false);
+        column.getValue(false, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolverTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolverTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import io.debezium.connector.vitess.AnonymousValue;
 import io.debezium.connector.vitess.VitessType;
+import io.debezium.jdbc.TemporalPrecisionMode;
 
 public class ReplicationMessageColumnValueResolverTest {
 
@@ -26,7 +27,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.INTEGER),
                 new VitessColumnValue("10".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(10);
     }
 
@@ -35,7 +37,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.SMALLINT),
                 new VitessColumnValue("10".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo((short) 10);
     }
 
@@ -44,7 +47,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.BIGINT),
                 new VitessColumnValue("10".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(10L);
     }
 
@@ -53,7 +57,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.VARCHAR),
                 new VitessColumnValue("foo".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo("foo");
     }
 
@@ -62,7 +67,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.BLOB),
                 new VitessColumnValue("foo".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo("foo".getBytes());
     }
 
@@ -71,7 +77,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.BINARY),
                 new VitessColumnValue("foo".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo("foo".getBytes());
     }
 
@@ -80,7 +87,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.FLOAT),
                 new VitessColumnValue("1.1".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(1.1F);
     }
 
@@ -89,7 +97,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.DOUBLE),
                 new VitessColumnValue("1.1".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(1.1D);
     }
 
@@ -98,7 +107,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.OTHER),
                 new VitessColumnValue("foo".getBytes()),
-                true);
+                true,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo("foo");
     }
 
@@ -107,7 +117,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.OTHER),
                 new VitessColumnValue("foo".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isNull();
     }
 
@@ -116,8 +127,20 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.TIME),
                 new VitessColumnValue("01:02:03".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(Duration.ofSeconds(3 + 2 * 60 + 1 * 60 * 60));
+    }
+
+    @Test
+    public void shouldResolveTimeToString() {
+        String timeString = "01:02:03";
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.TIME),
+                new VitessColumnValue(timeString.getBytes()),
+                false,
+                TemporalPrecisionMode.ISOSTRING);
+        assertThat(resolvedJavaValue).isEqualTo(timeString);
     }
 
     @Test
@@ -125,7 +148,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.TIME),
                 new VitessColumnValue("01:02:03.666".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(Duration.ofMillis((3 + 2 * 60 + 1 * 60 * 60) * 1000 + 666));
     }
 
@@ -134,7 +158,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.TIME),
                 new VitessColumnValue("01:02:03.66".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(Duration.ofMillis(((3 + 2 * 60 + 1 * 60 * 60) * 100 + 66) * 10));
     }
 
@@ -145,8 +170,20 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.DATE),
                 new VitessColumnValue(date.getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(expectedDate);
+    }
+
+    @Test
+    public void shouldResolveDateToString() {
+        String date = "2020-02-12";
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.DATE),
+                new VitessColumnValue(date.getBytes()),
+                false,
+                TemporalPrecisionMode.ISOSTRING);
+        assertThat(resolvedJavaValue).isEqualTo(date);
     }
 
     @Test
@@ -155,7 +192,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.INTEGER),
                 new VitessColumnValue(year.getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(2020);
     }
 
@@ -164,7 +202,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.TIMESTAMP_WITH_TIMEZONE),
                 new VitessColumnValue("2020-02-12 01:02:03.1234".getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo("2020-02-12 01:02:03.1234");
     }
 
@@ -176,8 +215,21 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.TIMESTAMP),
                 new VitessColumnValue(timestampString.getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(expectedTimestamp);
+    }
+
+    @Test
+    public void shouldResolveDatetimeToString() {
+        String datetimeString = "2020-02-12 01:02:03";
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                // Datetime gets mapped to Types.TIMESTAMP by VitessType
+                new VitessType(AnonymousValue.getString(), Types.TIMESTAMP),
+                new VitessColumnValue(datetimeString.getBytes()),
+                false,
+                TemporalPrecisionMode.ISOSTRING);
+        assertThat(resolvedJavaValue).isEqualTo(datetimeString);
     }
 
     @Test
@@ -188,7 +240,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.TIMESTAMP),
                 new VitessColumnValue(timestampString.getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(expectedTimestamp);
     }
 
@@ -200,7 +253,8 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.TIMESTAMP),
                 new VitessColumnValue(timestampString.getBytes()),
-                false);
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
         assertThat(resolvedJavaValue).isEqualTo(expectedTimestamp);
     }
 }


### PR DESCRIPTION
[DBZ-8826](https://issues.redhat.com/browse/DBZ-8826)

We should also be able to output as strings for temporal types (time, date, datetime). Accomplish this by using the TemporalPrecisionMode.ISO_STRING mode. Note: In order to prevent loss of information, we customize the behavior compared to other connectors. Specifically, we want to ensure that impossible values like 0000-00-00 are still sent identical to their upstream values. Other connectors convert to a timestamp then back to a string (so converting 0000-00-00 fails). Instead, we do not do this conversion, and simply send the string value sent by MySQL.

Note: later we could modify debezium core to have a mode called RAW_STRING that does this. I went with this approach to keep things contained with vitess-connector and to not block on that. Later, If it's something we think other connectors want & we add it to core, then we can refactor the vitess-connector to use it.

Other changes
- Remove some code no longer needed
- Refactor some tests