### PR TITLE
debezium/dbz#2547 Add vitess.cells option to pin the VStream to specific cells

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -326,7 +326,20 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withWidth(Width.MEDIUM)
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withDescription("Comma-separated list of Vitess cells (or cell aliases) the VStream"
-                    + " should be served from. If not set, vtgate applies its default cell selection.");
+                    + " should be served from. If not set, vtgate defaults to its own local cell."
+                    + " Only applies when '" + VITESS_CONFIG_GROUP_PREFIX + "tablet.type' is REPLICA or RDONLY;"
+                    + " for MASTER the shard primary is used regardless of cell.");
+
+    public static final Field CELL_PREFERENCE = Field.create(VITESS_CONFIG_GROUP_PREFIX + "cell.preference")
+            .withDisplayName("VStream cell preference")
+            .withType(Type.STRING)
+            .withWidth(Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withValidation(VitessConnectorConfig::validateCellPreference)
+            .withDescription("Controls how vtgate's tablet picker treats the cells listed in '" + VITESS_CONFIG_GROUP_PREFIX + "cells':"
+                    + " 'preferlocalwithalias' (vtgate's default) prefers tablets in vtgate's local cell and its alias before the other listed cells,"
+                    + " while 'onlyspecified' restricts tablet selection to exactly the listed cells (no local-cell fallback),"
+                    + " which is required to pin the VStream to specific cells.");
 
     public static final Field INHERIT_EPOCH = Field.create(VITESS_CONFIG_GROUP_PREFIX + "inherit.epoch")
             .withDisplayName("Inherit epoch")
@@ -563,6 +576,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .group(Field.Group.CONNECTOR_ADVANCED,
                     STOP_ON_RESHARD_FLAG,
                     CELLS,
+                    CELL_PREFERENCE,
                     INHERIT_EPOCH,
                     SHARD_EPOCH_MAP,
                     KEEPALIVE_INTERVAL_MS,
@@ -729,6 +743,19 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         return 0;
     }
 
+    private static int validateCellPreference(Configuration config, Field field, ValidationOutput problems) {
+        String cellPreference = config.getString(field);
+        if (cellPreference == null || cellPreference.isEmpty()) {
+            return 0;
+        }
+        // vtgate parses this value case-insensitively (blank falls back to 'preferlocalwithalias').
+        if (!"preferlocalwithalias".equalsIgnoreCase(cellPreference) && !"onlyspecified".equalsIgnoreCase(cellPreference)) {
+            problems.accept(field, cellPreference, "Valid values are 'preferlocalwithalias' and 'onlyspecified'");
+            return 1;
+        }
+        return 0;
+    }
+
     private static int validateInheritEpoch(Configuration config, Field field, ValidationOutput problems) {
         Boolean inheritEpoch = config.getBoolean(field);
         String factory = config.getString(CommonConnectorConfig.TRANSACTION_METADATA_FACTORY);
@@ -765,6 +792,10 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public String getCells() {
         return getConfig().getString(CELLS);
+    }
+
+    public String getCellPreference() {
+        return getConfig().getString(CELL_PREFERENCE);
     }
 
     public boolean getInheritEpoch() {

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -320,6 +320,14 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withDescription("Control StopOnReshard VStream flag."
                     + " If set true, the old VStream will be stopped after a reshard operation.");
 
+    public static final Field CELLS = Field.create(VITESS_CONFIG_GROUP_PREFIX + "cells")
+            .withDisplayName("VStream cells")
+            .withType(Type.STRING)
+            .withWidth(Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Comma-separated list of Vitess cells (or cell aliases) the VStream"
+                    + " should be served from. If not set, vtgate applies its default cell selection.");
+
     public static final Field INHERIT_EPOCH = Field.create(VITESS_CONFIG_GROUP_PREFIX + "inherit.epoch")
             .withDisplayName("Inherit epoch")
             .withType(Type.BOOLEAN)
@@ -554,6 +562,7 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
                     SOURCE_INFO_STRUCT_MAKER)
             .group(Field.Group.CONNECTOR_ADVANCED,
                     STOP_ON_RESHARD_FLAG,
+                    CELLS,
                     INHERIT_EPOCH,
                     SHARD_EPOCH_MAP,
                     KEEPALIVE_INTERVAL_MS,
@@ -752,6 +761,10 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public boolean getStopOnReshard() {
         return getConfig().getBoolean(STOP_ON_RESHARD_FLAG);
+    }
+
+    public String getCells() {
+        return getConfig().getString(CELLS);
     }
 
     public boolean getInheritEpoch() {

--- a/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessConnectorConfig.java
@@ -185,6 +185,70 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
     }
 
+    /**
+     * The set of predefined CellPreference options. Values mirror the values accepted by
+     * vtgate's tablet picker for the {@code VStreamFlags.cell_preference} flag, which vtgate
+     * parses case-insensitively.
+     */
+    public enum CellPreference implements EnumeratedValue {
+        /**
+         * Prefer tablets in vtgate's local cell (and its cell alias) before the cells listed
+         * in {@code vitess.cells}. This is vtgate's default behavior.
+         */
+        PREFER_LOCAL_WITH_ALIAS("preferlocalwithalias"),
+
+        /**
+         * Restrict tablet selection to exactly the cells listed in {@code vitess.cells},
+         * with no local-cell fallback. Required to pin the VStream to specific cells.
+         */
+        ONLY_SPECIFIED("onlyspecified");
+
+        private final String value;
+
+        CellPreference(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static CellPreference parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (CellPreference option : CellPreference.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @param defaultValue the default value; may be null
+         * @return the matching option, or null if no match is found and the non-null default is invalid
+         */
+        public static CellPreference parse(String value, String defaultValue) {
+            CellPreference preference = parse(value);
+            if (preference == null && defaultValue != null) {
+                preference = parse(defaultValue);
+            }
+            return preference;
+        }
+    }
+
     public static final Field VTGATE_HOST = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.HOSTNAME)
             .withDisplayName("Vitess database hostname")
             .withType(Type.STRING)
@@ -332,10 +396,9 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public static final Field CELL_PREFERENCE = Field.create(VITESS_CONFIG_GROUP_PREFIX + "cell.preference")
             .withDisplayName("VStream cell preference")
-            .withType(Type.STRING)
+            .withEnum(CellPreference.class, CellPreference.PREFER_LOCAL_WITH_ALIAS)
             .withWidth(Width.MEDIUM)
             .withImportance(ConfigDef.Importance.MEDIUM)
-            .withValidation(VitessConnectorConfig::validateCellPreference)
             .withDescription("Controls how vtgate's tablet picker treats the cells listed in '" + VITESS_CONFIG_GROUP_PREFIX + "cells':"
                     + " 'preferlocalwithalias' (vtgate's default) prefers tablets in vtgate's local cell and its alias before the other listed cells,"
                     + " while 'onlyspecified' restricts tablet selection to exactly the listed cells (no local-cell fallback),"
@@ -743,19 +806,6 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         return 0;
     }
 
-    private static int validateCellPreference(Configuration config, Field field, ValidationOutput problems) {
-        String cellPreference = config.getString(field);
-        if (cellPreference == null || cellPreference.isEmpty()) {
-            return 0;
-        }
-        // vtgate parses this value case-insensitively (blank falls back to 'preferlocalwithalias').
-        if (!"preferlocalwithalias".equalsIgnoreCase(cellPreference) && !"onlyspecified".equalsIgnoreCase(cellPreference)) {
-            problems.accept(field, cellPreference, "Valid values are 'preferlocalwithalias' and 'onlyspecified'");
-            return 1;
-        }
-        return 0;
-    }
-
     private static int validateInheritEpoch(Configuration config, Field field, ValidationOutput problems) {
         Boolean inheritEpoch = config.getBoolean(field);
         String factory = config.getString(CommonConnectorConfig.TRANSACTION_METADATA_FACTORY);
@@ -794,8 +844,8 @@ public class VitessConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getString(CELLS);
     }
 
-    public String getCellPreference() {
-        return getConfig().getString(CELL_PREFERENCE);
+    public CellPreference getCellPreference() {
+        return CellPreference.parse(getConfig().getString(CELL_PREFERENCE), CELL_PREFERENCE.defaultValueAsString());
     }
 
     public boolean getInheritEpoch() {

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -305,6 +305,10 @@ public class VitessReplicationConnection implements ReplicationConnection {
                 .setHeartbeatInterval(getHeartbeatSeconds())
                 .setStreamKeyspaceHeartbeats(config.getStreamKeyspaceHeartbeats());
 
+        if (!Strings.isNullOrEmpty(config.getCells())) {
+            vStreamFlagsBuilder.setCells(config.getCells());
+        }
+
         if (!Strings.isNullOrEmpty(config.getConfig().getString(CommonConnectorConfig.SNAPSHOT_MODE_TABLES))) {
             final List<String> allTables = new VitessMetadata(config).getTables();
             List<String> tablesToCopy = VitessConnector.getTablesToCopyByPrefix(config, allTables);

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -308,6 +308,9 @@ public class VitessReplicationConnection implements ReplicationConnection {
         if (!Strings.isNullOrEmpty(config.getCells())) {
             vStreamFlagsBuilder.setCells(config.getCells());
         }
+        if (!Strings.isNullOrEmpty(config.getCellPreference())) {
+            vStreamFlagsBuilder.setCellPreference(config.getCellPreference());
+        }
 
         if (!Strings.isNullOrEmpty(config.getConfig().getString(CommonConnectorConfig.SNAPSHOT_MODE_TABLES))) {
             final List<String> allTables = new VitessMetadata(config).getTables();

--- a/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/vitess/connection/VitessReplicationConnection.java
@@ -303,13 +303,11 @@ public class VitessReplicationConnection implements ReplicationConnection {
                 .setStopOnReshard(config.getStopOnReshard())
                 .setExcludeKeyspaceFromTableName(config.getExcludeKeyspaceFromTableName())
                 .setHeartbeatInterval(getHeartbeatSeconds())
-                .setStreamKeyspaceHeartbeats(config.getStreamKeyspaceHeartbeats());
+                .setStreamKeyspaceHeartbeats(config.getStreamKeyspaceHeartbeats())
+                .setCellPreference(config.getCellPreference().getValue());
 
         if (!Strings.isNullOrEmpty(config.getCells())) {
             vStreamFlagsBuilder.setCells(config.getCells());
-        }
-        if (!Strings.isNullOrEmpty(config.getCellPreference())) {
-            vStreamFlagsBuilder.setCellPreference(config.getCellPreference());
         }
 
         if (!Strings.isNullOrEmpty(config.getConfig().getString(CommonConnectorConfig.SNAPSHOT_MODE_TABLES))) {

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -356,4 +356,54 @@ public class VitessConnectorConfigTest {
         assertThat(VitessConnectorConfig.ALL_FIELDS).anyMatch(field -> field.name().equals("vitess.cells"));
     }
 
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldGetCellPreference() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.CELL_PREFERENCE, "onlyspecified")
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getCellPreference()).isEqualTo("onlyspecified");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldDefaultCellPreferenceToNull() {
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(TestHelper.defaultConfig().build());
+        assertThat(connectorConfig.getCellPreference()).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldPassCellPreferenceValidationForKnownValues() {
+        // vtgate parses the value case-insensitively, so mixed case must validate too.
+        for (String value : new String[]{ "preferlocalwithalias", "onlyspecified", "OnlySpecified" }) {
+            Configuration configuration = TestHelper.defaultConfig()
+                    .with(VitessConnectorConfig.CELL_PREFERENCE, value)
+                    .build();
+            List<String> problems = new ArrayList<>();
+            boolean valid = VitessConnectorConfig.CELL_PREFERENCE.validate(configuration, (field, fieldValue, message) -> problems.add(message));
+            assertThat(valid).isTrue();
+            assertThat(problems).isEmpty();
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldFailCellPreferenceValidationForUnknownValue() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.CELL_PREFERENCE, "nearest")
+                .build();
+        List<String> problems = new ArrayList<>();
+        boolean valid = VitessConnectorConfig.CELL_PREFERENCE.validate(configuration, (field, value, message) -> problems.add(message));
+        assertThat(valid).isFalse();
+        assertThat(problems).containsExactly("Valid values are 'preferlocalwithalias' and 'onlyspecified'");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldExposeCellPreferenceInConfigDefinition() {
+        assertThat(VitessConnectorConfig.ALL_FIELDS).anyMatch(field -> field.name().equals("vitess.cell.preference"));
+    }
+
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -333,4 +333,27 @@ public class VitessConnectorConfigTest {
                 .hasSize(1);
     }
 
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldGetCells() {
+        Configuration configuration = TestHelper.defaultConfig()
+                .with(VitessConnectorConfig.CELLS, "cell1,cell2")
+                .build();
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
+        assertThat(connectorConfig.getCells()).isEqualTo("cell1,cell2");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldDefaultCellsToNull() {
+        VitessConnectorConfig connectorConfig = new VitessConnectorConfig(TestHelper.defaultConfig().build());
+        assertThat(connectorConfig.getCells()).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldExposeCellsInConfigDefinition() {
+        assertThat(VitessConnectorConfig.ALL_FIELDS).anyMatch(field -> field.name().equals("vitess.cells"));
+    }
+
 }

--- a/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessConnectorConfigTest.java
@@ -363,14 +363,25 @@ public class VitessConnectorConfigTest {
                 .with(VitessConnectorConfig.CELL_PREFERENCE, "onlyspecified")
                 .build();
         VitessConnectorConfig connectorConfig = new VitessConnectorConfig(configuration);
-        assertThat(connectorConfig.getCellPreference()).isEqualTo("onlyspecified");
+        assertThat(connectorConfig.getCellPreference()).isEqualTo(VitessConnectorConfig.CellPreference.ONLY_SPECIFIED);
     }
 
     @Test
     @FixFor("debezium/dbz#2547")
-    public void shouldDefaultCellPreferenceToNull() {
+    public void shouldDefaultCellPreferenceToPreferLocalWithAlias() {
         VitessConnectorConfig connectorConfig = new VitessConnectorConfig(TestHelper.defaultConfig().build());
-        assertThat(connectorConfig.getCellPreference()).isNull();
+        assertThat(connectorConfig.getCellPreference()).isEqualTo(VitessConnectorConfig.CellPreference.PREFER_LOCAL_WITH_ALIAS);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2547")
+    public void shouldParseCellPreferenceCaseInsensitively() {
+        // vtgate parses the value case-insensitively, so mixed case must resolve too.
+        assertThat(VitessConnectorConfig.CellPreference.parse("OnlySpecified"))
+                .isEqualTo(VitessConnectorConfig.CellPreference.ONLY_SPECIFIED);
+        assertThat(VitessConnectorConfig.CellPreference.parse("preferlocalwithalias"))
+                .isEqualTo(VitessConnectorConfig.CellPreference.PREFER_LOCAL_WITH_ALIAS);
+        assertThat(VitessConnectorConfig.CellPreference.parse("nearest")).isNull();
     }
 
     @Test
@@ -397,7 +408,7 @@ public class VitessConnectorConfigTest {
         List<String> problems = new ArrayList<>();
         boolean valid = VitessConnectorConfig.CELL_PREFERENCE.validate(configuration, (field, value, message) -> problems.add(message));
         assertThat(valid).isFalse();
-        assertThat(problems).containsExactly("Valid values are 'preferlocalwithalias' and 'onlyspecified'");
+        assertThat(problems).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2547

vtgate's `VStream` API accepts `VStreamFlags.cells` — a comma-separated list of cells (or cell aliases) that restricts which tablets serve the stream. This adds a new **optional** `vitess.cells` STRING option, registered in `CONFIG_DEFINITION` (CONNECTOR_ADVANCED group, next to the other VStream flag `vitess.stop_on_reshard`), and applies it to the flags builder only when non-empty — when unset, vtgate's default cell selection applies, so existing configurations are unaffected.

Motivation: in multi-cell Vitess deployments this is the standard locality control; without it the VStream may be served from tablets in a remote cell, adding cross-cell traffic and latency.

Unit tests added (`@FixFor` annotated): option round-trip, null default, and exposure via `CONFIG_DEFINITION`/`ALL_FIELDS`.

Happy to follow up with a docs PR to `debezium/debezium` for the connector property table — let me know if that should land together with this or after.

**AI disclosure** (per `AI_USAGE_POLICY.md`): I used Claude Code to help draft this change and its tests. I reviewed the change and ran the test suite locally before submitting.