### PR TITLE
DBZ-9014 Make load balancing policy configurable

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -349,14 +349,14 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withValidation(Field::isInteger)
             .withDescription("Specify the maximum message size in bytes allowed to be received on the channel.");
 
-    public static final Field GRPC_DEFAULT_LOAD_BALANCING_POLICY = Field.create(VITESS_CONFIG_GROUP_PREFIX + "grpc.default_load_balancing_policy")
+    public static final Field GRPC_DEFAULT_LOAD_BALANCING_POLICY = Field.create(VITESS_CONFIG_GROUP_PREFIX + "grpc.default.load.balancing.policy")
             .withDisplayName("VStream gRPC default load balancing policy")
             .withType(Type.STRING)
             .withWidth(Width.MEDIUM)
             .withDefault(GrpcUtil.DEFAULT_LB_POLICY)
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withValidation(VitessConnectorConfig::validateLoadBalancingPolicy)
-            .withDescription("Specify the maximum message size in bytes allowed to be received on the channel.");
+            .withDescription("Specify the default load balancing policy used to connect to Vitess, e.g., 'pick_first', 'round_robin'");
 
     public static final Field INCLUDE_UNKNOWN_DATATYPES = Field.create("include.unknown.datatypes")
             .withDisplayName("Include unknown datatypes")

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -68,7 +68,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
      */
     public Vtgate.ExecuteResponse execute(String sqlStatement) {
         LOGGER.debug("Executing sqlStament {}", sqlStatement);
-        ManagedChannel channel = newChannel(config.getVtgateHost(), config.getVtgatePort(), config.getGrpcMaxInboundMessageSize());
+        ManagedChannel channel = newChannel();
         managedChannel.compareAndSet(null, channel);
 
         Vtgate.ExecuteRequest request = Vtgate.ExecuteRequest.newBuilder()
@@ -79,7 +79,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
     public Vtgate.ExecuteResponse execute(String sqlStatement, String shard) {
         LOGGER.info("Executing sqlStament {}", sqlStatement);
-        ManagedChannel channel = newChannel(config.getVtgateHost(), config.getVtgatePort(), config.getGrpcMaxInboundMessageSize());
+        ManagedChannel channel = newChannel();
         managedChannel.compareAndSet(null, channel);
 
         String target = String.format("%s:%s@%s", config.getKeyspace(), shard, config.getTabletType());
@@ -97,7 +97,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
                                Vgtid vgtid, ReplicationMessageProcessor processor, AtomicReference<Throwable> error) {
         Objects.requireNonNull(vgtid);
 
-        ManagedChannel channel = newChannel(config.getVtgateHost(), config.getVtgatePort(), config.getGrpcMaxInboundMessageSize());
+        ManagedChannel channel = newChannel();
         managedChannel.compareAndSet(null, channel);
 
         VitessGrpc.VitessStub stub = newStub(channel);
@@ -349,10 +349,11 @@ public class VitessReplicationConnection implements ReplicationConnection {
         return stub;
     }
 
-    private ManagedChannel newChannel(String vtgateHost, int vtgatePort, int maxInboundMessageSize) {
-        ManagedChannel channel = ManagedChannelBuilder.forAddress(vtgateHost, vtgatePort)
+    private ManagedChannel newChannel() {
+        ManagedChannel channel = ManagedChannelBuilder.forAddress(config.getVtgateHost(), config.getVtgatePort())
+                .defaultLoadBalancingPolicy(config.getGrpcDefaultLoadBalancingPolicy())
                 .usePlaintext()
-                .maxInboundMessageSize(maxInboundMessageSize)
+                .maxInboundMessageSize(config.getGrpcMaxInboundMessageSize())
                 .keepAliveTime(config.getKeepaliveInterval().toMillis(), TimeUnit.MILLISECONDS)
                 .build();
         return channel;

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -83,6 +83,54 @@ public class VitessConnectorConfigTest {
     }
 
     @Test
+    public void shouldInvalidLoadBalancerPolicyFailValidation() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.GRPC_DEFAULT_LOAD_BALANCING_POLICY, "foo").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.GRPC_DEFAULT_LOAD_BALANCING_POLICY), printConsumer);
+        assertThat(inputs.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldRoundRobinLoadBalancerPolicyPassValidation() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.GRPC_DEFAULT_LOAD_BALANCING_POLICY, "round_robin").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.GRPC_DEFAULT_LOAD_BALANCING_POLICY), printConsumer);
+        assertThat(inputs.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldPickFirstLoadBalancerPolicyPassValidation() {
+        Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.GRPC_DEFAULT_LOAD_BALANCING_POLICY, "pick_first").build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.GRPC_DEFAULT_LOAD_BALANCING_POLICY), printConsumer);
+        assertThat(inputs.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldDefaultLoadBalancerPolicyPassValidation() {
+        Configuration configuration = TestHelper.defaultConfig().build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.GRPC_DEFAULT_LOAD_BALANCING_POLICY), printConsumer);
+        assertThat(inputs.size()).isEqualTo(0);
+    }
+
+    @Test
     public void shouldImproperShardEpochMapFailValidation() {
         Configuration configuration = TestHelper.defaultConfig().with(VitessConnectorConfig.SHARD_EPOCH_MAP, "foo").build();
         VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);


### PR DESCRIPTION
[DBZ-9014](https://issues.redhat.com/browse/DBZ-9014)

Make load balancing policy configurable.

The default is pick first (what it does currently when not specified). Round robin is also supported. Others may be added as well, so future proof it by keeping the config open as a string (with validation that the policy is supported for the current version).