### PR TITLE
Support VStream Max Age (for ORCA metrics client-based load balancing)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
         <version.debezium>${project.version}</version.debezium>
 
         <version.grpc>1.75.0</version.grpc>
+        <version.com.google.protobuf>4.34.1</version.com.google.protobuf>
+        <version.com.google.protobuf.protoc>4.34.1</version.com.google.protobuf.protoc>
 
         <!--
           Specify the properties that will be used for setting up the integration tests' Docker container.

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -364,6 +364,18 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withValidation(VitessConnectorConfig::validateLoadBalancingPolicy)
             .withDescription("Specify the default load balancing policy used to connect to Vitess, e.g., 'pick_first', 'round_robin'");
 
+    public static final Field MAX_STREAM_AGE_SECONDS = Field.create(VITESS_CONFIG_GROUP_PREFIX + "max.stream.age.seconds")
+            .withDisplayName("VStream max stream age (seconds)")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withDefault(0)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withValidation(Field::isNonNegativeInteger)
+            .withDescription("Maximum duration (in seconds) a VStream runs before the server terminates it with UNAVAILABLE. "
+                    + "The client reconnects automatically. A jitter of +/-10% is added server-side to spread out reconnections. "
+                    + "0 means no maximum age (disabled). "
+                    + "This enables periodic rebalancing for ORCA-aware gRPC load balancing.");
+
     public static final Field INCLUDE_UNKNOWN_DATATYPES = Field.create("include.unknown.datatypes")
             .withDisplayName("Include unknown datatypes")
             .withType(Type.BOOLEAN)
@@ -554,7 +566,8 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     CONNECTOR_GENERATION,
                     STREAM_KEYSPACE_HEARTBEATS,
                     EXCLUDE_KEYSPACE_FROM_TABLE_NAME,
-                    EXCLUDE_EMPTY_SHARDS)
+                    EXCLUDE_EMPTY_SHARDS,
+                    MAX_STREAM_AGE_SECONDS)
             .events(
                     INCLUDE_UNKNOWN_DATATYPES,
                     SOURCE_INFO_STRUCT_MAKER)
@@ -785,6 +798,10 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public String getGrpcDefaultLoadBalancingPolicy() {
         return getConfig().getString(GRPC_DEFAULT_LOAD_BALANCING_POLICY);
+    }
+
+    public int getMaxStreamAgeSeconds() {
+        return getConfig().getInteger(MAX_STREAM_AGE_SECONDS);
     }
 
     public boolean includeUnknownDatatypes() {

--- a/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessStreamingChangeEventSource.java
@@ -67,12 +67,21 @@ public class VitessStreamingChangeEventSource implements StreamingChangeEventSou
 
         try {
             AtomicReference<Throwable> error = new AtomicReference<>();
-            replicationConnection.startStreaming(
-                    offsetContext.getRestartVgtid(), newReplicationMessageProcessor(partition, offsetContext), error);
 
             while (context.isRunning() && error.get() == null) {
-                pauseNoMessage.sleepWhen(true);
+                replicationConnection.startStreaming(
+                        offsetContext.getRestartVgtid(), newReplicationMessageProcessor(partition, offsetContext), error);
+
+                while (context.isRunning() && error.get() == null && !replicationConnection.isStreamRestartNeeded()) {
+                    pauseNoMessage.sleepWhen(true);
+                }
+
+                if (replicationConnection.isStreamRestartNeeded()) {
+                    replicationConnection.setStreamRestartNeeded(false);
+                    continue;
+                }
             }
+
             if (error.get() != null) {
                 LOGGER.error("Error during streaming", error.get());
                 throw error.get();

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationConnection.java
@@ -27,4 +27,17 @@ public interface ReplicationConnection extends AutoCloseable {
      */
     void startStreaming(
                         Vgtid vgtid, ReplicationMessageProcessor processor, AtomicReference<Throwable> error);
+
+    /**
+     * Check if the stream needs to be restarted due to server-initiated termination
+     * (e.g., max stream age exceeded).
+     *
+     * @return true if the stream should be restarted without bubbling up the error
+     */
+    boolean isStreamRestartNeeded();
+
+    /**
+     * Set or clear the stream restart flag.
+     */
+    void setStreamRestartNeeded(boolean needed);
 }

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -57,6 +57,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
     private final VitessConnectorConfig config;
     // Channel closing is invoked from the change-event-source-coordinator thread
     private final AtomicReference<ManagedChannel> managedChannel = new AtomicReference<>();
+    private final AtomicReference<Boolean> streamRestartNeeded = new AtomicReference<>(false);
 
     public VitessReplicationConnection(VitessConnectorConfig config, VitessDatabaseSchema schema) {
         this.messageDecoder = new VStreamOutputMessageDecoder(schema);
@@ -95,12 +96,29 @@ public class VitessReplicationConnection implements ReplicationConnection {
     }
 
     @Override
+    public boolean isStreamRestartNeeded() {
+        return streamRestartNeeded.get();
+    }
+
+    @Override
+    public void setStreamRestartNeeded(boolean needed) {
+        streamRestartNeeded.set(needed);
+    }
+
+    @Override
     public void startStreaming(
                                Vgtid vgtid, ReplicationMessageProcessor processor, AtomicReference<Throwable> error) {
         Objects.requireNonNull(vgtid);
 
-        ManagedChannel channel = newChannel();
-        managedChannel.compareAndSet(null, channel);
+        ManagedChannel channel = managedChannel.get();
+        if (channel == null || channel.isShutdown() || channel.isTerminated()) {
+            LOGGER.info("Creating new gRPC channel for VStream");
+            channel = newChannel();
+            managedChannel.set(channel);
+        }
+        else {
+            LOGGER.debug("Reusing existing gRPC channel for VStream");
+        }
 
         VitessGrpc.VitessStub stub = newStub(channel);
 
@@ -255,9 +273,16 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
             @Override
             public void onError(Throwable t) {
-                LOGGER.error("VStream streaming onError. Status: {}", Status.fromThrowable(t), t);
-                // Only propagate the first error
-                error.compareAndSet(null, t);
+                Status status = Status.fromThrowable(t);
+                if (shouldRestartStream(status)) {
+                    LOGGER.info("VStream terminated, restarting stream on existing gRPC channel (preserves ORCA metrics): {}", status);
+                    streamRestartNeeded.set(true);
+                }
+                else {
+                    LOGGER.error("VStream streaming onError. Status: {}", Status.fromThrowable(t), t);
+                    // Only propagate the first error
+                    error.compareAndSet(null, t);
+                }
                 reset();
             }
 
@@ -292,7 +317,8 @@ public class VitessReplicationConnection implements ReplicationConnection {
                 .setStopOnReshard(config.getStopOnReshard())
                 .setExcludeKeyspaceFromTableName(config.getExcludeKeyspaceFromTableName())
                 .setHeartbeatInterval(getHeartbeatSeconds())
-                .setStreamKeyspaceHeartbeats(config.getStreamKeyspaceHeartbeats());
+                .setStreamKeyspaceHeartbeats(config.getStreamKeyspaceHeartbeats())
+                .setMaxStreamAgeSeconds(config.getMaxStreamAgeSeconds());
 
         if (!Strings.isNullOrEmpty(config.getConfig().getString(CommonConnectorConfig.SNAPSHOT_MODE_TABLES))) {
             final List<String> allTables = new VitessMetadata(config).getTables();
@@ -358,6 +384,20 @@ public class VitessReplicationConnection implements ReplicationConnection {
             stub = stub.withCallCredentials(new StaticAuthCredentials(config.getVtgateUsername(), config.getVtgatePassword()));
         }
         return stub;
+    }
+
+    /**
+     * Determines if the stream should be restarted (reopened) on the existing gRPC channel
+     * rather than propagating the error. This allows the channel to be preserved, which
+     * maintains ORCA metrics for weighted load balancing.
+     */
+    private static boolean shouldRestartStream(Status status) {
+        if (status.getCode() == Status.Code.UNAVAILABLE
+                && status.getDescription() != null
+                && status.getDescription().contains("vstream exceeded maximum age")) {
+            return true;
+        }
+        return false;
     }
 
     private ManagedChannel newChannel() {

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -282,4 +282,34 @@ public class VitessConnectorConfigTest {
         assertThat(connectorConfig.getConnectorGeneration()).isEqualTo(0);
     }
 
+    @Test
+    public void shouldGetMaxStreamAgeSeconds() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.MAX_STREAM_AGE_SECONDS, 3600)
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getMaxStreamAgeSeconds()).isEqualTo(3600);
+    }
+
+    @Test
+    public void shouldGetMaxStreamAgeSecondsDefaultValue() {
+        Configuration configuration = TestHelper.defaultConfig().build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getMaxStreamAgeSeconds()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldNegativeMaxStreamAgeSecondsFailValidation() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.MAX_STREAM_AGE_SECONDS, -1)
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        List<String> inputs = new ArrayList<>();
+        Consumer<String> printConsumer = (input) -> {
+            inputs.add(input);
+        };
+        connectorConfig.validateAndRecord(List.of(VitessConnectorConfig.MAX_STREAM_AGE_SECONDS), printConsumer);
+        assertThat(inputs.size()).isEqualTo(1);
+    }
+
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -2647,6 +2647,32 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         Testing.print("*** Done with verifying without offset.storage.per.task");
     }
 
+    @Test
+    public void shouldRestartStreamWhenMaxStreamAgeExceeded() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        final LogInterceptor replicationLogInterceptor = new LogInterceptor(VitessReplicationConnection.class);
+
+        int maxStreamAgeSeconds = 5;
+        startConnector(config -> config
+                .with(VitessConnectorConfig.MAX_STREAM_AGE_SECONDS, maxStreamAgeSeconds),
+                false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_NUMERIC_TYPES_STMT, schemasAndValuesForNumericTypes(), TestHelper.PK_FIELD);
+
+        int waitSeconds = maxStreamAgeSeconds * 2 + 10;
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(waitSeconds))
+                .pollInterval(Duration.ofSeconds(1))
+                .until(() -> replicationLogInterceptor.containsMessage(
+                        "VStream terminated, restarting stream on existing gRPC channel"));
+
+        assertConnectorIsRunning();
+    }
+
     private void waitForGtidAcquiring(final LogInterceptor logInterceptor) {
         // The inserts must happen only after GTID to stream from is obtained
         Awaitility.await().atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))


### PR DESCRIPTION
Pre-requisites (tests will fail trivially until these are complete)
- new vitess-grpc-client version needs to be released 
- https://github.com/debezium/debezium/pull/7391 or equivalent

This allows us to periodically terminate streams and utilize built grpc-java client-based load balancers that detect cpu/memory usage of vtgate servers.

Read about the motivation here https://github.com/vitessio/vitess/issues/19589

Fixes debezium/dbz#1873