### PR TITLE
DBZ-9008 Log stack trace when connection fails

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnector.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnector.java
@@ -260,7 +260,7 @@ public class VitessConnector extends RelationalBaseSourceConnector {
             LOGGER.info("Successfully tested connection for {}", testVitessMetadata.getConnectionString());
         }
         catch (RuntimeException e) {
-            LOGGER.info("Failed testing connection for {} ", testVitessMetadata.getConnectionString());
+            LOGGER.error("Failed testing connection for " + testVitessMetadata.getConnectionString(), e);
             hostnameValue.addErrorMessage("Unable to connect: " + e.getMessage());
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9008

We were omitting the stack trace, use logger.error to include it as throwable arg.