### PR TITLE
DBZ 9176 Remove heartbeat creation from the configuration in favor of using `HeartbeatFactory`

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -5,8 +5,6 @@
  */
 package io.debezium.connector.vitess;
 
-import static io.debezium.config.ConfigurationNames.DATABASE_CONFIG_PREFIX;
-
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -35,15 +33,10 @@ import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.vitess.connection.VitessTabletType;
 import io.debezium.connector.vitess.pipeline.txmetadata.ShardEpochMap;
 import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionMetadataFactory;
-import io.debezium.heartbeat.Heartbeat;
-import io.debezium.heartbeat.HeartbeatConnectionProvider;
-import io.debezium.heartbeat.HeartbeatErrorHandler;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
-import io.debezium.schema.SchemaNameAdjuster;
-import io.debezium.spi.topic.TopicNamingStrategy;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.internal.GrpcUtil;
@@ -813,15 +806,6 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
     @Override
     public Optional<EnumeratedValue> getSnapshotLockingMode() {
         return Optional.empty();
-    }
-
-    @Override
-    public Heartbeat createHeartbeat(TopicNamingStrategy topicNamingStrategy, SchemaNameAdjuster schemaNameAdjuster,
-                                     HeartbeatConnectionProvider connectionProvider, HeartbeatErrorHandler errorHandler) {
-        if (getHeartbeatInterval().isZero()) {
-            return Heartbeat.DEFAULT_NOOP_HEARTBEAT;
-        }
-        return new VitessHeartbeatImpl(getHeartbeatInterval(), topicNamingStrategy.heartbeatTopic(), getLogicalName(), schemaNameAdjuster);
     }
 
     public BigIntUnsignedHandlingMode getBigIntUnsgnedHandlingMode() {

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorTask.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorTask.java
@@ -121,6 +121,8 @@ public class VitessConnectorTask extends BaseSourceTask<VitessPartition, VitessO
                     new Filters(connectorConfig).tableFilter(),
                     DataChangeEvent::new,
                     metadataProvider,
+                    new VitessHeartbeatFactory()
+                            .getScheduledHeartbeat(connectorConfig, null, null, queue),
                     schemaNameAdjuster,
                     connectorConfig.getServiceRegistry().tryGetService(DebeziumHeaderProducer.class));
 

--- a/src/main/java/io/debezium/connector/vitess/VitessHeartbeatFactory.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessHeartbeatFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess;
+
+import static io.debezium.config.CommonConnectorConfig.TOPIC_NAMING_STRATEGY;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.heartbeat.DebeziumHeartbeatFactory;
+import io.debezium.heartbeat.Heartbeat.ScheduledHeartbeat;
+import io.debezium.heartbeat.HeartbeatConnectionProvider;
+import io.debezium.heartbeat.HeartbeatErrorHandler;
+import io.debezium.pipeline.DataChangeEvent;
+
+public class VitessHeartbeatFactory implements DebeziumHeartbeatFactory {
+    @Override
+    public ScheduledHeartbeat getScheduledHeartbeat(CommonConnectorConfig connectorConfig, HeartbeatConnectionProvider connectionProvider,
+                                                    HeartbeatErrorHandler errorHandler, ChangeEventQueue<DataChangeEvent> queue) {
+        if (connectorConfig.getHeartbeatInterval().isZero()) {
+            return ScheduledHeartbeat.NOOP_HEARTBEAT;
+        }
+        return new VitessHeartbeatImpl(connectorConfig.getHeartbeatInterval(),
+                connectorConfig.getTopicNamingStrategy(TOPIC_NAMING_STRATEGY).heartbeatTopic(),
+                connectorConfig.getLogicalName(),
+                connectorConfig.schemaNameAdjuster(), queue);
+    }
+}

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -19,8 +19,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionMetadataFactory;
 import io.debezium.heartbeat.Heartbeat;
-import io.debezium.schema.DefaultTopicNamingStrategy;
-import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.heartbeat.Heartbeat.ScheduledHeartbeat;
 
 public class VitessConnectorConfigTest {
 
@@ -28,27 +27,31 @@ public class VitessConnectorConfigTest {
     public void shouldGetVitessHeartbeatImplWhenIntervalSet() {
         Configuration configuration = TestHelper.defaultConfig().with(
                 Heartbeat.HEARTBEAT_INTERVAL, 1000).build();
-        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
-        Heartbeat heartbeat = connectorConfig.createHeartbeat(
-                DefaultTopicNamingStrategy.create(connectorConfig),
-                SchemaNameAdjuster.NO_OP,
+
+        ScheduledHeartbeat heartbeat = new VitessHeartbeatFactory().getScheduledHeartbeat(
+                new VitessConnectorConfig(configuration),
+                null,
                 null,
                 null);
+
         assertThat(heartbeat).isNotNull();
         assertThat(heartbeat instanceof VitessHeartbeatImpl).isTrue();
     }
 
     @Test
     public void shouldGetVitessHeartbeatNoOp() {
-        Configuration configuration = TestHelper.defaultConfig().build();
-        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
-        Heartbeat heartbeat = connectorConfig.createHeartbeat(
-                DefaultTopicNamingStrategy.create(connectorConfig),
-                SchemaNameAdjuster.NO_OP,
+        Configuration configuration = TestHelper
+                .defaultConfig()
+                .build();
+
+        ScheduledHeartbeat heartbeat = new VitessHeartbeatFactory().getScheduledHeartbeat(
+                new VitessConnectorConfig(configuration),
+                null,
                 null,
                 null);
+
         assertThat(heartbeat).isNotNull();
-        assertThat(heartbeat).isEqualTo(Heartbeat.DEFAULT_NOOP_HEARTBEAT);
+        assertThat(heartbeat).isEqualTo(ScheduledHeartbeat.NOOP_HEARTBEAT);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessHeartbeatImplTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessHeartbeatImplTest.java
@@ -9,62 +9,120 @@ package io.debezium.connector.vitess;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
+import java.time.Instant;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
 
-import io.debezium.function.BlockingConsumer;
+import io.debezium.connector.SnapshotRecord;
+import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.heartbeat.Heartbeat;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.spi.schema.DataCollectionId;
+import io.debezium.util.LoggingContext;
 
 public class VitessHeartbeatImplTest {
 
-    class CapturingBlockingConsumer implements BlockingConsumer<SourceRecord> {
+    private final ChangeEventQueue<DataChangeEvent> eventQueue = new ChangeEventQueue.Builder<DataChangeEvent>()
+            .maxBatchSize(10)
+            .maxQueueSize(20)
+            .loggingContextSupplier(() -> LoggingContext.forConnector("a", "b", "c"))
+            .pollInterval(Duration.ofMillis(500))
+            .build();
 
-        private final List<SourceRecord> records = new ArrayList<>();
-
-        @Override
-        public void accept(SourceRecord record) throws InterruptedException {
-            this.records.add(record);
-        }
-
-        public List<SourceRecord> getRecords() {
-            return records;
-        }
-    }
+    private final VitessHeartbeatImpl underTest = new VitessHeartbeatImpl(Duration.ofMillis(1), "topicName", "key", SchemaNameAdjuster.NO_OP, eventQueue);
 
     @Test
     public void shouldNotSendRecordIfNoOffset() throws InterruptedException {
-        Heartbeat heartbeat = new VitessHeartbeatImpl(Duration.ofMillis(1), "topicName", "key", SchemaNameAdjuster.NO_OP);
-        CapturingBlockingConsumer blockingConsumer = new CapturingBlockingConsumer();
-        heartbeat.forcedBeat(null, null, blockingConsumer);
-        assertThat(blockingConsumer.getRecords()).isEmpty();
+        underTest.emit(null, null);
+
+        assertThat(eventQueue.poll()).isEmpty();
     }
 
     @Test
     public void shouldSendRecordIfOffsetPresent() throws InterruptedException {
-        Heartbeat heartbeat = new VitessHeartbeatImpl(Duration.ofMillis(1), "topicName", "key", SchemaNameAdjuster.NO_OP);
-        CapturingBlockingConsumer blockingConsumer = new CapturingBlockingConsumer();
-        Map<String, ?> offset = Map.of("foo", "bar");
-        heartbeat.forcedBeat(null, offset, blockingConsumer);
-        assertThat(blockingConsumer.getRecords()).isNotEmpty();
+        underTest.emit(null, createOffsetContext(Map.of("foo", "bar")));
+
+        assertThat(eventQueue.poll()).isNotEmpty();
     }
 
     @Test
     public void shouldSendRecordWithVgtid() throws InterruptedException {
-        Heartbeat heartbeat = new VitessHeartbeatImpl(Duration.ofMillis(1), "topicName", "key", SchemaNameAdjuster.NO_OP);
-        CapturingBlockingConsumer blockingConsumer = new CapturingBlockingConsumer();
-        String expectedVgtid = "bar";
-        Map<String, ?> offset = Map.of("vgtid", expectedVgtid);
-        heartbeat.forcedBeat(null, offset, blockingConsumer);
-        SourceRecord record = blockingConsumer.getRecords().get(0);
-        assertThat(record).isNotNull();
-        Struct value = (Struct) record.value();
-        assertThat(value.get(SourceInfo.VGTID_KEY)).isEqualTo(expectedVgtid);
+        ChangeEventQueue<DataChangeEvent> eventQueue = new ChangeEventQueue.Builder<DataChangeEvent>()
+                .maxBatchSize(10)
+                .maxQueueSize(20)
+                .loggingContextSupplier(() -> LoggingContext.forConnector("a", "b", "c"))
+                .pollInterval(Duration.ofMillis(500))
+                .build();
+
+        Heartbeat heartbeat = new VitessHeartbeatImpl(Duration.ofMillis(1), "topicName", "key", SchemaNameAdjuster.NO_OP, eventQueue);
+
+        heartbeat.emit(null, createOffsetContext(Map.of("vgtid", "bar")));
+
+        DataChangeEvent actual = eventQueue.poll().get(0);
+
+        assertThat(actual).isNotNull();
+        Struct value = (Struct) actual.getRecord().value();
+        assertThat(value.get(SourceInfo.VGTID_KEY)).isEqualTo("bar");
+    }
+
+    private static OffsetContext createOffsetContext(final Map<String, String> offset) {
+        return new OffsetContext() {
+            @Override
+            public Map<String, ?> getOffset() {
+                return offset;
+            }
+
+            @Override
+            public Schema getSourceInfoSchema() {
+                return null;
+            }
+
+            @Override
+            public Struct getSourceInfo() {
+                return null;
+            }
+
+            @Override
+            public boolean isInitialSnapshotRunning() {
+                return false;
+            }
+
+            @Override
+            public void markSnapshotRecord(SnapshotRecord record) {
+
+            }
+
+            @Override
+            public void preSnapshotStart(boolean onDemand) {
+
+            }
+
+            @Override
+            public void preSnapshotCompletion() {
+
+            }
+
+            @Override
+            public void postSnapshotCompletion() {
+
+            }
+
+            @Override
+            public void event(DataCollectionId collectionId, Instant timestamp) {
+
+            }
+
+            @Override
+            public TransactionContext getTransactionContext() {
+                return null;
+            }
+        };
     }
 
 }


### PR DESCRIPTION
## Context

Actually in Debezium there are different way to instantiate an Heartbeat, which are not aligned.

## Changes
we propose to remove the usage in the `ConnectorConfiguration` in favor of `HeartBeatFactory`. Furthermore we deprecate the `constructors` in favor of a parameter based `factory`. 

## References
#depends https://github.com/debezium/debezium/pull/6530