### PR TITLE
DBZ-8966 use CustomConverter in serviceRegistry and remove usage in ConnectorConfiguration

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessDatabaseSchema.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessDatabaseSchema.java
@@ -11,6 +11,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.RelationalDatabaseSchema;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -28,7 +29,7 @@ public class VitessDatabaseSchema extends RelationalDatabaseSchema {
     public VitessDatabaseSchema(
                                 VitessConnectorConfig config,
                                 SchemaNameAdjuster schemaNameAdjuster,
-                                TopicNamingStrategy<TableId> topicNamingStrategy) {
+                                TopicNamingStrategy<TableId> topicNamingStrategy, CustomConverterRegistry customConverterRegistry) {
         super(
                 config,
                 topicNamingStrategy,
@@ -44,7 +45,7 @@ public class VitessDatabaseSchema extends RelationalDatabaseSchema {
                                 config.getBigIntUnsgnedHandlingMode(),
                                 config.overrideDatetimeToNullable()),
                         schemaNameAdjuster,
-                        config.customConverterRegistry(),
+                        customConverterRegistry,
                         config.getSourceInfoStructMaker().schema(),
                         config.getTransactionMetadataFactory().getTransactionStructMaker().getTransactionBlockSchema(),
                         config.getFieldNamer(),

--- a/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessBigIntUnsignedTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,6 +26,7 @@ import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
 import io.debezium.connector.vitess.connection.VStreamOutputReplicationMessage;
 import io.debezium.data.Envelope;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableSchema;
 import io.debezium.schema.DefaultTopicNamingStrategy;
@@ -91,7 +93,7 @@ public class VitessBigIntUnsignedTest {
         schema = new VitessDatabaseSchema(
                 connectorConfig,
                 SchemaNameAdjuster.create(),
-                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig));
+                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig), new CustomConverterRegistry(Collections.emptyList()));
         decoder = new VStreamOutputMessageDecoder(schema);
         // initialize schema by FIELD event
         decoder.processMessage(TestHelper.newFieldEvent(defaultColumnValues(mode)), null, null, false);

--- a/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessChangeRecordEmitterTest.java
@@ -7,6 +7,8 @@ package io.debezium.connector.vitess;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -20,6 +22,7 @@ import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
 import io.debezium.connector.vitess.connection.VStreamOutputReplicationMessage;
 import io.debezium.data.Envelope;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.spi.topic.TopicNamingStrategy;
@@ -44,7 +47,7 @@ public class VitessChangeRecordEmitterTest {
         schema = new VitessDatabaseSchema(
                 connectorConfig,
                 SchemaNameAdjuster.create(),
-                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig));
+                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig), new CustomConverterRegistry(Collections.emptyList()));
         decoder = new VStreamOutputMessageDecoder(schema);
         // initialize schema by FIELD event
         decoder.processMessage(TestHelper.defaultFieldEvent(), null, null, false);

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -1748,12 +1748,10 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         // Connector receives a row whose column name is not valid, task should fail
         TestHelper.execute("ALTER TABLE numeric_table ADD `@1` INT;");
         TestHelper.execute(INSERT_NUMERIC_TYPES_STMT);
-        // Connector should still be running & retrying
-        assertConnectorIsRunning();
-        assertTrue("The task is expected to keep retrying and not complete", isConnectorRunning.get());
-        stopConnector();
-        assertFalse("The connector should be stopped now", isConnectorRunning.get());
-        assertThat(logInterceptor.containsErrorMessage("Illegal prefix '@' for column: @1")).isTrue();
+
+        Awaitility.await()
+                .atMost(100, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(logInterceptor.containsErrorMessage("Illegal prefix '@' for column: @1")).isTrue());
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessReplicationConnectionIT.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -36,6 +37,7 @@ import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.schema.SchemaNameAdjuster;
@@ -68,7 +70,7 @@ public class VitessReplicationConnectionIT {
                         null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
                         "1", "skip").build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema);
@@ -112,7 +114,7 @@ public class VitessReplicationConnectionIT {
                         null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
                         "1", "warn").build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema);
@@ -155,7 +157,7 @@ public class VitessReplicationConnectionIT {
                         null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
                         "1", "fail").build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema);
@@ -199,7 +201,7 @@ public class VitessReplicationConnectionIT {
                         "1", null).build());
         conf.getEventProcessingFailureHandlingMode();
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema);
@@ -239,7 +241,7 @@ public class VitessReplicationConnectionIT {
         // setup fixture
         final VitessConnectorConfig conf = new VitessConnectorConfig(TestHelper.defaultConfig().build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         try (VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema)) {
@@ -306,7 +308,7 @@ public class VitessReplicationConnectionIT {
         final VitessConnectorConfig conf = new VitessConnectorConfig(TestHelper.defaultConfig().with(
                 Heartbeat.HEARTBEAT_INTERVAL, 1000).build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         try (VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema)) {
@@ -368,7 +370,7 @@ public class VitessReplicationConnectionIT {
         // setup fixture
         final VitessConnectorConfig conf = new VitessConnectorConfig(TestHelper.defaultConfig().build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         try (VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema)) {
@@ -478,7 +480,7 @@ public class VitessReplicationConnectionIT {
         final VitessConnectorConfig conf = new VitessConnectorConfig(TestHelper.defaultConfig()
                 .with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, tableInclude).build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         try (VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema)) {
@@ -554,7 +556,7 @@ public class VitessReplicationConnectionIT {
     public void shouldReturnUpdatedSchemaWithOnlineDdl() throws Exception {
         final VitessConnectorConfig conf = new VitessConnectorConfig(TestHelper.defaultConfig().build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
         AtomicReference<Throwable> error = new AtomicReference<>();
         try (VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema)) {
             Vgtid startingVgtid = Vgtid.of(
@@ -637,7 +639,7 @@ public class VitessReplicationConnectionIT {
         final VitessConnectorConfig conf = new VitessConnectorConfig(TestHelper.defaultConfig()
                 .with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, tableInclude).build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
-                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
+                conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf), new CustomConverterRegistry(Collections.emptyList()));
 
         AtomicReference<Throwable> error = new AtomicReference<>();
         try (VitessReplicationConnection connection = new VitessReplicationConnection(conf, vitessDatabaseSchema)) {

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTemporalTypesTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTemporalTypesTest.java
@@ -10,6 +10,7 @@ import static io.debezium.connector.vitess.VitessValueConverterTest.temporalFiel
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.kafka.connect.data.Field;
@@ -22,6 +23,7 @@ import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
 import io.debezium.relational.Column;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.Table;
 import io.debezium.relational.ValueConverter;
 import io.debezium.schema.DefaultTopicNamingStrategy;
@@ -60,7 +62,7 @@ public class VitessValueConverterTemporalTypesTest {
         schema = new VitessDatabaseSchema(
                 config,
                 SchemaNameAdjuster.create(),
-                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(config));
+                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(config), new CustomConverterRegistry(Collections.emptyList()));
         decoder = new VStreamOutputMessageDecoder(schema);
     }
 

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.kafka.connect.data.Field;
@@ -26,6 +27,7 @@ import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
 import io.debezium.relational.Column;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.Table;
 import io.debezium.relational.ValueConverter;
 import io.debezium.schema.DefaultTopicNamingStrategy;
@@ -61,7 +63,7 @@ public class VitessValueConverterTest {
         schema = new VitessDatabaseSchema(
                 config,
                 SchemaNameAdjuster.create(),
-                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(config));
+                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(config), new CustomConverterRegistry(Collections.emptyList()));
         decoder = new VStreamOutputMessageDecoder(schema);
     }
 

--- a/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VStreamOutputMessageDecoderTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.Types;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -26,6 +27,7 @@ import io.debezium.connector.vitess.VitessConnectorConfig;
 import io.debezium.connector.vitess.VitessDatabaseSchema;
 import io.debezium.doc.FixFor;
 import io.debezium.openlineage.DebeziumOpenLineageEmitter;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DefaultTopicNamingStrategy;
@@ -52,7 +54,7 @@ public class VStreamOutputMessageDecoderTest {
         schema = new VitessDatabaseSchema(
                 connectorConfig,
                 SchemaNameAdjuster.create(),
-                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig));
+                (TopicNamingStrategy) DefaultTopicNamingStrategy.create(connectorConfig), new CustomConverterRegistry(Collections.emptyList()));
         decoder = new VStreamOutputMessageDecoder(schema);
     }
 


### PR DESCRIPTION
## Context

Currently, the `CustomConverterRegistry` is retrieved from `ConnectorConfiguration`. This can lead to some issues:

- Multiple points of retrieval for the registry
- Mixing configuration with business logic

## Decision

Use the `ServiceRegistry` to retrieve the `CustomConverterRegistry`.

#depends https://github.com/debezium/debezium/pull/6553