### PR TITLE
DBZ-8861 Add workload name to all queries issued by Debezium

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -485,14 +485,6 @@ public class VitessReplicationConnection implements ReplicationConnection {
         return shardEpochMap;
     }
 
-    public String connectionString() {
-        return String.format("vtgate gRPC connection %s:%s", config.getVtgateHost(), config.getVtgatePort());
-    }
-
-    public String username() {
-        return config.getVtgateUsername();
-    }
-
     private static Topodata.TabletType toTopodataTabletType(VitessTabletType tabletType) {
         switch (tabletType) {
             case MASTER:

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorTest.java
@@ -733,6 +733,31 @@ public class VitessConnectorTest {
     }
 
     @Test
+    public void testValidatesConnection() {
+        Map<String, String> props = new HashMap<>() {
+            {
+                put("connector.class", "io.debezium.connector.vitess.VitessConnector");
+                put("database.hostname", "host1");
+                put("database.port", "15999");
+                put("database.user", "vitess");
+                put("database.password", "vitess-password");
+                put("vitess.keyspace", "byuser");
+                put("vitess.tablet.type", "MASTER");
+                put("database.server.name", "dummy");
+                put(VitessConnectorConfig.TASKS_MAX_CONFIG, "2");
+                put(VitessConnectorConfig.OFFSET_STORAGE_TASK_KEY_GEN.name(), "0");
+                put(VitessConnectorConfig.PREV_NUM_TASKS.name(), "1");
+            }
+        };
+        VitessConnector connector = new VitessConnector();
+        Map<String, ConfigValue> configs = connector.validateAllFields(Configuration.from(props));
+        connector.validateConnection(configs, Configuration.from(props));
+        assertThat(configs.get("database.hostname").errorMessages().size()).isEqualTo(1);
+        String expectedError = "Unable to connect: Unexpected error while running query: /*vt+ WORKLOAD_NAME=debezium */ SHOW DATABASES;";
+        assertThat(configs.get("database.hostname").errorMessages().get(0)).isEqualTo(expectedError);
+    }
+
+    @Test
     public void testTaskConfigsNegativeOffsetStorageTaskKeyGen() {
         Map<String, String> props = new HashMap<>() {
             {

--- a/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
@@ -19,6 +19,13 @@ import io.vitess.proto.Query;
 public class VitessMetadataTest {
 
     @Test
+    public void shouldInsertWorkloadNameInAllQueries() {
+        String expectedQuery = "/*vt+ WORKLOAD_NAME=debezium */ Select * keyspace.foo;";
+        String actualQuery = VitessMetadata.formatQuery("Select * %s.foo;", "keyspace");
+        assertThat(actualQuery).isEqualTo(expectedQuery);
+    }
+
+    @Test
     public void shouldGetNonEmptyShards() {
         List<List<String>> rowValues = List.of(
                 List.of("zone1", "keyspace", "-80", "PRIMARY", "SERVING", "zone1-001", "d55", "2024-07-11"),

--- a/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessEpochProviderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/pipeline/txmetadata/VitessEpochProviderTest.java
@@ -10,6 +10,7 @@ import static io.debezium.connector.vitess.TestHelper.TEST_SHARD1_EPOCH;
 import static io.debezium.connector.vitess.TestHelper.TEST_SHARD_TO_EPOCH;
 import static io.debezium.connector.vitess.TestHelper.VGTID_JSON_TEMPLATE;
 import static io.debezium.connector.vitess.TestHelper.VGTID_SINGLE_SHARD_JSON_TEMPLATE;
+import static io.debezium.connector.vitess.VgtidTest.TEST_SHARD2;
 import static io.debezium.connector.vitess.VgtidTest.VGTID_BOTH_CURRENT;
 import static io.debezium.connector.vitess.VgtidTest.VGTID_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -115,6 +116,8 @@ public class VitessEpochProviderTest {
                 Vgtid.EMPTY_GTID);
         Long epoch = provider.getEpoch(VgtidTest.TEST_SHARD, vgtidJsonEmpty, VGTID_JSON);
         assertThat(epoch).isEqualTo(1L);
+        // Both shards had their epoch incremented
+        assertThat(provider.getShardEpochMap().getMap()).isEqualTo(Map.of(TEST_SHARD1, 1L, TEST_SHARD2, 1L));
     }
 
     @Test


### PR DESCRIPTION
This is supported by [Vitess](https://vitess.io/docs/21.0/user-guides/configuration-advanced/comment-directives/#workload-name-workload_name) for tracking which application is issuing the queries. Add this workload name info in every query we use (refactor things so all queries are issued from VitessMetadata).

Also clarify one test I noticed can be stronger assertion (assert epoch incremented for all shards).