### PR TITLE
debezium/dbz#2191 Fix BIT column being silently dropped in Vitess connector

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -150,7 +150,7 @@ public class VitessType {
             case "FLOAT64":
                 return new VitessType(type, Types.DOUBLE);
             case "BIT":
-                return new VitessType(type, Types.BIT);
+                return new VitessType(type, Types.BIT, field.getColumnLength());
             default:
                 return new VitessType(type, Types.OTHER);
         }

--- a/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -149,6 +149,8 @@ public class VitessType {
                 return new VitessType(type, Types.FLOAT);
             case "FLOAT64":
                 return new VitessType(type, Types.DOUBLE);
+            case "BIT":
+                return new VitessType(type, Types.BIT);
             default:
                 return new VitessType(type, Types.OTHER);
         }

--- a/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -151,6 +151,27 @@ public class VitessValueConverter extends JdbcValueConverters {
         return matches(typeName, Query.Type.TIMESTAMP.name());
     }
 
+    @Override
+    protected ValueConverter convertBits(Column column, Field fieldDefn) {
+        if (column.length() <= 1) {
+            // BIT(1) - VStream sends raw bytes; convert to boolean as JdbcValueConverters expects
+            return (data) -> {
+                if (data instanceof byte[]) {
+                    byte[] bytes = (byte[]) data;
+                    return bytes.length > 0 && bytes[0] != 0;
+                }
+                return super.convertBits(column, fieldDefn).convert(data);
+            };
+        }
+        // BIT(N) - VStream sends raw bytes; return as-is for Kafka Connect BYTES schema
+        return (data) -> {
+            if (data instanceof byte[]) {
+                return data;
+            }
+            return super.convertBits(column, fieldDefn).convert(data);
+        };
+    }
+
     // Convert Java value to Kafka Connect value.
     @Override
     public ValueConverter converter(Column inputColumn, Field fieldDefn) {

--- a/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -153,20 +153,14 @@ public class VitessValueConverter extends JdbcValueConverters {
 
     @Override
     protected ValueConverter convertBits(Column column, Field fieldDefn) {
-        if (column.length() <= 1) {
-            // BIT(1) - VStream sends raw bytes; convert to boolean as JdbcValueConverters expects
-            return (data) -> {
-                if (data instanceof byte[]) {
-                    byte[] bytes = (byte[]) data;
+        // VStream sends raw bytes; convert BIT(1) to boolean as JdbcValueConverters expects,
+        // return BIT(N) as-is for Kafka Connect BYTES schema
+        return (data) -> {
+            if (data instanceof byte[] bytes) {
+                if (column.length() <= 1) {
                     return bytes.length > 0 && bytes[0] != 0;
                 }
-                return super.convertBits(column, fieldDefn).convert(data);
-            };
-        }
-        // BIT(N) - VStream sends raw bytes; return as-is for Kafka Connect BYTES schema
-        return (data) -> {
-            if (data instanceof byte[]) {
-                return data;
+                return bytes;
             }
             return super.convertBits(column, fieldDefn).convert(data);
         };

--- a/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
@@ -37,6 +37,7 @@ public class ReplicationMessageColumnValueResolver {
                 return value.asInteger();
             case Types.BIGINT:
                 return value.asLong();
+            case Types.BIT:
             case Types.BLOB:
             case Types.BINARY:
                 return value.asBytes();

--- a/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +45,19 @@ public class VitessTypeTest {
         assertThat(VitessType.resolve(asField(Query.Type.ENUM)).getJdbcId()).isEqualTo(Types.INTEGER);
         assertThat(VitessType.resolve(asField(Query.Type.SET)).getJdbcId()).isEqualTo(Types.BIGINT);
         assertThat(VitessType.resolve(asField(Query.Type.GEOMETRY)).getJdbcId()).isEqualTo(Types.OTHER);
-        assertThat(VitessType.resolve(asField(Query.Type.BIT)).getJdbcId()).isEqualTo(Types.BIT);
+    }
+
+    @Test
+    public void shouldResolveBitWithColumnLength() {
+        Query.Field bit1 = Query.Field.newBuilder().setType(Query.Type.BIT).setColumnLength(1).build();
+        VitessType resolved1 = VitessType.resolve(bit1);
+        assertThat(resolved1.getJdbcId()).isEqualTo(Types.BIT);
+        assertThat(resolved1.getPrecision()).isEqualTo(Optional.of(1));
+
+        Query.Field bit8 = Query.Field.newBuilder().setType(Query.Type.BIT).setColumnLength(8).build();
+        VitessType resolved8 = VitessType.resolve(bit8);
+        assertThat(resolved8.getJdbcId()).isEqualTo(Types.BIT);
+        assertThat(resolved8.getPrecision()).isEqualTo(Optional.of(8));
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessTypeTest.java
@@ -44,6 +44,7 @@ public class VitessTypeTest {
         assertThat(VitessType.resolve(asField(Query.Type.ENUM)).getJdbcId()).isEqualTo(Types.INTEGER);
         assertThat(VitessType.resolve(asField(Query.Type.SET)).getJdbcId()).isEqualTo(Types.BIGINT);
         assertThat(VitessType.resolve(asField(Query.Type.GEOMETRY)).getJdbcId()).isEqualTo(Types.OTHER);
+        assertThat(VitessType.resolve(asField(Query.Type.BIT)).getJdbcId()).isEqualTo(Types.BIT);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
@@ -319,4 +319,21 @@ public class VitessValueConverterTest {
         assertThat(VitessValueConverter.stringToConnectDate("0000-00-00 00:00:00")).isNull();
         assertThat(logInterceptor.containsMessage("Invalid value")).isTrue();
     }
+
+    @Test
+    public void shouldConvertBit1ToBoolean() {
+        Column column = Column.editor().name("bit1").type("BIT").jdbcType(Types.BIT).length(1).optional(true).create();
+        Field field = new Field("bit1", 0, Schema.BOOLEAN_SCHEMA);
+        ValueConverter valueConverter = converter.converter(column, field);
+        assertThat(valueConverter.convert(new byte[]{ 0x01 })).isEqualTo(Boolean.TRUE);
+        assertThat(valueConverter.convert(new byte[]{ 0x00 })).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    public void shouldConvertBitNToBytes() {
+        Column column = Column.editor().name("bit8").type("BIT").jdbcType(Types.BIT).length(8).optional(true).create();
+        Field field = new Field("bit8", 0, Schema.BYTES_SCHEMA);
+        ValueConverter valueConverter = converter.converter(column, field);
+        assertThat(valueConverter.convert(new byte[]{ 0x05 })).isEqualTo(new byte[]{ 0x05 });
+    }
 }

--- a/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolverTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolverTest.java
@@ -63,6 +63,16 @@ public class ReplicationMessageColumnValueResolverTest {
     }
 
     @Test
+    public void shouldResolveBitToBytes() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.BIT),
+                new VitessColumnValue(new byte[]{ 0x05 }),
+                false,
+                TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS);
+        assertThat(resolvedJavaValue).isEqualTo(new byte[]{ 0x05 });
+    }
+
+    @Test
     public void shouldResolveBlobToBytes() {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.BLOB),


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2191

Two missing cases combine to silently drop any `BIT(N)` column from change events:

1. **`VitessType.resolve()`** — no `"BIT"` case in the type-name switch, so `BIT` columns fell through to `default` → JDBC type `OTHER` (1111).
2. **`ReplicationMessageColumnValueResolver.resolveValue()`** — no arm for `Types.BIT` (`-7`), so it fell through to `return null`, silently dropping the value.

**Fix:** add `"BIT" → Types.BIT` in `VitessType.resolve()`, and add `case Types.BIT: return value.asBytes()` alongside the existing `BLOB`/`BINARY` arm in `resolveValue()`. VStream already encodes `BIT` column values as raw bytes, and `JdbcValueConverters.convertBits` already maps `Types.BIT` to the correct Kafka Connect schema type (`BOOLEAN` for `BIT(1)`, `BYTES` for `BIT(N)`), so no further changes are needed.

Tests added in `VitessTypeTest` (resolves to `Types.BIT`) and `ReplicationMessageColumnValueResolverTest` (returns raw bytes).