### PR TITLE
debezium/dbz#2545 debezium/dbz#2546 Fix gRPC channel lifecycle and vgtid reference-equality bugs

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -461,7 +461,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
             // If offset storage per task is disabled, then find the vgtid elsewhere
             if (config.getShard() == null || config.getShard().isEmpty()) {
                 // This case is not supported by the Vitess, so our workaround is to get all the shards from vtgate.
-                if (config.getVgtid() == Vgtid.EMPTY_GTID) {
+                if (Vgtid.EMPTY_GTID.equals(config.getVgtid())) {
                     List<String> shards = new VitessMetadata(config).getShards();
                     List<String> gtids = Collections.nCopies(shards.size(), config.getVgtid());
                     vgtid = buildVgtid(config.getKeyspace(), shards, gtids);
@@ -478,8 +478,8 @@ public class VitessReplicationConnection implements ReplicationConnection {
                 List<String> shards = config.getShard();
                 String vgtidString = config.getVgtid();
                 List<String> gtids;
-                if (vgtidString == Vgtid.CURRENT_GTID ||
-                        vgtidString == Vgtid.EMPTY_GTID) {
+                if (Vgtid.CURRENT_GTID.equals(vgtidString) ||
+                        Vgtid.EMPTY_GTID.equals(vgtidString)) {
                     gtids = Collections.nCopies(shards.size(), vgtidString);
                     vgtid = buildVgtid(config.getKeyspace(), shards, gtids);
                 }

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -70,8 +70,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
      */
     public Vtgate.ExecuteResponse execute(String sqlStatement) {
         LOGGER.debug("Executing sqlStament {}", sqlStatement);
-        ManagedChannel channel = newChannel();
-        managedChannel.compareAndSet(null, channel);
+        ManagedChannel channel = replaceManagedChannel();
 
         Vtgate.ExecuteRequest request = Vtgate.ExecuteRequest.newBuilder()
                 .setQuery(Proto.bindQuery(sqlStatement, Collections.emptyMap()))
@@ -81,8 +80,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
 
     public Vtgate.ExecuteResponse execute(String sqlStatement, String shard) {
         LOGGER.info("Executing sqlStament {}", sqlStatement);
-        ManagedChannel channel = newChannel();
-        managedChannel.compareAndSet(null, channel);
+        ManagedChannel channel = replaceManagedChannel();
 
         String target = String.format("%s:%s@%s", config.getKeyspace(), shard, config.getTabletType());
         Vtgate.Session session = Vtgate.Session.newBuilder().setTargetString(target).setAutocommit(true).build();
@@ -109,8 +107,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
                                Vgtid vgtid, ReplicationMessageProcessor processor, AtomicReference<Throwable> error) {
         Objects.requireNonNull(vgtid);
 
-        ManagedChannel channel = newChannel();
-        managedChannel.compareAndSet(null, channel);
+        ManagedChannel channel = replaceManagedChannel();
 
         VitessGrpc.VitessStub stub = newStub(channel);
 
@@ -384,13 +381,31 @@ public class VitessReplicationConnection implements ReplicationConnection {
         return channel;
     }
 
+    /**
+     * Create a new channel and make it the tracked channel, shutting down the previously
+     * tracked channel (if any) so repeated connects do not leak channels.
+     */
+    private ManagedChannel replaceManagedChannel() {
+        ManagedChannel channel = newChannel();
+        ManagedChannel previous = managedChannel.getAndSet(channel);
+        if (previous != null) {
+            previous.shutdownNow();
+        }
+        return channel;
+    }
+
     /** Close the gRPC connection to VStream */
     @Override
     public void close() throws Exception {
         LOGGER.info("Closing replication connection");
-        managedChannel.get().shutdownNow();
+        ManagedChannel channel = managedChannel.get();
+        if (channel == null) {
+            LOGGER.info("No VStream GRPC channel was created, nothing to close.");
+            return;
+        }
+        channel.shutdownNow();
         LOGGER.trace("VStream GRPC channel shutdownNow is invoked.");
-        if (managedChannel.get().awaitTermination(5, TimeUnit.SECONDS)) {
+        if (channel.awaitTermination(5, TimeUnit.SECONDS)) {
             LOGGER.info("VStream GRPC channel is shutdown in time.");
         }
         else {

--- a/src/test/java/io/debezium/connector/vitess/connection/VitessReplicationConnectionTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VitessReplicationConnectionTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.vitess.TestHelper;
+import io.debezium.connector.vitess.Vgtid;
 import io.debezium.connector.vitess.VitessConnectorConfig;
 import io.debezium.doc.FixFor;
 
@@ -32,6 +33,25 @@ public class VitessReplicationConnectionTest {
         VitessReplicationConnection connection = new VitessReplicationConnection(
                 new VitessConnectorConfig(TestHelper.defaultConfig().build()), null);
         assertThatNoException().isThrownBy(connection::close);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2546")
+    public void shouldBuildVgtidFromExplicitEmptyVgtidWithShards() {
+        // Build the empty string at runtime so it is an equal-but-distinct instance of
+        // Vgtid.EMPTY_GTID, like a value parsed from user configuration.
+        String explicitEmptyVgtid = new StringBuilder().toString();
+        VitessConnectorConfig config = new VitessConnectorConfig(TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.SNAPSHOT_MODE, VitessConnectorConfig.SnapshotMode.NEVER.getValue())
+                .with(VitessConnectorConfig.SHARD, "-80")
+                .with(VitessConnectorConfig.VGTID, explicitEmptyVgtid)
+                .build());
+
+        Vgtid vgtid = VitessReplicationConnection.defaultVgtid(config);
+
+        assertThat(vgtid.getShardGtids()).hasSize(1);
+        assertThat(vgtid.getShardGtids().get(0).getShard()).isEqualTo("-80");
+        assertThat(vgtid.getShardGtids().get(0).getGtid()).isEqualTo(Vgtid.EMPTY_GTID);
     }
 
 }

--- a/src/test/java/io/debezium/connector/vitess/connection/VitessReplicationConnectionTest.java
+++ b/src/test/java/io/debezium/connector/vitess/connection/VitessReplicationConnectionTest.java
@@ -7,11 +7,13 @@
 package io.debezium.connector.vitess.connection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.vitess.TestHelper;
 import io.debezium.connector.vitess.VitessConnectorConfig;
+import io.debezium.doc.FixFor;
 
 public class VitessReplicationConnectionTest {
 
@@ -23,4 +25,13 @@ public class VitessReplicationConnectionTest {
         assertThat(connection.quoteIdentifier("tenant-a")).isEqualTo("`tenant-a`");
         assertThat(connection.quoteIdentifier("weird`name")).isEqualTo("`weird``name`");
     }
+
+    @Test
+    @FixFor("debezium/dbz#2545")
+    public void shouldCloseWithoutEverConnecting() {
+        VitessReplicationConnection connection = new VitessReplicationConnection(
+                new VitessConnectorConfig(TestHelper.defaultConfig().build()), null);
+        assertThatNoException().isThrownBy(connection::close);
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2545
Fixes https://github.com/debezium/dbz/issues/2546

Two connection-level bugs in `VitessReplicationConnection`:

1. **gRPC channel lifecycle** — `execute(...)` and `startStreaming(...)` each created a new `ManagedChannel` but stored it with `compareAndSet(null, channel)`, which retains only the first channel ever created: every later connect (task restart, re-streaming after an error, metadata query) leaked a channel with its threads and sockets, and `close()` only shut down the first one. The three call sites now go through a `replaceManagedChannel()` helper that swaps with `getAndSet` and shuts down the previous channel. `close()` also threw `NullPointerException` when no channel was ever created (startup failure before connecting), masking the original error during shutdown — it now null-guards and uses a single snapshot of the reference for both `shutdownNow()` and `awaitTermination(...)`.

2. **vgtid reference equality** — `defaultVgtid` compared the configured vgtid string against `Vgtid.CURRENT_GTID` / `Vgtid.EMPTY_GTID` with `==`, which only works because `getVgtid()` happens to return those exact constant references on the default paths. An explicit `vitess.vgtid=""` either crashed in `Vgtid.of("")` (with `vitess.shard` set) or **silently** built a `current`-position vgtid instead of the requested from-the-beginning read (without `vitess.shard`). Now compares with constant-first `equals`.

Unit tests added (`@FixFor` annotated): `close()` on a never-connected connection no longer throws, and an explicit empty vgtid with shards builds the correct from-the-beginning vgtid — the empty string is constructed at runtime so it is an equal-but-distinct instance, like a value parsed from user configuration. Both tests fail on current `main` and pass with the fixes.

**AI disclosure** (per `AI_USAGE_POLICY.md`): I used Claude Code to help draft this fix and its tests. I reviewed the change and ran the test suite locally before submitting.