### PR TITLE
debezium/dbz#2054 Backtick-quote keyspace and table identifiers in Vitess SQL

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
@@ -46,6 +46,28 @@ public class VitessMetadata {
         return formattedQuery;
     }
 
+    // MySQL identifier quoting: wrap in backticks and escape any embedded backtick by doubling.
+    // Required because keyspace/table names can legally contain characters that are not valid
+    // in bare MySQL identifiers (e.g. hyphens).
+    public static String quoteIdentifier(String identifier) {
+        return "`" + identifier.replace("`", "``") + "`";
+    }
+
+    // Escape a value to be placed inside a MySQL single-quoted string literal.
+    @VisibleForTesting
+    static String escapeStringLiteral(String value) {
+        return value.replace("\\", "\\\\").replace("'", "\\'");
+    }
+
+    // Escape LIKE wildcards so they match literally. Backslash is the LIKE escape character and
+    // must be escaped first; otherwise an unescaped `_` in a keyspace name would over-match
+    // (e.g. `foo_bar` would also match `foo-bar`). Apply before escapeStringLiteral so the added
+    // backslashes are themselves doubled when embedded in the literal.
+    @VisibleForTesting
+    static String escapeLikePattern(String value) {
+        return value.replace("\\", "\\\\").replace("_", "\\_").replace("%", "\\%");
+    }
+
     public List<String> getShards() {
         List<String> shards;
         if (config.excludeEmptyShards()) {
@@ -78,7 +100,7 @@ public class VitessMetadata {
             response = executeQuery(query, randomShard);
         }
         else {
-            query = formatQuery("SHOW TABLES FROM %s", config.getKeyspace());
+            query = formatQuery("SHOW TABLES FROM %s", quoteIdentifier(config.getKeyspace()));
             response = executeQuery(query);
         }
         logResponse(response, query);
@@ -92,7 +114,7 @@ public class VitessMetadata {
     }
 
     private List<String> getVitessShards() {
-        String query = formatQuery("SHOW VITESS_SHARDS LIKE '%s/%%'", config.getKeyspace());
+        String query = formatQuery("SHOW VITESS_SHARDS LIKE '%s/%%'", escapeStringLiteral(escapeLikePattern(config.getKeyspace())));
         Vtgate.ExecuteResponse response = executeQuery(query);
         logResponse(response, query);
         List<String> rows = getFlattenedRowsFromResponse(response);

--- a/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessMetadata.java
@@ -46,13 +46,6 @@ public class VitessMetadata {
         return formattedQuery;
     }
 
-    // MySQL identifier quoting: wrap in backticks and escape any embedded backtick by doubling.
-    // Required because keyspace/table names can legally contain characters that are not valid
-    // in bare MySQL identifiers (e.g. hyphens).
-    public static String quoteIdentifier(String identifier) {
-        return "`" + identifier.replace("`", "``") + "`";
-    }
-
     // Escape a value to be placed inside a MySQL single-quoted string literal.
     @VisibleForTesting
     static String escapeStringLiteral(String value) {
@@ -100,8 +93,13 @@ public class VitessMetadata {
             response = executeQuery(query, randomShard);
         }
         else {
-            query = formatQuery("SHOW TABLES FROM %s", quoteIdentifier(config.getKeyspace()));
-            response = executeQuery(query);
+            try (VitessReplicationConnection connection = new VitessReplicationConnection(config, null)) {
+                query = formatQuery("SHOW TABLES FROM %s", connection.quoteIdentifier(config.getKeyspace()));
+                response = connection.execute(query);
+            }
+            catch (Exception e) {
+                throw new RuntimeException(String.format("Unexpected error while getting tables from keyspace: %s", config.getKeyspace()), e);
+            }
         }
         logResponse(response, query);
         List<String> tables = getFlattenedRowsFromResponse(response);

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -94,6 +94,16 @@ public class VitessReplicationConnection implements ReplicationConnection {
         return newBlockingStub(channel).execute(request);
     }
 
+    /**
+     * Quote an identifier (e.g. a keyspace or table name) so it can be safely interpolated into
+     * SQL sent to vtgate: wrap it in backticks and escape any embedded backtick by doubling it.
+     * Required because keyspace/table names can legally contain characters that are not valid
+     * in bare MySQL identifiers (e.g. hyphens).
+     */
+    public String quoteIdentifier(String identifier) {
+        return "`" + identifier.replace("`", "``") + "`";
+    }
+
     @Override
     public void startStreaming(
                                Vgtid vgtid, ReplicationMessageProcessor processor, AtomicReference<Throwable> error) {
@@ -308,7 +318,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
             final List<String> allTables = new VitessMetadata(config).getTables();
             List<String> includedTables = VitessConnector.getIncludedTables(config, allTables);
             for (String table : includedTables) {
-                String sql = "select * from " + VitessMetadata.quoteIdentifier(table);
+                String sql = "select * from " + quoteIdentifier(table);
                 // See rule in: https://github.com/vitessio/vitess/blob/release-14.0/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go#L316
                 Binlogdata.Rule rule = Binlogdata.Rule.newBuilder().setMatch(table).setFilter(sql).build();
                 LOGGER.info("Add vstream table filtering: {}", rule.getMatch());

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -308,7 +308,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
             final List<String> allTables = new VitessMetadata(config).getTables();
             List<String> includedTables = VitessConnector.getIncludedTables(config, allTables);
             for (String table : includedTables) {
-                String sql = "select * from `" + table + "`";
+                String sql = "select * from " + VitessMetadata.quoteIdentifier(table);
                 // See rule in: https://github.com/vitessio/vitess/blob/release-14.0/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go#L316
                 Binlogdata.Rule rule = Binlogdata.Rule.newBuilder().setMatch(table).setFilter(sql).build();
                 LOGGER.info("Add vstream table filtering: {}", rule.getMatch());

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -200,6 +200,24 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     }
 
     @Test
+    public void shouldStreamFromTableWithDashInName() throws Exception {
+        String table = "dash-table";
+        TestHelper.execute(String.format("DROP TABLE IF EXISTS `%s`;", table));
+        TestHelper.execute(String.format("CREATE TABLE `%s` (id BIGINT NOT NULL AUTO_INCREMENT, int_col INT, PRIMARY KEY (id));", table));
+        startConnector(
+                builder -> builder.with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, TEST_UNSHARDED_KEYSPACE + "." + table),
+                false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        executeAndWait(String.format("INSERT INTO `%s` (int_col) VALUES (1);", table));
+        SourceRecord record = assertRecordInserted(TEST_UNSHARDED_KEYSPACE + "." + table, TestHelper.PK_FIELD);
+        assertSourceInfo(record, TEST_SERVER, TEST_UNSHARDED_KEYSPACE, table);
+    }
+
+    @Test
     @FixFor("DBZ-7962")
     public void shouldReceiveHeartbeatEvents() throws Exception {
         TestHelper.executeDDL("vitess_create_tables.ddl");

--- a/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
@@ -61,13 +61,6 @@ public class VitessMetadataTest {
     }
 
     @Test
-    public void shouldQuoteIdentifier() {
-        assertThat(VitessMetadata.quoteIdentifier("keyspace")).isEqualTo("`keyspace`");
-        assertThat(VitessMetadata.quoteIdentifier("tenant-a")).isEqualTo("`tenant-a`");
-        assertThat(VitessMetadata.quoteIdentifier("weird`name")).isEqualTo("`weird``name`");
-    }
-
-    @Test
     public void shouldEscapeStringLiteral() {
         assertThat(VitessMetadata.escapeStringLiteral("plain")).isEqualTo("plain");
         assertThat(VitessMetadata.escapeStringLiteral("it's")).isEqualTo("it\\'s");

--- a/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessMetadataTest.java
@@ -59,4 +59,27 @@ public class VitessMetadataTest {
         List<List<String>> input = List.of(List.of("foo"), List.of("bar"));
         assertThat(VitessMetadata.flattenAndConcat(input)).isEqualTo(expected);
     }
+
+    @Test
+    public void shouldQuoteIdentifier() {
+        assertThat(VitessMetadata.quoteIdentifier("keyspace")).isEqualTo("`keyspace`");
+        assertThat(VitessMetadata.quoteIdentifier("tenant-a")).isEqualTo("`tenant-a`");
+        assertThat(VitessMetadata.quoteIdentifier("weird`name")).isEqualTo("`weird``name`");
+    }
+
+    @Test
+    public void shouldEscapeStringLiteral() {
+        assertThat(VitessMetadata.escapeStringLiteral("plain")).isEqualTo("plain");
+        assertThat(VitessMetadata.escapeStringLiteral("it's")).isEqualTo("it\\'s");
+        assertThat(VitessMetadata.escapeStringLiteral("back\\slash")).isEqualTo("back\\\\slash");
+    }
+
+    @Test
+    public void shouldEscapeLikePattern() {
+        assertThat(VitessMetadata.escapeLikePattern("plain")).isEqualTo("plain");
+        assertThat(VitessMetadata.escapeLikePattern("foo_bar")).isEqualTo("foo\\_bar");
+        assertThat(VitessMetadata.escapeLikePattern("100%")).isEqualTo("100\\%");
+        // Backslash must be escaped first so the backslashes added for `_` / `%` are not themselves doubled.
+        assertThat(VitessMetadata.escapeLikePattern("a\\b_c")).isEqualTo("a\\\\b\\_c");
+    }
 }

--- a/src/test/java/io/debezium/connector/vitess/connection/VitessReplicationConnectionTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VitessReplicationConnectionTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.vitess.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.vitess.TestHelper;
+import io.debezium.connector.vitess.VitessConnectorConfig;
+
+public class VitessReplicationConnectionTest {
+
+    @Test
+    public void shouldQuoteIdentifier() {
+        VitessReplicationConnection connection = new VitessReplicationConnection(
+                new VitessConnectorConfig(TestHelper.defaultConfig().build()), null);
+        assertThat(connection.quoteIdentifier("keyspace")).isEqualTo("`keyspace`");
+        assertThat(connection.quoteIdentifier("tenant-a")).isEqualTo("`tenant-a`");
+        assertThat(connection.quoteIdentifier("weird`name")).isEqualTo("`weird``name`");
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2054.

## Summary

Vitess keyspace and table names that aren't valid bare MySQL identifiers
(most commonly names containing a hyphen) caused metadata queries to fail
at vtgate with a syntax error, after which the connector silently returned
zero tables and produced no events.

Three sites interpolated names into SQL without quoting/escaping:
- `VitessMetadata#getTables` — `SHOW TABLES FROM <keyspace>`
- `VitessMetadata#getVitessShards` — `SHOW VITESS_SHARDS LIKE '<keyspace>/%'`
  (also did not escape LIKE wildcards, so an unescaped `_` in a keyspace
  name would over-match)
- `VitessReplicationConnection` VStream filter SQL — `select * from \`<table>\``
  (did not escape embedded backticks in a table name)

Adds `quoteIdentifier`, `escapeStringLiteral`, and `escapeLikePattern`
helpers on `VitessMetadata` and routes every interpolation site through
them.

## Test plan

- New unit tests in `VitessMetadataTest` cover plain identifiers,
  hyphenated names, embedded backticks, and LIKE wildcards including the
  ordering invariant (backslash escaped before `_`/`%`).
- DCO sign-off present.