### PR TITLE
debezium/dbz#2126 Add protobuf and protoc overrides to upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
         <version.debezium>${project.version}</version.debezium>
 
         <version.grpc>1.75.0</version.grpc>
+        <version.com.google.protobuf>4.34.1</version.com.google.protobuf>
+        <version.com.google.protobuf.protoc>4.34.1</version.com.google.protobuf.protoc>
 
         <!--
           Specify the properties that will be used for setting up the integration tests' Docker container.


### PR DESCRIPTION
Bump version ahead of new vitess-grpc-client release (backward compatible still works with existing too)

Fixes https://github.com/debezium/dbz/issues/2126