### PR TITLE
debezium/dbz#2063 Emit ISO 8601 strings for TIMESTAMP columns mapped to ZonedTimestamp

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -9,7 +9,13 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -47,6 +53,13 @@ public class VitessValueConverter extends JdbcValueConverters {
 
     private static final Pattern DATE_FIELD_PATTERN = Pattern.compile("([0-9]*)-([0-9]*)-([0-9]*)");
     private static final Pattern TIME_FIELD_PATTERN = Pattern.compile("(\\-?[0-9]*):([0-9]*)(:([0-9]*))?(\\.([0-9]*))?");
+    // VStream emits MySQL TIMESTAMP values as UTC strings ("yyyy-MM-dd HH:mm:ss" with optional fractional seconds)
+    private static final DateTimeFormatter TIMESTAMP_FIELD_FORMATTER = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+            .optionalEnd()
+            .toFormatter();
 
     public VitessValueConverter(
                                 DecimalMode decimalMode,
@@ -393,5 +406,54 @@ public class VitessValueConverter extends JdbcValueConverters {
             return null;
         }
         return Timestamp.valueOf(datetimeString);
+    }
+
+    /**
+     * Converts a value object for an expected JDBC type of {@link java.sql.Types#TIMESTAMP_WITH_TIMEZONE}, which is
+     * the case for the MySQL TIMESTAMP type.
+     *
+     * VStream emits TIMESTAMP values as raw UTC strings, which {@code ZonedTimestamp.toIsoString} would otherwise
+     * pass through verbatim, so the emitted value would not be a valid ISO 8601 zoned timestamp. Parse the string
+     * into a {@link ZonedDateTime} first, mirroring the binlog-based MySQL connector, so the emitted value is
+     * ISO 8601 in UTC (e.g. 2020-02-13T01:02:03Z) as the {@link io.debezium.time.ZonedTimestamp} contract requires.
+     *
+     * @param column the column in which the value appears
+     * @param fieldDefn the field definition for the SourceRecord's {@link Schema}; never null
+     * @param data the data; may be null
+     *
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     */
+    @Override
+    protected Object convertTimestampWithZone(Column column, Field fieldDefn, Object data) {
+        Object value = data;
+        if (data instanceof String) {
+            try {
+                value = stringToZonedDateTime((String) data);
+            }
+            catch (DateTimeParseException e) {
+                INVALID_VALUE_LOGGER.warn("Invalid value '{}' stored in column converted to null value", data);
+                value = null;
+            }
+        }
+        return super.convertTimestampWithZone(column, fieldDefn, value);
+    }
+
+    /**
+     * Called for TIMESTAMP type of MySQL. Converts the UTC string emitted by VStream to a {@link ZonedDateTime}
+     * in UTC, like the binlog-based MySQL connector's event deserializer does.
+     *
+     * If the datetimeString cannot be represented by a ZonedDateTime, then it returns null.
+     * This happens if either month or day are equal to zero, like the binlog-based MySQL connector's event
+     * deserializer does for values outside of the legal MySQL TIMESTAMP range.
+     *
+     * @param timestampString The String to convert
+     * @return The java.time.ZonedDateTime
+     */
+    public static ZonedDateTime stringToZonedDateTime(String timestampString) {
+        if (timestampString.matches("^\\d{4}-00-00.*$")) {
+            INVALID_VALUE_LOGGER.warn("Invalid value '{}' stored in column converted to null value", timestampString);
+            return null;
+        }
+        return LocalDateTime.parse(timestampString, TIMESTAMP_FIELD_FORMATTER).atZone(ZoneOffset.UTC);
     }
 }

--- a/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
+++ b/src/test/java/io/debezium/connector/vitess/AbstractVitessConnectorTest.java
@@ -209,6 +209,15 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
     protected static final String DATETIME_PRECISION5 = DATETIME + ".12345";
     protected static final String TIMESTAMP_PRECISION3 = TIMESTAMP + ".123";
     protected static final String TIMESTAMP_PRECISION6 = TIMESTAMP + ".123456";
+
+    // TIMESTAMP values are emitted as ISO 8601 strings in UTC, with fractional digits per the column's precision
+    protected static final String TIMESTAMP_ISO = "2020-02-13T01:02:03Z";
+    protected static final String TIMESTAMP_PRECISION3_ISO = "2020-02-13T01:02:03.123Z";
+    protected static final String TIMESTAMP_PRECISION6_ISO = "2020-02-13T01:02:03.123456Z";
+    protected static final String EPOCH_TIMESTAMP_ISO = "1970-01-01T00:00:01Z";
+    protected static final String EPOCH_TIMESTAMP_PRECISION6_ISO = "1970-01-01T00:00:01.000000Z";
+    // The JdbcValueConverters fallback for a zero-date TIMESTAMP in a non-optional column
+    protected static final String FALLBACK_TIMESTAMP_ISO = "1970-01-01T00:00:00Z";
     protected static final String INSERT_PRECISION_TIME_TYPES_STMT = "INSERT INTO time_table_precision ("
             + "time_col1,"
             + "time_col4,"
@@ -422,9 +431,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col4", MicroTimestamp.schema(), getMicrosForDatetime(EPOCH_DATETIME_PRECISION4, 4)),
                         new SchemaAndValueField(
-                                "timestamp_col", ZonedTimestamp.schema(), ZERO_TIMESTAMP),
+                                "timestamp_col", ZonedTimestamp.schema(), FALLBACK_TIMESTAMP_ISO),
                         new SchemaAndValueField(
-                                "timestamp_col6", ZonedTimestamp.schema(), ZERO_TIMESTAMP_PRECISION6),
+                                "timestamp_col6", ZonedTimestamp.schema(), FALLBACK_TIMESTAMP_ISO),
                         new SchemaAndValueField("year_col", Year.schema(), Integer.valueOf(ZERO_YEAR))));
         return fields;
     }
@@ -441,9 +450,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col4", Schema.STRING_SCHEMA, ZERO_DATETIME_PRECISION4),
                         new SchemaAndValueField(
-                                "timestamp_col", ZonedTimestamp.schema(), ZERO_TIMESTAMP),
+                                "timestamp_col", ZonedTimestamp.schema(), FALLBACK_TIMESTAMP_ISO),
                         new SchemaAndValueField(
-                                "timestamp_col6", ZonedTimestamp.schema(), ZERO_TIMESTAMP_PRECISION6),
+                                "timestamp_col6", ZonedTimestamp.schema(), FALLBACK_TIMESTAMP_ISO),
                         new SchemaAndValueField("year_col", Year.schema(), Integer.valueOf(ZERO_YEAR))));
         return fields;
     }
@@ -460,9 +469,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col4", MicroTimestamp.builder().optional().schema(), null),
                         new SchemaAndValueField(
-                                "timestamp_col", ZonedTimestamp.builder().optional().schema(), ZERO_TIMESTAMP),
+                                "timestamp_col", ZonedTimestamp.builder().optional().schema(), null),
                         new SchemaAndValueField(
-                                "timestamp_col6", ZonedTimestamp.builder().optional().schema(), ZERO_TIMESTAMP_PRECISION6),
+                                "timestamp_col6", ZonedTimestamp.builder().optional().schema(), null),
                         new SchemaAndValueField("year_col", Year.builder().optional().schema(), Integer.valueOf(ZERO_YEAR))));
         return fields;
     }
@@ -479,9 +488,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col4", MicroTimestamp.builder().optional().schema(), null),
                         new SchemaAndValueField(
-                                "timestamp_col", ZonedTimestamp.schema(), ZERO_TIMESTAMP),
+                                "timestamp_col", ZonedTimestamp.schema(), FALLBACK_TIMESTAMP_ISO),
                         new SchemaAndValueField(
-                                "timestamp_col6", ZonedTimestamp.schema(), ZERO_TIMESTAMP_PRECISION6),
+                                "timestamp_col6", ZonedTimestamp.schema(), FALLBACK_TIMESTAMP_ISO),
                         new SchemaAndValueField("year_col", Year.schema(), Integer.valueOf(ZERO_YEAR))));
         return fields;
     }
@@ -498,9 +507,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col4", MicroTimestamp.builder().optional().schema(), getMicrosForDatetime(EPOCH_DATETIME_PRECISION4, 4)),
                         new SchemaAndValueField(
-                                "timestamp_col", ZonedTimestamp.schema(), EPOCH_TIMESTAMP),
+                                "timestamp_col", ZonedTimestamp.schema(), EPOCH_TIMESTAMP_ISO),
                         new SchemaAndValueField(
-                                "timestamp_col6", ZonedTimestamp.schema(), EPOCH_TIMESTAMP_PRECISION6),
+                                "timestamp_col6", ZonedTimestamp.schema(), EPOCH_TIMESTAMP_PRECISION6_ISO),
                         new SchemaAndValueField("year_col", Year.schema(), Integer.valueOf(EPOCH_YEAR))));
         return fields;
     }
@@ -514,7 +523,7 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col", Timestamp.schema(), getMillisForDatetime(DATETIME, 0)),
                         new SchemaAndValueField(
-                                "timestamp_col", ZonedTimestamp.schema(), TIMESTAMP),
+                                "timestamp_col", ZonedTimestamp.schema(), TIMESTAMP_ISO),
                         new SchemaAndValueField("year_col", Year.schema(), Integer.valueOf(YEAR))));
         return fields;
     }
@@ -528,7 +537,7 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col", org.apache.kafka.connect.data.Timestamp.SCHEMA, getDateForDatetime(DATETIME, 0)),
                         new SchemaAndValueField(
-                                "timestamp_col", ZonedTimestamp.schema(), TIMESTAMP),
+                                "timestamp_col", ZonedTimestamp.schema(), TIMESTAMP_ISO),
                         new SchemaAndValueField("year_col", Year.schema(), Integer.valueOf(YEAR))));
         return fields;
     }
@@ -544,9 +553,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col5", MicroTimestamp.schema(), getMicrosForDatetime(DATETIME_PRECISION5, 5)),
                         new SchemaAndValueField(
-                                "timestamp_col3", ZonedTimestamp.schema(), TIMESTAMP_PRECISION3),
+                                "timestamp_col3", ZonedTimestamp.schema(), TIMESTAMP_PRECISION3_ISO),
                         new SchemaAndValueField(
-                                "timestamp_col6", ZonedTimestamp.schema(), TIMESTAMP_PRECISION6)));
+                                "timestamp_col6", ZonedTimestamp.schema(), TIMESTAMP_PRECISION6_ISO)));
         return fields;
     }
 
@@ -561,9 +570,9 @@ public abstract class AbstractVitessConnectorTest extends AbstractAsyncEngineCon
                         new SchemaAndValueField(
                                 "datetime_col5", org.apache.kafka.connect.data.Timestamp.SCHEMA, getDateForDatetime(DATETIME_PRECISION5, 5)),
                         new SchemaAndValueField(
-                                "timestamp_col3", ZonedTimestamp.schema(), TIMESTAMP_PRECISION3),
+                                "timestamp_col3", ZonedTimestamp.schema(), TIMESTAMP_PRECISION3_ISO),
                         new SchemaAndValueField(
-                                "timestamp_col6", ZonedTimestamp.schema(), TIMESTAMP_PRECISION6)));
+                                "timestamp_col6", ZonedTimestamp.schema(), TIMESTAMP_PRECISION6_ISO)));
         return fields;
     }
 

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
@@ -70,6 +70,7 @@ public class VitessValueConverterTest {
                 new TestHelper.ColumnValue("time_col", Query.Type.TIME, Types.TIME, "01:02:03".getBytes(), 3600),
                 new TestHelper.ColumnValue("year_col", Query.Type.YEAR, Types.INTEGER, "2020".getBytes(), 2020),
                 new TestHelper.ColumnValue("datetime_col", Query.Type.DATETIME, Types.TIMESTAMP, "2020-01-01 01:02:03".getBytes(), 3600),
+                new TestHelper.ColumnValue("timestamp_col", Query.Type.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE, "2020-01-01 01:02:03".getBytes(), 3600),
                 new TestHelper.ColumnValue("date_col", Query.Type.DATE, Types.DATE, "2020-01-01".getBytes(), 3600));
     }
 
@@ -269,5 +270,35 @@ public class VitessValueConverterTest {
         final LogInterceptor logInterceptor = new LogInterceptor(VitessValueConverter.class.getName() + ".invalid_value");
         assertThat(VitessValueConverter.stringToLocalDate("0000-00-00")).isNull();
         assertThat(logInterceptor.containsMessage("Invalid value")).isTrue();
+    }
+
+    @Test
+    public void shouldConvertStringToZonedDateTime() {
+        assertThat(VitessValueConverter.stringToZonedDateTime("2000-01-01 00:00:00")).isEqualTo(
+                LocalDate.of(2000, 1, 1).atStartOfDay().atZone(ZoneOffset.UTC));
+        assertThat(VitessValueConverter.stringToZonedDateTime("2000-01-01 00:00:00.123")).isEqualTo(
+                LocalDate.of(2000, 1, 1).atStartOfDay().withNano(123 * 1000 * 1000).atZone(ZoneOffset.UTC));
+        assertThat(VitessValueConverter.stringToZonedDateTime("2000-01-01 00:00:00.123456")).isEqualTo(
+                LocalDate.of(2000, 1, 1).atStartOfDay().withNano(123456 * 1000).atZone(ZoneOffset.UTC));
+    }
+
+    @Test
+    public void shouldConvertZeroDateStringToNullZonedDateTime() {
+        final LogInterceptor logInterceptor = new LogInterceptor(VitessValueConverter.class.getName() + ".invalid_value");
+        assertThat(VitessValueConverter.stringToZonedDateTime("0000-00-00 00:00:00")).isNull();
+        assertThat(logInterceptor.containsMessage("Invalid value")).isTrue();
+    }
+
+    @Test
+    public void shouldConvertTimestampToIsoString() throws InterruptedException {
+        decoder.processMessage(temporalFieldEvent(), null, null, false);
+        Table table = schema.tableFor(TestHelper.defaultTableId());
+
+        String col = "timestamp_col";
+        Column column = table.columnWithName(col);
+        Field field = new Field(col, 0, Schema.STRING_SCHEMA);
+
+        ValueConverter valueConverter = converter.converter(column, field);
+        assertThat(valueConverter.convert("2020-01-01 01:02:03")).isEqualTo("2020-01-01T01:02:03Z");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2063

VStream emits MySQL `TIMESTAMP` values as raw UTC strings (`2020-02-13 01:02:03`), and `ZonedTimestamp.toIsoString` passes `String` input through verbatim — so the value carried under the `ZonedTimestamp` schema was never a valid ISO 8601 zoned timestamp, violating the type's contract (and differing from the binlog-based MySQL connector, which deserializes `TIMESTAMP` into a UTC `ZonedDateTime` and emits e.g. `2020-02-13T01:02:03Z`).

This change overrides `convertTimestampWithZone` in `VitessValueConverter` to parse the VStream string into a `ZonedDateTime` in UTC before delegating to the `JdbcValueConverters` implementation. The emitted value is now ISO 8601 in UTC, with fractional digits padded per the column's declared precision (`TIMESTAMP(3)` → `2020-02-13T01:02:03.123Z`), consistent with the MySQL connector and with the existing Vitess connector documentation (which already shows the ISO form).

**Compatibility notes:**
* This is a value-format change for all `time.precision.mode` settings that map `TIMESTAMP` to `ZonedTimestamp` (i.e. everything except `connect` after #287) — consumers that adapted to the raw format will see ISO 8601 strings instead. Likely deserves a release-note/breaking-change mention.
* The MySQL zero-date sentinel (`0000-00-00 00:00:00`), which previously passed through verbatim, now converts to null for optional columns and the epoch fallback for non-optional columns — mirroring the binlog connector's deserializer (null for values outside the legal `TIMESTAMP` range) and the existing zero-date `DATETIME` semantics in this connector.
* Verified with the full timestamp integration test matrix (default `adaptive_time_microseconds`, `connect`, `isostring`, all zero-value variants) against a live Vitess cluster; the existing IT expectations codified the raw pass-through values and are updated accordingly.

Note: this PR touches the same file as #287 (dbz#2060) but is independent; whichever merges second will need a trivial rebase — happy to do that promptly.