### PR TITLE
debezium/dbz#2548 Convert zero-day DATETIME values to null instead of crashing the task

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -435,9 +435,16 @@ public class VitessValueConverter extends JdbcValueConverters {
      * @return The java.sql.Timestamp
      */
     public static Timestamp stringToTimestamp(String datetimeString) {
-        if (datetimeString.matches("^\\d{4}-00-00.*$")) {
-            INVALID_VALUE_LOGGER.warn("Invalid value '{}' stored in column converted to null value", datetimeString);
-            return null;
+        final Matcher matcher = DATE_FIELD_PATTERN.matcher(datetimeString);
+        if (matcher.find()) {
+            final int month = Integer.parseInt(matcher.group(2));
+            final int day = Integer.parseInt(matcher.group(3));
+            if (month == 0 || day == 0) {
+                // Invalid dates with a zero month or day (e.g. 2024-01-00) cannot be represented
+                // by java.sql.Timestamp; match the stringToLocalDate handling and convert to null.
+                INVALID_VALUE_LOGGER.warn("Invalid value '{}' stored in column converted to null value", datetimeString);
+                return null;
+            }
         }
         return Timestamp.valueOf(datetimeString);
     }

--- a/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessValueConverterTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.vitess.connection.VStreamOutputMessageDecoder;
+import io.debezium.doc.FixFor;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.Column;
 import io.debezium.relational.CustomConverterRegistry;
@@ -263,6 +264,16 @@ public class VitessValueConverterTest {
                 Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(12345 * 1000 * 10)));
         assertThat(VitessValueConverter.stringToTimestamp("2000-01-01 00:00:00.123456")).isEqualTo(
                 Timestamp.valueOf(LocalDate.of(2000, 1, 1).atStartOfDay().withNano(123456 * 1000)));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2548")
+    public void shouldConvertInvalidTimestampToNull() {
+        final LogInterceptor logInterceptor = new LogInterceptor(VitessValueConverter.class.getName() + ".invalid_value");
+        assertThat(VitessValueConverter.stringToTimestamp("0000-00-00 00:00:00")).isNull();
+        assertThat(VitessValueConverter.stringToTimestamp("2024-00-15 10:00:00")).isNull();
+        assertThat(VitessValueConverter.stringToTimestamp("2024-01-00 10:00:00")).isNull();
+        assertThat(logInterceptor.containsMessage("Invalid value")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2548

`stringToTimestamp` nulls out invalid zero-datetimes with the regex `^\d{4}-00-00.*$`, which only matches a zero **month**. MySQL also permits a valid month with a zero **day** (e.g. `2024-01-00 10:00:00`); such a value fell through to `Timestamp.valueOf(...)`, which throws `IllegalArgumentException` and kills the task.

The fix mirrors the companion `stringToLocalDate`: extract year/month/day with the existing `DATE_FIELD_PATTERN` and treat `month == 0 || day == 0` as the invalid-value case (WARN + null). Strings that don't match the pattern fall through to `Timestamp.valueOf` unchanged.

Unit test added (`@FixFor` annotated) covering `0000-00-00`, zero-month, and zero-day datetimes — it fails on current `main` with the `IllegalArgumentException` above and passes with the fix.

**AI disclosure** (per `AI_USAGE_POLICY.md`): I used Claude Code to help draft this fix and its test. I reviewed the change and ran the test suite locally before submitting.