### PR TITLE
debezium/dbz#2060 Honor time.precision.mode=connect for TIMESTAMP columns

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -16,6 +16,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -109,6 +110,12 @@ public class VitessValueConverter extends JdbcValueConverters {
         if (isTemporal(typeName) && temporalPrecisionMode.equals(TemporalPrecisionMode.ISOSTRING)) {
             return SchemaBuilder.string();
         }
+        // MySQL TIMESTAMP is mapped to Types.TIMESTAMP_WITH_TIMEZONE, for which JdbcValueConverters hardcodes
+        // ZonedTimestamp regardless of the configured time.precision.mode. Honor `connect` mode here so TIMESTAMP
+        // columns use Kafka Connect's Timestamp logical type (epoch millis), consistent with DATETIME.
+        if (isTimestamp(typeName) && temporalPrecisionMode.equals(TemporalPrecisionMode.CONNECT)) {
+            return org.apache.kafka.connect.data.Timestamp.builder();
+        }
 
         final SchemaBuilder jdbcSchemaBuilder = super.schemaBuilder(column);
         if (jdbcSchemaBuilder == null) {
@@ -133,6 +140,15 @@ public class VitessValueConverter extends JdbcValueConverters {
         return matches(typeName, Query.Type.DATE.name()) ||
                 matches(typeName, Query.Type.TIME.name()) ||
                 matches(typeName, Query.Type.DATETIME.name());
+    }
+
+    /**
+     * Detect the MySQL TIMESTAMP type, which {@link VitessType} maps to {@link java.sql.Types#TIMESTAMP_WITH_TIMEZONE}
+     * @param typeName
+     * @return if it is a timestamp type
+     */
+    private static boolean isTimestamp(String typeName) {
+        return matches(typeName, Query.Type.TIMESTAMP.name());
     }
 
     // Convert Java value to Kafka Connect value.
@@ -169,6 +185,9 @@ public class VitessValueConverter extends JdbcValueConverters {
 
         if (isTemporal(typeName) && temporalPrecisionMode.equals(TemporalPrecisionMode.ISOSTRING)) {
             return (data) -> convertString(column, fieldDefn, data);
+        }
+        if (isTimestamp(typeName) && temporalPrecisionMode.equals(TemporalPrecisionMode.CONNECT)) {
+            return (data) -> convertTimestampToConnectDate(column, fieldDefn, data);
         }
 
         final ValueConverter jdbcConverter = super.converter(column, fieldDefn);
@@ -410,7 +429,7 @@ public class VitessValueConverter extends JdbcValueConverters {
 
     /**
      * Converts a value object for an expected JDBC type of {@link java.sql.Types#TIMESTAMP_WITH_TIMEZONE}, which is
-     * the case for the MySQL TIMESTAMP type.
+     * the case for the MySQL TIMESTAMP type (in all time.precision.mode values except connect).
      *
      * VStream emits TIMESTAMP values as raw UTC strings, which {@code ZonedTimestamp.toIsoString} would otherwise
      * pass through verbatim, so the emitted value would not be a valid ISO 8601 zoned timestamp. Parse the string
@@ -455,5 +474,57 @@ public class VitessValueConverter extends JdbcValueConverters {
             return null;
         }
         return LocalDateTime.parse(timestampString, TIMESTAMP_FIELD_FORMATTER).atZone(ZoneOffset.UTC);
+    }
+
+    /**
+     * Called for TIMESTAMP type of MySQL when time.precision.mode is connect. Converts the UTC string emitted by
+     * VStream to a {@link java.util.Date} holding the corresponding epoch millis, the value type expected by Kafka
+     * Connect's {@link org.apache.kafka.connect.data.Timestamp} logical type.
+     *
+     * If the datetimeString cannot be represented by a Date, then it returns null.
+     * This happens if either month or day are equal to zero.
+     *
+     * @param datetimeString The String to convert
+     * @return The java.util.Date
+     */
+    public static Date stringToConnectDate(String datetimeString) {
+        if (datetimeString.matches("^\\d{4}-00-00.*$")) {
+            INVALID_VALUE_LOGGER.warn("Invalid value '{}' stored in column converted to null value", datetimeString);
+            return null;
+        }
+        return Date.from(LocalDateTime.parse(datetimeString, TIMESTAMP_FIELD_FORMATTER).toInstant(ZoneOffset.UTC));
+    }
+
+    /**
+     * Convert a raw TIMESTAMP value into a {@link java.util.Date} suitable for Kafka Connect's
+     * {@link org.apache.kafka.connect.data.Timestamp} logical type.
+     *
+     * The string value is parsed before being handed to {@code convertValue} so that the MySQL zero-date sentinel
+     * follows the same path as a DATETIME zero-date: null for optional columns, the schema default value or the
+     * epoch fallback for non-optional columns.
+     *
+     * @param column the column in which the value appears
+     * @param fieldDefn the field definition for the SourceRecord's {@link Schema}; never null
+     * @param data the data; may be null
+     *
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     */
+    protected Object convertTimestampToConnectDate(Column column, Field fieldDefn, Object data) {
+        Object value = data;
+        if (data instanceof String) {
+            try {
+                value = stringToConnectDate((String) data);
+            }
+            catch (DateTimeParseException e) {
+                INVALID_VALUE_LOGGER.warn("Invalid value '{}' stored in column converted to null value", data);
+                value = null;
+            }
+        }
+        final Object parsed = value;
+        return convertValue(column, fieldDefn, parsed, new Date(0L), (r) -> {
+            if (parsed instanceof Date) {
+                r.deliver(parsed);
+            }
+        });
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -528,6 +528,14 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
         return fields;
     }
 
+    protected List<SchemaAndValueField> schemasAndValuesForTimestampWithTimeZone() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField("timestamp_col", ZonedTimestamp.schema(), TIMESTAMP_ISO)));
+        return fields;
+    }
+
     protected List<SchemaAndValueField> schemasAndValuesForTimeTypeConnect() {
         final List<SchemaAndValueField> fields = new ArrayList<>();
         fields.addAll(
@@ -537,8 +545,30 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col", org.apache.kafka.connect.data.Timestamp.SCHEMA, getDateForDatetime(DATETIME, 0)),
                         new SchemaAndValueField(
-                                "timestamp_col", ZonedTimestamp.schema(), TIMESTAMP_ISO),
+                                "timestamp_col", org.apache.kafka.connect.data.Timestamp.SCHEMA, getDateForDatetime(TIMESTAMP, 0)),
                         new SchemaAndValueField("year_col", Year.schema(), Integer.valueOf(YEAR))));
+        return fields;
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForTimestampTypeZeroDateConnect() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField(
+                                "timestamp_col", org.apache.kafka.connect.data.Timestamp.SCHEMA, new java.util.Date(0L)),
+                        new SchemaAndValueField(
+                                "timestamp_col6", org.apache.kafka.connect.data.Timestamp.SCHEMA, new java.util.Date(0L))));
+        return fields;
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForTimestampTypeZeroDateNullableConnect() {
+        final List<SchemaAndValueField> fields = new ArrayList<>();
+        fields.addAll(
+                Arrays.asList(
+                        new SchemaAndValueField(
+                                "timestamp_col", org.apache.kafka.connect.data.Timestamp.builder().optional().schema(), null),
+                        new SchemaAndValueField(
+                                "timestamp_col6", org.apache.kafka.connect.data.Timestamp.builder().optional().schema(), null)));
         return fields;
     }
 
@@ -570,9 +600,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col5", org.apache.kafka.connect.data.Timestamp.SCHEMA, getDateForDatetime(DATETIME_PRECISION5, 5)),
                         new SchemaAndValueField(
-                                "timestamp_col3", ZonedTimestamp.schema(), TIMESTAMP_PRECISION3_ISO),
+                                "timestamp_col3", org.apache.kafka.connect.data.Timestamp.SCHEMA, getDateForDatetime(TIMESTAMP_PRECISION3, 3)),
                         new SchemaAndValueField(
-                                "timestamp_col6", ZonedTimestamp.schema(), TIMESTAMP_PRECISION6_ISO)));
+                                "timestamp_col6", org.apache.kafka.connect.data.Timestamp.SCHEMA, getDateForDatetime(TIMESTAMP_PRECISION6, 6))));
         return fields;
     }
 

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorIT.java
@@ -584,6 +584,19 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
     }
 
     @Test
+    public void shouldReceiveChangesForInsertsWithTimestampWithTimeZoneMapping() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector();
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_TIME_TYPES_STMT, schemasAndValuesForTimestampWithTimeZone(), TestHelper.PK_FIELD);
+    }
+
+    @Test
     public void shouldReceiveChangesForInsertsWithTimestampTypesZeroValues() throws Exception {
         TestHelper.executeDDL("vitess_create_tables.ddl");
         startConnector();
@@ -678,6 +691,36 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
 
         consumer.expects(expectedRecordsCount);
         assertInsert(INSERT_PRECISION_TIME_TYPES_STMT, schemasAndValuesForTimeTypePrecisionConnect(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveChangesForInsertsWithTimestampTypesZeroValuesConnect() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(
+                VitessConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.CONNECT),
+                false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_TIME_TYPES_ZERO_VALUE_STMT, schemasAndValuesForTimestampTypeZeroDateConnect(), TestHelper.PK_FIELD);
+    }
+
+    @Test
+    public void shouldReceiveChangesForInsertsWithTimestampTypesZeroValuesNullableConnect() throws Exception {
+        TestHelper.executeDDL("vitess_create_tables.ddl");
+        startConnector(config -> config.with(
+                VitessConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.CONNECT),
+                false);
+        assertConnectorIsRunning();
+
+        int expectedRecordsCount = 1;
+        consumer = testConsumer(expectedRecordsCount);
+
+        consumer.expects(expectedRecordsCount);
+        assertInsert(INSERT_TIME_TYPES_ZERO_VALUE_NULLABLE_STMT, schemasAndValuesForTimestampTypeZeroDateNullableConnect(), TestHelper.PK_FIELD);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTemporalTypesTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTemporalTypesTest.java
@@ -9,6 +9,7 @@ package io.debezium.connector.vitess;
 import static io.debezium.connector.vitess.VitessValueConverterTest.temporalFieldEvent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
@@ -44,10 +45,13 @@ public class VitessValueConverterTemporalTypesTest {
 
     @BeforeEach
     public void before() {
+        init(TemporalPrecisionMode.ISOSTRING);
+    }
 
+    private void init(TemporalPrecisionMode temporalPrecisionMode) {
         VitessConnectorConfig config = new VitessConnectorConfig(
                 TestHelper.defaultConfig().with(
-                        VitessConnectorConfig.TIME_PRECISION_MODE.name(), TemporalPrecisionMode.ISOSTRING).build());
+                        VitessConnectorConfig.TIME_PRECISION_MODE.name(), temporalPrecisionMode).build());
         converter = new VitessValueConverter(
                 config.getDecimalMode(),
                 config.getTemporalPrecisionMode(),
@@ -104,6 +108,55 @@ public class VitessValueConverterTemporalTypesTest {
         String timeString = "00:00:00";
         Object actual = valueConverter.convert(timeString);
         assertThat(actual).isEqualTo(timeString);
+    }
+
+    @Test
+    public void shouldGetConnectTimestampSchemaBuilderForTimestampWithConnectTimePrecisionMode() throws InterruptedException {
+        init(TemporalPrecisionMode.CONNECT);
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        Column column = table.columnWithName("timestamp_col");
+        SchemaBuilder schemaBuilder = converter.schemaBuilder(column);
+        assertThat(schemaBuilder.schema()).isEqualTo(org.apache.kafka.connect.data.Timestamp.builder().schema());
+    }
+
+    @Test
+    public void shouldConvertTimestampToDateWithConnectTimePrecisionMode() throws InterruptedException {
+        init(TemporalPrecisionMode.CONNECT);
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        String col = "timestamp_col";
+        Column column = table.columnWithName(col);
+        Field field = new Field(col, 3, org.apache.kafka.connect.data.Timestamp.builder().schema());
+
+        ValueConverter valueConverter = converter.converter(column, field);
+        Object actual = valueConverter.convert("2020-01-01 01:02:03");
+        assertThat(actual).isEqualTo(java.util.Date.from(
+                LocalDateTime.of(2020, 1, 1, 1, 2, 3).toInstant(ZoneOffset.UTC)));
+    }
+
+    @Test
+    public void shouldConvertZeroTimestampWithConnectTimePrecisionMode() throws InterruptedException {
+        init(TemporalPrecisionMode.CONNECT);
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        String col = "timestamp_col";
+        Column column = table.columnWithName(col);
+
+        // The MySQL zero-date sentinel converts to null for optional columns, like a DATETIME zero-date
+        ValueConverter nullableConverter = converter.converter(
+                column.edit().optional(true).create(),
+                new Field(col, 3, org.apache.kafka.connect.data.Timestamp.builder().optional().schema()));
+        assertThat(nullableConverter.convert("0000-00-00 00:00:00")).isNull();
+
+        // For non-optional columns it converts to the epoch fallback
+        ValueConverter requiredConverter = converter.converter(
+                column.edit().optional(false).create(),
+                new Field(col, 3, org.apache.kafka.connect.data.Timestamp.builder().schema()));
+        assertThat(requiredConverter.convert("0000-00-00 00:00:00")).isEqualTo(new java.util.Date(0L));
     }
 
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
@@ -301,4 +301,22 @@ public class VitessValueConverterTest {
         ValueConverter valueConverter = converter.converter(column, field);
         assertThat(valueConverter.convert("2020-01-01 01:02:03")).isEqualTo("2020-01-01T01:02:03Z");
     }
+
+    @Test
+    public void shouldConvertStringToConnectDate() {
+        assertThat(VitessValueConverter.stringToConnectDate("2000-01-01 00:00:00")).isEqualTo(
+                java.util.Date.from(LocalDate.of(2000, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC)));
+        assertThat(VitessValueConverter.stringToConnectDate("2000-01-01 00:00:00.123")).isEqualTo(
+                java.util.Date.from(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(123 * 1000 * 1000).toInstant(ZoneOffset.UTC)));
+        // Kafka Connect's Timestamp logical type has millisecond precision, sub-millisecond fractions are truncated
+        assertThat(VitessValueConverter.stringToConnectDate("2000-01-01 00:00:00.123456")).isEqualTo(
+                java.util.Date.from(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(123 * 1000 * 1000).toInstant(ZoneOffset.UTC)));
+    }
+
+    @Test
+    public void shouldConvertInvalidValueToConnectDate() {
+        final LogInterceptor logInterceptor = new LogInterceptor(VitessValueConverter.class.getName() + ".invalid_value");
+        assertThat(VitessValueConverter.stringToConnectDate("0000-00-00 00:00:00")).isNull();
+        assertThat(logInterceptor.containsMessage("Invalid value")).isTrue();
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2060

MySQL `TIMESTAMP` is mapped to `Types.TIMESTAMP_WITH_TIMEZONE`, for which `JdbcValueConverters` hardcodes `ZonedTimestamp` regardless of the configured `time.precision.mode`, so `connect` mode was silently ignored for `TIMESTAMP` columns while being honored for `DATETIME`, `DATE`, and `TIME`.

This change intercepts the `TIMESTAMP` path in `VitessValueConverter` when the mode is `connect` and emits Kafka Connect's `Timestamp` logical type (int64 epoch millis), parsing the UTC string emitted by VStream. The MySQL zero-date sentinel (`0000-00-00 00:00:00`) follows the same path as a `DATETIME` zero-date: null for optional columns, the schema default or epoch for non-optional columns.

**Scope / compatibility notes:**
* Only `connect` mode changes. All other precision modes (`adaptive_time_microseconds`, `isostring`) keep emitting `ZonedTimestamp` for `TIMESTAMP`, matching the documented exclusion. The unchanged expectations of the existing non-connect integration tests cover this.
* For users running `time.precision.mode=connect` with `TIMESTAMP` columns this is a behavior change (string `ZonedTimestamp` → int64 `Timestamp`) — i.e. the documented contract is now honored. May be worth a release-note mention.
* The existing connect-mode integration test expectations codified the old behavior and are updated accordingly; new unit and integration tests cover the conversion including zero-date values on both nullable and non-nullable columns.

A matching documentation update for `vitess.adoc` (adding the `TIMESTAMP` row to the connect-mode mapping table) is submitted separately to `debezium/debezium`.