### PR TITLE
debezium/dbz#2479 debezium/dbz#2480 Fix inherit.epoch validation and gRPC header value parsing

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -723,8 +723,9 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
     private static int validateInheritEpoch(Configuration config, Field field, ValidationOutput problems) {
         Boolean inheritEpoch = config.getBoolean(field);
         String factory = config.getString(CommonConnectorConfig.TRANSACTION_METADATA_FACTORY);
-        if (inheritEpoch && !factory.equals(VitessOrderedTransactionMetadataFactory.class.getName())) {
+        if (inheritEpoch && !VitessOrderedTransactionMetadataFactory.class.getName().equals(factory)) {
             problems.accept(field, inheritEpoch, "Inherit epoch cannot be enabled without VitessOrderedTransactionMetadataFactory");
+            return 1;
         }
         return 0;
     }

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -772,7 +772,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         Map<String, String> grpcHeadersMap = new HashMap<>();
 
         for (String header : grpcHeaders.split(CSV_DELIMITER)) {
-            String[] keyAndValue = header.split(":");
+            String[] keyAndValue = header.split(":", 2);
             if (keyAndValue.length == 2) {
                 grpcHeadersMap.put(keyAndValue[0], keyAndValue[1]);
             }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -305,4 +305,27 @@ public class VitessConnectorConfigTest {
         assertThat(problems).isEmpty();
     }
 
+    @Test
+    public void shouldGetGrpcHeadersWithColonsInValue() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.GRPC_HEADERS, "authorization:Bearer a:b:c,x-custom-header:value")
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getGrpcHeaders())
+                .containsEntry("authorization", "Bearer a:b:c")
+                .containsEntry("x-custom-header", "value")
+                .hasSize(2);
+    }
+
+    @Test
+    public void shouldSkipGrpcHeadersWithoutColon() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.GRPC_HEADERS, "not-a-header,x-custom-header:value")
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getGrpcHeaders())
+                .containsEntry("x-custom-header", "value")
+                .hasSize(1);
+    }
+
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.vitess.pipeline.txmetadata.VitessOrderedTransactionMetadataFactory;
+import io.debezium.doc.FixFor;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.heartbeat.Heartbeat.ScheduledHeartbeat;
 
@@ -283,6 +284,7 @@ public class VitessConnectorConfigTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2479")
     public void shouldFailInheritEpochValidationWithoutOrderedTransactionMetadataFactory() {
         Configuration configuration = TestHelper.defaultConfig()
                 .with(VitessConnectorConfig.INHERIT_EPOCH, true)
@@ -294,6 +296,7 @@ public class VitessConnectorConfigTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2479")
     public void shouldPassInheritEpochValidationWithOrderedTransactionMetadataFactory() {
         Configuration configuration = TestHelper.defaultConfig()
                 .with(VitessConnectorConfig.INHERIT_EPOCH, true)
@@ -306,6 +309,7 @@ public class VitessConnectorConfigTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2480")
     public void shouldGetGrpcHeadersWithColonsInValue() {
         Configuration configuration = TestHelper.defaultConfig()
                 .with(VitessConnectorConfig.GRPC_HEADERS, "authorization:Bearer a:b:c,x-custom-header:value")
@@ -318,6 +322,7 @@ public class VitessConnectorConfigTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2480")
     public void shouldSkipGrpcHeadersWithoutColon() {
         Configuration configuration = TestHelper.defaultConfig()
                 .with(VitessConnectorConfig.GRPC_HEADERS, "not-a-header,x-custom-header:value")

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -282,4 +282,27 @@ public class VitessConnectorConfigTest {
         assertThat(connectorConfig.getConnectorGeneration()).isEqualTo(0);
     }
 
+    @Test
+    public void shouldFailInheritEpochValidationWithoutOrderedTransactionMetadataFactory() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.INHERIT_EPOCH, true)
+                .build();
+        List<String> problems = new ArrayList<>();
+        boolean valid = VitessConnectorConfig.INHERIT_EPOCH.validate(configuration, (field, value, message) -> problems.add(message));
+        assertThat(valid).isFalse();
+        assertThat(problems).containsExactly("Inherit epoch cannot be enabled without VitessOrderedTransactionMetadataFactory");
+    }
+
+    @Test
+    public void shouldPassInheritEpochValidationWithOrderedTransactionMetadataFactory() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.INHERIT_EPOCH, true)
+                .with(CommonConnectorConfig.TRANSACTION_METADATA_FACTORY, VitessOrderedTransactionMetadataFactory.class.getName())
+                .build();
+        List<String> problems = new ArrayList<>();
+        boolean valid = VitessConnectorConfig.INHERIT_EPOCH.validate(configuration, (field, value, message) -> problems.add(message));
+        assertThat(valid).isTrue();
+        assertThat(problems).isEmpty();
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2479
Fixes https://github.com/debezium/dbz/issues/2480

Two small `VitessConnectorConfig` bugs:

1. **`validateInheritEpoch`** reported its problem via `problems.accept(...)` but always returned `0`. Field validators return the number of problems found, so the configuration was treated as valid and the connector started with `vitess.inherit.epoch=true` but without `VitessOrderedTransactionMetadataFactory` — the validation message was effectively dead code. Now returns the problem count (matching `validateTimePrecisionMode`), and the factory comparison is null-safe.

2. **`getGrpcHeaders`** split each configured header on every colon, so any header whose *value* contains a colon (bearer tokens, URLs, timestamps) failed the `length == 2` check and was silently dropped with only a WARN log. Now splits on the first colon only (`split(":", 2)`); entries without any colon are still rejected with the warning.

Unit tests added for both: validation fail/pass pairs for `inherit.epoch`, header values with embedded colons, and the no-colon rejection path.

**AI disclosure** (per `AI_USAGE_POLICY.md`): I used Claude Code to help draft this fix and its tests. I reviewed the change and ran the test suite locally before submitting.